### PR TITLE
Fix authorization and add frontend validation (Issues #4, #11)

### DIFF
--- a/backend/src/main/java/com/jari/attachment/AttachmentController.java
+++ b/backend/src/main/java/com/jari/attachment/AttachmentController.java
@@ -2,11 +2,13 @@ package com.jari.attachment;
 
 import com.jari.common.dto.ApiResponse;
 import com.jari.issue.IssueDto;
+import com.jari.security.AuthHelper;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -19,13 +21,18 @@ import java.util.List;
 public class AttachmentController {
 
     private final AttachmentService attachmentService;
+    private final AuthHelper authHelper;
 
-    public AttachmentController(AttachmentService attachmentService) {
+    public AttachmentController(AttachmentService attachmentService, AuthHelper authHelper) {
         this.attachmentService = attachmentService;
+        this.authHelper = authHelper;
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<IssueDto.AttachmentDto>>> list(@PathVariable Long issueId) {
+    public ResponseEntity<ApiResponse<List<IssueDto.AttachmentDto>>> list(
+            @PathVariable Long projectId, @PathVariable Long issueId,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, projectId);
         List<IssueDto.AttachmentDto> attachments = attachmentService.getByIssueId(issueId).stream()
                 .map(a -> new IssueDto.AttachmentDto(a.getId(), a.getFileName(), a.getContentType(),
                         a.getFileSize(), a.getUploadedBy(), a.getCreatedAt().toString()))
@@ -35,10 +42,11 @@ public class AttachmentController {
 
     @PostMapping
     public ResponseEntity<ApiResponse<IssueDto.AttachmentDto>> upload(
-            @PathVariable Long issueId,
+            @PathVariable Long projectId, @PathVariable Long issueId,
             @RequestParam("file") MultipartFile file,
             @AuthenticationPrincipal UserDetails currentUser) {
-        Long userId = Long.parseLong(currentUser.getUsername());
+        authHelper.requireProjectMemberOrAdminManager(currentUser, projectId);
+        Long userId = authHelper.getCurrentUserId(currentUser);
         Attachment attachment = attachmentService.upload(issueId, file, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(
                 new IssueDto.AttachmentDto(attachment.getId(), attachment.getFileName(),
@@ -48,13 +56,17 @@ public class AttachmentController {
     }
 
     @DeleteMapping("/{attachmentId}")
-    public ResponseEntity<Void> delete(@PathVariable Long attachmentId) {
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    public ResponseEntity<Void> delete(@PathVariable Long projectId, @PathVariable Long attachmentId) {
         attachmentService.delete(attachmentId);
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/download/{attachmentId}")
-    public ResponseEntity<Resource> download(@PathVariable Long attachmentId) {
+    public ResponseEntity<Resource> download(
+            @PathVariable Long projectId, @PathVariable Long attachmentId,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, projectId);
         Resource resource = attachmentService.download(attachmentId);
         Attachment attachment = attachmentService.getById(attachmentId);
         return ResponseEntity.ok()

--- a/backend/src/main/java/com/jari/common/storage/FilesystemStorageService.java
+++ b/backend/src/main/java/com/jari/common/storage/FilesystemStorageService.java
@@ -28,7 +28,10 @@ public class FilesystemStorageService implements StorageService {
     @Override
     public String store(byte[] content, String fileName, String contentType) {
         String uniqueName = UUID.randomUUID() + "_" + fileName;
-        Path targetPath = basePath.resolve(uniqueName);
+        Path targetPath = basePath.resolve(uniqueName).normalize();
+        if (!targetPath.startsWith(basePath)) {
+            throw new RuntimeException("Path traversal detected");
+        }
         try {
             Files.write(targetPath, content);
         } catch (IOException e) {
@@ -41,6 +44,9 @@ public class FilesystemStorageService implements StorageService {
     public Resource load(String path) {
         try {
             Path file = basePath.resolve(path).normalize();
+            if (!file.startsWith(basePath)) {
+                throw new RuntimeException("Path traversal detected");
+            }
             Resource resource = new UrlResource(file.toUri());
             if (resource.exists() && resource.isReadable()) {
                 return resource;
@@ -55,6 +61,9 @@ public class FilesystemStorageService implements StorageService {
     public void delete(String path) {
         try {
             Path file = basePath.resolve(path).normalize();
+            if (!file.startsWith(basePath)) {
+                throw new RuntimeException("Path traversal detected");
+            }
             Files.deleteIfExists(file);
         } catch (IOException e) {
             throw new RuntimeException("Failed to delete file: " + path, e);

--- a/backend/src/main/java/com/jari/documentation/WikiPageController.java
+++ b/backend/src/main/java/com/jari/documentation/WikiPageController.java
@@ -2,9 +2,11 @@ package com.jari.documentation;
 
 import com.jari.common.dto.ApiResponse;
 import com.jari.issue.Issue;
+import com.jari.security.AuthHelper;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -16,20 +18,27 @@ import java.util.List;
 public class WikiPageController {
 
     private final WikiPageService wikiPageService;
+    private final AuthHelper authHelper;
 
-    public WikiPageController(WikiPageService wikiPageService) {
+    public WikiPageController(WikiPageService wikiPageService, AuthHelper authHelper) {
         this.wikiPageService = wikiPageService;
+        this.authHelper = authHelper;
     }
 
     @GetMapping("/pages")
-    public ResponseEntity<ApiResponse<List<WikiPageDto.TreeItem>>> getPageTree(@PathVariable Long projectId) {
+    public ResponseEntity<ApiResponse<List<WikiPageDto.TreeItem>>> getPageTree(
+            @PathVariable Long projectId, @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, projectId);
         List<WikiPage> rootPages = wikiPageService.getPageTree(projectId);
         List<WikiPageDto.TreeItem> tree = rootPages.stream().map(p -> toTreeItem(p)).toList();
         return ResponseEntity.ok(ApiResponse.of(tree));
     }
 
     @GetMapping("/pages/{pageId}")
-    public ResponseEntity<ApiResponse<WikiPageDto>> getPage(@PathVariable Long projectId, @PathVariable Long pageId) {
+    public ResponseEntity<ApiResponse<WikiPageDto>> getPage(
+            @PathVariable Long projectId, @PathVariable Long pageId,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, projectId);
         WikiPage page = wikiPageService.getById(pageId);
         return ResponseEntity.ok(ApiResponse.of(toDto(page)));
     }
@@ -39,7 +48,8 @@ public class WikiPageController {
             @PathVariable Long projectId,
             @Valid @RequestBody WikiPageDto.CreateRequest request,
             @AuthenticationPrincipal UserDetails currentUser) {
-        Long userId = Long.parseLong(currentUser.getUsername());
+        authHelper.requireProjectMemberOrAdminManager(currentUser, projectId);
+        Long userId = authHelper.getCurrentUserId(currentUser);
         WikiPage created = wikiPageService.create(projectId, request, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(toDto(created)));
     }
@@ -47,12 +57,15 @@ public class WikiPageController {
     @PutMapping("/pages/{pageId}")
     public ResponseEntity<ApiResponse<WikiPageDto>> updatePage(
             @PathVariable Long projectId, @PathVariable Long pageId,
-            @RequestBody WikiPageDto.UpdateRequest request) {
+            @RequestBody WikiPageDto.UpdateRequest request,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectMemberOrAdminManager(currentUser, projectId);
         WikiPage updated = wikiPageService.update(pageId, request);
         return ResponseEntity.ok(ApiResponse.of(toDto(updated)));
     }
 
     @DeleteMapping("/pages/{pageId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
     public ResponseEntity<Void> deletePage(@PathVariable Long projectId, @PathVariable Long pageId) {
         wikiPageService.delete(pageId);
         return ResponseEntity.noContent().build();
@@ -61,14 +74,18 @@ public class WikiPageController {
     @PatchMapping("/pages/{pageId}/position")
     public ResponseEntity<ApiResponse<WikiPageDto>> updatePosition(
             @PathVariable Long projectId, @PathVariable Long pageId,
-            @RequestBody WikiPageDto.PositionRequest request) {
+            @RequestBody WikiPageDto.PositionRequest request,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectMemberOrAdminManager(currentUser, projectId);
         WikiPage updated = wikiPageService.updatePosition(pageId, request);
         return ResponseEntity.ok(ApiResponse.of(toDto(updated)));
     }
 
     @GetMapping("/search")
     public ResponseEntity<ApiResponse<List<WikiPageDto.SearchHit>>> search(
-            @PathVariable Long projectId, @RequestParam String q) {
+            @PathVariable Long projectId, @RequestParam String q,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, projectId);
         List<WikiPageDto.SearchHit> hits = wikiPageService.search(projectId, q).stream()
                 .map(p -> new WikiPageDto.SearchHit(p.getId(), p.getTitle(), p.getSlug()))
                 .toList();

--- a/backend/src/main/java/com/jari/issue/IssueController.java
+++ b/backend/src/main/java/com/jari/issue/IssueController.java
@@ -4,11 +4,13 @@ import com.jari.attachment.AttachmentService;
 import com.jari.common.dto.ApiResponse;
 import com.jari.common.dto.PaginatedResponse;
 import com.jari.common.dto.PaginatedResponse.PaginationInfo;
+import com.jari.security.AuthHelper;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -22,10 +24,12 @@ public class IssueController {
 
     private final IssueService issueService;
     private final IssueMapper issueMapper;
+    private final AuthHelper authHelper;
 
-    public IssueController(IssueService issueService, IssueMapper issueMapper) {
+    public IssueController(IssueService issueService, IssueMapper issueMapper, AuthHelper authHelper) {
         this.issueService = issueService;
         this.issueMapper = issueMapper;
+        this.authHelper = authHelper;
     }
 
     @GetMapping
@@ -42,8 +46,10 @@ public class IssueController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) Instant createdBefore,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam(defaultValue = "createdAt,desc") String sort) {
+            @RequestParam(defaultValue = "createdAt,desc") String sort,
+            @AuthenticationPrincipal UserDetails currentUser) {
 
+        authHelper.requireProjectReadAccess(currentUser, projectId);
         Page<Issue> result = issueService.search(projectId, search, statusId, assigneeId, typeId,
                 priority, sprintId, labelId, createdAfter, createdBefore, page, size, sort);
         return ResponseEntity.ok(PaginatedResponse.of(
@@ -53,7 +59,10 @@ public class IssueController {
     }
 
     @GetMapping("/{issueId}")
-    public ResponseEntity<ApiResponse<IssueDto>> get(@PathVariable Long projectId, @PathVariable Long issueId) {
+    public ResponseEntity<ApiResponse<IssueDto>> get(
+            @PathVariable Long projectId, @PathVariable Long issueId,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, projectId);
         return ResponseEntity.ok(ApiResponse.of(issueMapper.toDto(issueService.getById(issueId))));
     }
 
@@ -62,7 +71,8 @@ public class IssueController {
             @PathVariable Long projectId,
             @Valid @RequestBody IssueDto.CreateRequest request,
             @AuthenticationPrincipal UserDetails currentUser) {
-        Long userId = Long.parseLong(currentUser.getUsername());
+        authHelper.requireProjectMemberOrAdminManager(currentUser, projectId);
+        Long userId = authHelper.getCurrentUserId(currentUser);
         Issue created = issueService.create(projectId, request, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(issueMapper.toDto(created)));
     }
@@ -70,12 +80,15 @@ public class IssueController {
     @PutMapping("/{issueId}")
     public ResponseEntity<ApiResponse<IssueDto>> update(
             @PathVariable Long projectId, @PathVariable Long issueId,
-            @RequestBody IssueDto.UpdateRequest request) {
+            @RequestBody IssueDto.UpdateRequest request,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectMemberOrAdminManager(currentUser, projectId);
         Issue updated = issueService.update(issueId, request);
         return ResponseEntity.ok(ApiResponse.of(issueMapper.toDto(updated)));
     }
 
     @DeleteMapping("/{issueId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
     public ResponseEntity<Void> delete(@PathVariable Long projectId, @PathVariable Long issueId) {
         issueService.delete(issueId);
         return ResponseEntity.noContent().build();
@@ -84,14 +97,19 @@ public class IssueController {
     @PatchMapping("/{issueId}/position")
     public ResponseEntity<ApiResponse<IssueDto>> updatePosition(
             @PathVariable Long projectId, @PathVariable Long issueId,
-            @RequestBody IssueDto.PositionRequest request) {
+            @RequestBody IssueDto.PositionRequest request,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectMemberOrAdminManager(currentUser, projectId);
         Issue updated = issueService.updatePosition(issueId, request);
         return ResponseEntity.ok(ApiResponse.of(issueMapper.toDto(updated)));
     }
 
     // Comments
     @GetMapping("/{issueId}/comments")
-    public ResponseEntity<ApiResponse<List<IssueDto.CommentDto>>> getComments(@PathVariable Long projectId, @PathVariable Long issueId) {
+    public ResponseEntity<ApiResponse<List<IssueDto.CommentDto>>> getComments(
+            @PathVariable Long projectId, @PathVariable Long issueId,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, projectId);
         return ResponseEntity.ok(ApiResponse.of(issueMapper.toCommentDtoList(issueService.getComments(issueId))));
     }
 
@@ -100,7 +118,8 @@ public class IssueController {
             @PathVariable Long projectId, @PathVariable Long issueId,
             @Valid @RequestBody IssueDto.CommentDto.CreateRequest request,
             @AuthenticationPrincipal UserDetails currentUser) {
-        Long userId = Long.parseLong(currentUser.getUsername());
+        authHelper.requireProjectMemberOrAdminManager(currentUser, projectId);
+        Long userId = authHelper.getCurrentUserId(currentUser);
         Comment comment = issueService.addComment(issueId, request, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(issueMapper.toCommentDto(comment)));
     }
@@ -108,12 +127,20 @@ public class IssueController {
     @PutMapping("/{issueId}/comments/{commentId}")
     public ResponseEntity<ApiResponse<IssueDto.CommentDto>> updateComment(
             @PathVariable Long projectId, @PathVariable Long issueId, @PathVariable Long commentId,
-            @Valid @RequestBody IssueDto.CommentDto.UpdateRequest request) {
-        Comment comment = issueService.updateComment(commentId, request);
+            @Valid @RequestBody IssueDto.CommentDto.UpdateRequest request,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, projectId);
+        Long userId = authHelper.getCurrentUserId(currentUser);
+        Comment comment = issueService.getComment(commentId);
+        if (!authHelper.hasAnyRole(currentUser, "ADMIN", "MANAGER") && !comment.getAuthor().getId().equals(userId)) {
+            throw new com.jari.common.exception.ForbiddenException("You can only edit your own comments");
+        }
+        comment = issueService.updateComment(commentId, request);
         return ResponseEntity.ok(ApiResponse.of(issueMapper.toCommentDto(comment)));
     }
 
     @DeleteMapping("/{issueId}/comments/{commentId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
     public ResponseEntity<Void> deleteComment(@PathVariable Long projectId, @PathVariable Long issueId, @PathVariable Long commentId) {
         issueService.deleteComment(commentId);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/jari/issue/IssueService.java
+++ b/backend/src/main/java/com/jari/issue/IssueService.java
@@ -184,6 +184,12 @@ public class IssueService {
         return commentRepository.save(comment);
     }
 
+    @Transactional(readOnly = true)
+    public Comment getComment(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new EntityNotFoundException("Comment", commentId));
+    }
+
     @Transactional
     public Comment updateComment(Long commentId, IssueDto.CommentDto.UpdateRequest request) {
         Comment comment = commentRepository.findById(commentId)

--- a/backend/src/main/java/com/jari/project/ProjectController.java
+++ b/backend/src/main/java/com/jari/project/ProjectController.java
@@ -4,6 +4,7 @@ import com.jari.common.dto.ApiResponse;
 import com.jari.common.dto.PaginatedResponse;
 import com.jari.common.dto.PaginatedResponse.PaginationInfo;
 import com.jari.common.exception.ForbiddenException;
+import com.jari.security.AuthHelper;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -23,10 +24,12 @@ public class ProjectController {
 
     private final ProjectService projectService;
     private final ProjectMapper projectMapper;
+    private final AuthHelper authHelper;
 
-    public ProjectController(ProjectService projectService, ProjectMapper projectMapper) {
+    public ProjectController(ProjectService projectService, ProjectMapper projectMapper, AuthHelper authHelper) {
         this.projectService = projectService;
         this.projectMapper = projectMapper;
+        this.authHelper = authHelper;
     }
 
     @GetMapping
@@ -39,9 +42,8 @@ public class ProjectController {
             @RequestParam(defaultValue = "createdAt,desc") String sort,
             @AuthenticationPrincipal UserDetails currentUser) {
 
-        Long userId = Long.parseLong(currentUser.getUsername());
-        boolean isAdminOrManagerOrExecutive = currentUser.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN") || a.getAuthority().equals("ROLE_MANAGER") || a.getAuthority().equals("ROLE_EXECUTIVE"));
+        Long userId = authHelper.getCurrentUserId(currentUser);
+        boolean isAdminOrManagerOrExecutive = authHelper.hasAnyRole(currentUser, "ADMIN", "MANAGER", "EXECUTIVE");
 
         Page<Project> result;
         if (isAdminOrManagerOrExecutive) {
@@ -68,7 +70,8 @@ public class ProjectController {
 
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<ProjectDto>> get(@PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
-        Long userId = Long.parseLong(currentUser.getUsername());
+        authHelper.requireProjectReadAccess(currentUser, id);
+        Long userId = authHelper.getCurrentUserId(currentUser);
         ProjectDto dto = projectMapper.toDto(projectService.getById(id));
         Set<Long> favoriteIds = projectService.getFavoriteProjectIds(userId);
         ProjectDto enriched = new ProjectDto(dto.id(), dto.name(), dto.key(), dto.description(),
@@ -105,14 +108,16 @@ public class ProjectController {
     @PostMapping("/{id}/favorite")
     public ResponseEntity<ApiResponse<ProjectDto>> toggleFavorite(
             @PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
-        Long userId = Long.parseLong(currentUser.getUsername());
+        Long userId = authHelper.getCurrentUserId(currentUser);
         boolean isFavorite = projectService.toggleFavorite(id, userId);
         return get(id, currentUser);
     }
 
     // Members
     @GetMapping("/{id}/members")
-    public ResponseEntity<ApiResponse<List<ProjectDto.MemberDto>>> getMembers(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<List<ProjectDto.MemberDto>>> getMembers(
+            @PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, id);
         List<ProjectDto.MemberDto> members = projectService.getMembers(id).stream()
                 .map(projectMapper::toMemberDto).toList();
         return ResponseEntity.ok(ApiResponse.of(members));
@@ -134,7 +139,9 @@ public class ProjectController {
 
     // Labels
     @GetMapping("/{id}/labels")
-    public ResponseEntity<ApiResponse<List<ProjectDto.LabelDto>>> getLabels(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<List<ProjectDto.LabelDto>>> getLabels(
+            @PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, id);
         List<ProjectDto.LabelDto> labels = projectService.getLabels(id).stream()
                 .map(l -> new ProjectDto.LabelDto(l.getId(), l.getName(), l.getColor())).toList();
         return ResponseEntity.ok(ApiResponse.of(labels));
@@ -166,7 +173,9 @@ public class ProjectController {
 
     // Board
     @GetMapping("/{id}/board")
-    public ResponseEntity<ApiResponse<ProjectDto.BoardConfigDto>> getBoard(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<ProjectDto.BoardConfigDto>> getBoard(
+            @PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, id);
         return ResponseEntity.ok(ApiResponse.of(projectService.getBoardConfig(id)));
     }
 

--- a/backend/src/main/java/com/jari/security/AuthHelper.java
+++ b/backend/src/main/java/com/jari/security/AuthHelper.java
@@ -1,0 +1,55 @@
+package com.jari.security;
+
+import com.jari.common.exception.ForbiddenException;
+import com.jari.project.ProjectService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthHelper {
+
+    private final ProjectService projectService;
+
+    public AuthHelper(ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    public Long getCurrentUserId(UserDetails currentUser) {
+        return Long.parseLong(currentUser.getUsername());
+    }
+
+    public boolean hasAnyRole(UserDetails currentUser, String... roles) {
+        for (String role : roles) {
+            if (currentUser.getAuthorities().stream()
+                    .anyMatch(a -> a.getAuthority().equals("ROLE_" + role))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void requireProjectReadAccess(UserDetails currentUser, Long projectId) {
+        if (hasAnyRole(currentUser, "ADMIN", "MANAGER", "EXECUTIVE")) return;
+        Long userId = getCurrentUserId(currentUser);
+        if (!projectService.isMember(projectId, userId)) {
+            throw new ForbiddenException("You do not have access to this project");
+        }
+    }
+
+    public void requireProjectMemberOrAdminManager(UserDetails currentUser, Long projectId) {
+        if (hasAnyRole(currentUser, "ADMIN", "MANAGER")) return;
+        Long userId = getCurrentUserId(currentUser);
+        if (!projectService.isMember(projectId, userId)) {
+            throw new ForbiddenException("You do not have access to this project");
+        }
+    }
+
+    public void requireSelfOrAdmin(UserDetails currentUser, Long targetUserId) {
+        if (hasAnyRole(currentUser, "ADMIN")) return;
+        Long userId = getCurrentUserId(currentUser);
+        if (!userId.equals(targetUserId)) {
+            throw new ForbiddenException("You can only modify your own data");
+        }
+    }
+}

--- a/backend/src/main/java/com/jari/sprint/BacklogController.java
+++ b/backend/src/main/java/com/jari/sprint/BacklogController.java
@@ -7,9 +7,12 @@ import com.jari.issue.Issue;
 import com.jari.issue.IssueDto;
 import com.jari.issue.IssueMapper;
 import com.jari.issue.IssueRepository;
+import com.jari.security.AuthHelper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,10 +21,12 @@ public class BacklogController {
 
     private final IssueRepository issueRepository;
     private final IssueMapper issueMapper;
+    private final AuthHelper authHelper;
 
-    public BacklogController(IssueRepository issueRepository, IssueMapper issueMapper) {
+    public BacklogController(IssueRepository issueRepository, IssueMapper issueMapper, AuthHelper authHelper) {
         this.issueRepository = issueRepository;
         this.issueMapper = issueMapper;
+        this.authHelper = authHelper;
     }
 
     @GetMapping
@@ -29,8 +34,10 @@ public class BacklogController {
             @PathVariable Long projectId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam(defaultValue = "position,asc") String sort) {
+            @RequestParam(defaultValue = "position,asc") String sort,
+            @AuthenticationPrincipal UserDetails currentUser) {
 
+        authHelper.requireProjectReadAccess(currentUser, projectId);
         PageRequest pageRequest = PageRequest.of(page, size);
         Page<Issue> result = issueRepository.findByProjectIdAndSprintIdIsNull(projectId, pageRequest);
         return ResponseEntity.ok(PaginatedResponse.of(

--- a/backend/src/main/java/com/jari/sprint/SprintController.java
+++ b/backend/src/main/java/com/jari/sprint/SprintController.java
@@ -5,12 +5,15 @@ import com.jari.issue.Issue;
 import com.jari.issue.IssueDto;
 import com.jari.issue.IssueMapper;
 import com.jari.issue.IssueRepository;
+import com.jari.security.AuthHelper;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,25 +26,32 @@ public class SprintController {
     private final SprintMapper sprintMapper;
     private final IssueRepository issueRepository;
     private final IssueMapper issueMapper;
+    private final AuthHelper authHelper;
 
     public SprintController(SprintService sprintService, SprintMapper sprintMapper,
-                            IssueRepository issueRepository, IssueMapper issueMapper) {
+                            IssueRepository issueRepository, IssueMapper issueMapper, AuthHelper authHelper) {
         this.sprintService = sprintService;
         this.sprintMapper = sprintMapper;
         this.issueRepository = issueRepository;
         this.issueMapper = issueMapper;
+        this.authHelper = authHelper;
     }
 
     @GetMapping
     public ResponseEntity<ApiResponse<List<SprintDto>>> list(
             @PathVariable Long projectId,
-            @RequestParam(required = false) String status) {
+            @RequestParam(required = false) String status,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, projectId);
         Sprint.SprintStatus statusEnum = status != null ? Sprint.SprintStatus.valueOf(status) : null;
         return ResponseEntity.ok(ApiResponse.of(sprintMapper.toDtoList(sprintService.getByProjectId(projectId, statusEnum))));
     }
 
     @GetMapping("/{sprintId}")
-    public ResponseEntity<ApiResponse<SprintDto>> get(@PathVariable Long projectId, @PathVariable Long sprintId) {
+    public ResponseEntity<ApiResponse<SprintDto>> get(
+            @PathVariable Long projectId, @PathVariable Long sprintId,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, projectId);
         return ResponseEntity.ok(ApiResponse.of(sprintMapper.toDto(sprintService.getById(sprintId))));
     }
 

--- a/backend/src/main/java/com/jari/timetracking/ReportController.java
+++ b/backend/src/main/java/com/jari/timetracking/ReportController.java
@@ -3,6 +3,7 @@ package com.jari.timetracking;
 import com.jari.common.dto.ApiResponse;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
@@ -22,6 +23,7 @@ public class ReportController {
     }
 
     @GetMapping("/time-by-project")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
     public ResponseEntity<ApiResponse<List<Map<String, Object>>>> timeByProject(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
@@ -50,6 +52,7 @@ public class ReportController {
     }
 
     @GetMapping("/time-by-user")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
     public ResponseEntity<ApiResponse<List<Map<String, Object>>>> timeByUser(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
@@ -77,6 +80,7 @@ public class ReportController {
     }
 
     @GetMapping("/time-by-issue")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
     public ResponseEntity<ApiResponse<List<Map<String, Object>>>> timeByIssue(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,

--- a/backend/src/main/java/com/jari/timetracking/TimeLogController.java
+++ b/backend/src/main/java/com/jari/timetracking/TimeLogController.java
@@ -3,11 +3,13 @@ package com.jari.timetracking;
 import com.jari.common.dto.ApiResponse;
 import com.jari.common.dto.PaginatedResponse;
 import com.jari.common.dto.PaginatedResponse.PaginationInfo;
+import com.jari.security.AuthHelper;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -21,17 +23,19 @@ public class TimeLogController {
 
     private final TimeLogService timeLogService;
     private final TimeLogMapper timeLogMapper;
+    private final AuthHelper authHelper;
 
-    public TimeLogController(TimeLogService timeLogService, TimeLogMapper timeLogMapper) {
+    public TimeLogController(TimeLogService timeLogService, TimeLogMapper timeLogMapper, AuthHelper authHelper) {
         this.timeLogService = timeLogService;
         this.timeLogMapper = timeLogMapper;
+        this.authHelper = authHelper;
     }
 
     @PostMapping
     public ResponseEntity<ApiResponse<TimeLogDto>> create(
             @Valid @RequestBody TimeLogDto.CreateRequest request,
             @AuthenticationPrincipal UserDetails currentUser) {
-        Long userId = Long.parseLong(currentUser.getUsername());
+        Long userId = authHelper.getCurrentUserId(currentUser);
         TimeLog created = timeLogService.create(request, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(timeLogMapper.toDto(created)));
     }
@@ -45,8 +49,13 @@ public class TimeLogController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam(defaultValue = "logDate,desc") String sort) {
+            @RequestParam(defaultValue = "logDate,desc") String sort,
+            @AuthenticationPrincipal UserDetails currentUser) {
 
+        if (userId != null && !userId.equals(authHelper.getCurrentUserId(currentUser))
+                && !authHelper.hasAnyRole(currentUser, "ADMIN", "MANAGER", "EXECUTIVE")) {
+            throw new com.jari.common.exception.ForbiddenException("You can only view your own time logs");
+        }
         Page<TimeLog> result = timeLogService.search(userId, issueId, projectId, startDate, endDate, page, size, sort);
         return ResponseEntity.ok(PaginatedResponse.of(
                 timeLogMapper.toDtoList(result.getContent()),
@@ -55,17 +64,33 @@ public class TimeLogController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<TimeLogDto>> get(@PathVariable Long id) {
-        return ResponseEntity.ok(ApiResponse.of(timeLogMapper.toDto(timeLogService.getById(id))));
+    public ResponseEntity<ApiResponse<TimeLogDto>> get(
+            @PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
+        TimeLog timeLog = timeLogService.getById(id);
+        Long currentUserId = authHelper.getCurrentUserId(currentUser);
+        if (!timeLog.getUser().getId().equals(currentUserId)
+                && !authHelper.hasAnyRole(currentUser, "ADMIN", "MANAGER")) {
+            throw new com.jari.common.exception.ForbiddenException("You can only view your own time logs");
+        }
+        return ResponseEntity.ok(ApiResponse.of(timeLogMapper.toDto(timeLog)));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<TimeLogDto>> update(@PathVariable Long id, @RequestBody TimeLogDto.UpdateRequest request) {
+    public ResponseEntity<ApiResponse<TimeLogDto>> update(
+            @PathVariable Long id, @RequestBody TimeLogDto.UpdateRequest request,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        TimeLog timeLog = timeLogService.getById(id);
+        Long currentUserId = authHelper.getCurrentUserId(currentUser);
+        if (!timeLog.getUser().getId().equals(currentUserId)
+                && !authHelper.hasAnyRole(currentUser, "ADMIN", "MANAGER")) {
+            throw new com.jari.common.exception.ForbiddenException("You can only edit your own time logs");
+        }
         TimeLog updated = timeLogService.update(id, request);
         return ResponseEntity.ok(ApiResponse.of(timeLogMapper.toDto(updated)));
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         timeLogService.delete(id);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/jari/timetracking/TimesheetController.java
+++ b/backend/src/main/java/com/jari/timetracking/TimesheetController.java
@@ -4,8 +4,6 @@ import com.jari.common.dto.ApiResponse;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -26,10 +24,10 @@ public class TimesheetController {
     }
 
     @GetMapping("/weekly")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
     public ResponseEntity<ApiResponse<Object>> weekly(
             @RequestParam Long userId,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStart,
-            @AuthenticationPrincipal UserDetails currentUser) {
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStart) {
         LocalDate weekEnd = weekStart.plusDays(6);
         List<TimeLog> logs = timeLogService.getWeeklyTimesheet(userId, weekStart, weekEnd);
 
@@ -46,10 +44,10 @@ public class TimesheetController {
     }
 
     @GetMapping("/daily")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
     public ResponseEntity<ApiResponse<Object>> daily(
             @RequestParam Long userId,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
-            @AuthenticationPrincipal UserDetails currentUser) {
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
         List<TimeLog> logs = timeLogService.getDailyTimesheet(userId, date);
         return ResponseEntity.ok(ApiResponse.of(Map.of(
                 "userId", userId,

--- a/backend/src/main/java/com/jari/user/UserController.java
+++ b/backend/src/main/java/com/jari/user/UserController.java
@@ -64,6 +64,7 @@ public class UserController {
     }
 
     @PutMapping("/{id}/password")
+    @PreAuthorize("hasRole('ADMIN') or #id == authentication.principal.username")
     public ResponseEntity<ApiResponse<Object>> changePassword(
             @PathVariable Long id,
             @Valid @RequestBody UserDto.PasswordChangeRequest request,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -42,4 +42,18 @@ export async function apiDelete(url: string): Promise<void> {
   await client.delete(url);
 }
 
+export function extractValidationErrors(err: unknown): Record<string, string> {
+  if (axios.isAxiosError(err) && err.response?.status === 422) {
+    const errors = (err.response.data as { errors?: Array<{ field: string; message: string }> }).errors;
+    if (errors) {
+      const result: Record<string, string> = {};
+      for (const e of errors) {
+        result[e.field] = e.message;
+      }
+      return result;
+    }
+  }
+  return {};
+}
+
 export default client;

--- a/frontend/src/components/common/Field.tsx
+++ b/frontend/src/components/common/Field.tsx
@@ -6,19 +6,23 @@ interface FieldProps {
   required?: boolean;
   textarea?: boolean;
   maxLength?: number;
+  minLength?: number;
+  error?: string;
   className?: string;
 }
 
-export default function Field({ label, value, onChange, type = 'text', required, textarea, maxLength, className }: FieldProps) {
+export default function Field({ label, value, onChange, type = 'text', required, textarea, maxLength, minLength, error, className }: FieldProps) {
   const id = label.replace(/\s+/g, '-').toLowerCase();
+  const inputClassName = `w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 ${error ? 'border-red-300 focus:ring-red-500' : 'border-gray-300 focus:ring-primary-500'}`;
   return (
     <div className={className}>
       <label htmlFor={id} className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
       {textarea ? (
-        <textarea id={id} value={value} onChange={(e) => onChange(e.target.value)} rows={3} required={required} maxLength={maxLength} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+        <textarea id={id} value={value} onChange={(e) => onChange(e.target.value)} rows={3} required={required} maxLength={maxLength} className={inputClassName} />
       ) : (
-        <input id={id} type={type} value={value} onChange={(e) => onChange(e.target.value)} required={required} maxLength={maxLength} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+        <input id={id} type={type} value={value} onChange={(e) => onChange(e.target.value)} required={required} maxLength={maxLength} minLength={minLength} className={inputClassName} />
       )}
+      {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
     </div>
   );
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -66,6 +66,7 @@ export default function LoginPage() {
                 value={password}
                 onChange={(e) => { setPassword(e.target.value); clearError(); }}
                 required
+                minLength={6}
                 autoComplete="current-password"
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 placeholder="Enter your password"

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -6,6 +6,7 @@ import { listPrograms } from '@/api/admin';
 import Modal from '@/components/common/Modal';
 import Field from '@/components/common/Field';
 import { listAllUsers } from '@/api/users';
+import { extractValidationErrors } from '@/api/client';
 import { useAuth } from '@/hooks/useAuth';
 import { formatDate, stageBadge } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
@@ -170,6 +171,7 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
   const [users, setUsers] = useState<UserDto[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [loadError, setLoadError] = useState<string | null>(null);
   const navigate = useNavigate();
 
@@ -184,8 +186,33 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
     }).catch(() => setLoadError('Failed to load users. You may not have permission.'));
   }, []);
 
+  const validate = (): boolean => {
+    const errors: Record<string, string> = {};
+    if (!/^[A-Z][A-Z0-9]*$/.test(key.toUpperCase())) {
+      errors.key = 'Key must start with a letter and contain only letters and numbers';
+    }
+    if (key.length < 2) {
+      errors.key = 'Key must be at least 2 characters';
+    }
+    if (strategicScore && (Number(strategicScore) < 1 || Number(strategicScore) > 10)) {
+      errors.strategicScore = 'Strategic score must be between 1 and 10';
+    }
+    if (plannedValue && isNaN(Number(plannedValue))) {
+      errors.plannedValue = 'Planned value must be a number';
+    }
+    if (budget && isNaN(Number(budget))) {
+      errors.budget = 'Budget must be a number';
+    }
+    if (targetStartDate && targetEndDate && targetEndDate < targetStartDate) {
+      errors.targetEndDate = 'End date must be after start date';
+    }
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!validate()) return;
     setSaving(true);
     setError(null);
     try {
@@ -204,8 +231,13 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
         targetEndDate: targetEndDate || undefined,
       });
       navigate(`/projects/${project.id}`);
-    } catch {
-      setError('Failed to create project. Check the details and try again.');
+    } catch (err) {
+      const serverErrors = extractValidationErrors(err);
+      if (Object.keys(serverErrors).length > 0) {
+        setFieldErrors(serverErrors);
+      } else {
+        setError('Failed to create project. Check the details and try again.');
+      }
     } finally {
       setSaving(false);
     }
@@ -223,8 +255,8 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
         {error && <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-3 py-2">{error}</div>}
         {loadError && <div className="bg-yellow-50 border border-yellow-200 text-yellow-700 text-sm rounded-lg px-3 py-2">{loadError}</div>}
         <div className="grid grid-cols-3 gap-4">
-          <Field label="Name" value={name} onChange={setName} required className="col-span-2" />
-          <Field label="Key" value={key} onChange={setKey} required maxLength={10} />
+          <Field label="Name" value={name} onChange={setName} required className="col-span-2" error={fieldErrors.name} />
+          <Field label="Key" value={key} onChange={setKey} required maxLength={10} error={fieldErrors.key} />
         </div>
         <Field label="Description" value={description} onChange={setDescription} textarea />
         <div className="grid grid-cols-2 gap-4">
@@ -253,16 +285,18 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
                 <option value="CLOSING">Closing</option>
               </select>
             </div>
-            <Field label="Strategic Score (1-10)" value={strategicScore} onChange={(v) => setStrategicScore(v.replace(/[^0-9]/g, ''))} />
+            <Field label="Strategic Score (1-10)" value={strategicScore} onChange={(v) => setStrategicScore(v.replace(/[^0-9]/g, ''))} error={fieldErrors.strategicScore} />
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Planned Value ($)</label>
-              <input type="text" value={plannedValue} onChange={(e) => setPlannedValue(e.target.value)} placeholder="0" className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+              <input type="text" value={plannedValue} onChange={(e) => setPlannedValue(e.target.value)} placeholder="0" className={`w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 ${fieldErrors.plannedValue ? 'border-red-300 focus:ring-red-500' : 'border-gray-300 focus:ring-primary-500'}`} />
+              {fieldErrors.plannedValue && <p className="mt-1 text-sm text-red-600">{fieldErrors.plannedValue}</p>}
             </div>
           </div>
           <div className="grid grid-cols-3 gap-4 mt-4">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Budget ($)</label>
-              <input type="text" value={budget} onChange={(e) => setBudget(e.target.value)} placeholder="0" className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+              <input type="text" value={budget} onChange={(e) => setBudget(e.target.value)} placeholder="0" className={`w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 ${fieldErrors.budget ? 'border-red-300 focus:ring-red-500' : 'border-gray-300 focus:ring-primary-500'}`} />
+              {fieldErrors.budget && <p className="mt-1 text-sm text-red-600">{fieldErrors.budget}</p>}
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Start Date</label>
@@ -270,7 +304,8 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">End Date</label>
-              <input type="date" value={targetEndDate} onChange={(e) => setTargetEndDate(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+              <input type="date" value={targetEndDate} onChange={(e) => setTargetEndDate(e.target.value)} className={`w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 ${fieldErrors.targetEndDate ? 'border-red-300 focus:ring-red-500' : 'border-gray-300 focus:ring-primary-500'}`} />
+              {fieldErrors.targetEndDate && <p className="mt-1 text-sm text-red-600">{fieldErrors.targetEndDate}</p>}
             </div>
           </div>
         </div>

--- a/frontend/src/pages/admin/UsersTab.tsx
+++ b/frontend/src/pages/admin/UsersTab.tsx
@@ -20,6 +20,7 @@ export default function UsersTab() {
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
   const [editingUser, setEditingUser] = useState<UserDto | null>(null);
+  const [deactivatingId, setDeactivatingId] = useState<number | null>(null);
 
   const fetchUsers = useCallback(async () => {
     setLoading(true);
@@ -72,7 +73,17 @@ export default function UsersTab() {
                     <div className="flex gap-2">
                       <button onClick={() => setEditingUser(u)} className="text-primary-600 hover:text-primary-800 text-xs font-medium">Edit</button>
                       {u.active && (
-                        <button onClick={async () => { await deactivateUser(u.id); fetchUsers(); }} className="text-red-600 hover:text-red-800 text-xs font-medium">Deactivate</button>
+                        <button
+                          onClick={async () => {
+                            setDeactivatingId(u.id);
+                            try { await deactivateUser(u.id); fetchUsers(); } finally { setDeactivatingId(null); }
+                          }}
+                          disabled={deactivatingId === u.id}
+                          className="text-red-600 hover:text-red-800 text-xs font-medium disabled:opacity-50 flex items-center gap-1"
+                        >
+                          {deactivatingId === u.id && <Spinner className="h-3 w-3" />}
+                          Deactivate
+                        </button>
                       )}
                     </div>
                   </td>
@@ -121,7 +132,7 @@ function CreateUserModal({ onClose }: { onClose: () => void }) {
           <Field label="Username" value={username} onChange={setUsername} required />
           <Field label="Email" type="email" value={email} onChange={setEmail} required />
         </div>
-        <Field label="Password" type="password" value={password} onChange={setPassword} required />
+        <Field label="Password" type="password" value={password} onChange={setPassword} required minLength={6} />
         <div className="grid grid-cols-2 gap-4">
           <Field label="First name" value={firstName} onChange={setFirstName} required />
           <Field label="Last name" value={lastName} onChange={setLastName} required />

--- a/frontend/src/pages/project-detail/SettingsTab.tsx
+++ b/frontend/src/pages/project-detail/SettingsTab.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { ProjectDto } from '@/types';
 import { updateProject } from '@/api/projects';
+import { extractValidationErrors } from '@/api/client';
 import EvmCard from './EvmCard';
 
 export default function SettingsTab({ project, onUpdate }: { project: ProjectDto; onUpdate: (p: ProjectDto) => void }) {
@@ -14,9 +15,32 @@ export default function SettingsTab({ project, onUpdate }: { project: ProjectDto
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const validate = (): boolean => {
+    const errors: Record<string, string> = {};
+    if (strategicScore && (Number(strategicScore) < 1 || Number(strategicScore) > 10)) {
+      errors.strategicScore = 'Strategic score must be between 1 and 10';
+    }
+    if (plannedValue && isNaN(Number(plannedValue))) {
+      errors.plannedValue = 'Planned value must be a number';
+    }
+    if (budget && isNaN(Number(budget))) {
+      errors.budget = 'Budget must be a number';
+    }
+    if (budgetSpent && isNaN(Number(budgetSpent))) {
+      errors.budgetSpent = 'Budget spent must be a number';
+    }
+    if (targetStartDate && targetEndDate && targetEndDate < targetStartDate) {
+      errors.targetEndDate = 'End date must be after start date';
+    }
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!validate()) return;
     setSaving(true); setError(null); setSuccess(false);
     try {
       const updated = await updateProject(project.id, {
@@ -27,8 +51,18 @@ export default function SettingsTab({ project, onUpdate }: { project: ProjectDto
       });
       onUpdate(updated);
       setSuccess(true);
-    } catch { setError('Failed to save project settings.'); } finally { setSaving(false); }
+    } catch (err) {
+      const serverErrors = extractValidationErrors(err);
+      if (Object.keys(serverErrors).length > 0) {
+        setFieldErrors(serverErrors);
+      } else {
+        setError('Failed to save project settings.');
+      }
+    } finally { setSaving(false); }
   };
+
+  const inputClass = (field: string) =>
+    `w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 ${fieldErrors[field] ? 'border-red-300 focus:ring-red-500' : 'border-gray-300 focus:ring-primary-500'}`;
 
   return (
     <div className="space-y-6">
@@ -51,7 +85,8 @@ export default function SettingsTab({ project, onUpdate }: { project: ProjectDto
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Strategic Score (1-10)</label>
-            <input type="number" min="1" max="10" value={strategicScore} onChange={e => setStrategicScore(e.target.value)} placeholder="e.g. 7" className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+            <input type="number" min="1" max="10" value={strategicScore} onChange={e => setStrategicScore(e.target.value)} placeholder="e.g. 7" className={inputClass('strategicScore')} />
+            {fieldErrors.strategicScore && <p className="mt-1 text-sm text-red-600">{fieldErrors.strategicScore}</p>}
           </div>
         </div>
 
@@ -59,26 +94,30 @@ export default function SettingsTab({ project, onUpdate }: { project: ProjectDto
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Planned Value (PV Baseline)</label>
-            <input type="text" value={plannedValue} onChange={e => setPlannedValue(e.target.value)} placeholder="e.g. 150000" className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+            <input type="text" value={plannedValue} onChange={e => setPlannedValue(e.target.value)} placeholder="e.g. 150000" className={inputClass('plannedValue')} />
+            {fieldErrors.plannedValue && <p className="mt-1 text-sm text-red-600">{fieldErrors.plannedValue}</p>}
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Total Budget</label>
-            <input type="text" value={budget} onChange={e => setBudget(e.target.value)} placeholder="e.g. 150000" className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+            <input type="text" value={budget} onChange={e => setBudget(e.target.value)} placeholder="e.g. 150000" className={inputClass('budget')} />
+            {fieldErrors.budget && <p className="mt-1 text-sm text-red-600">{fieldErrors.budget}</p>}
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Budget Spent (Non-Labor)</label>
-            <input type="text" value={budgetSpent} onChange={e => setBudgetSpent(e.target.value)} placeholder="e.g. 12000" className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+            <input type="text" value={budgetSpent} onChange={e => setBudgetSpent(e.target.value)} placeholder="e.g. 12000" className={inputClass('budgetSpent')} />
+            {fieldErrors.budgetSpent && <p className="mt-1 text-sm text-red-600">{fieldErrors.budgetSpent}</p>}
           </div>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Target Start Date</label>
-            <input type="date" value={targetStartDate} onChange={e => setTargetStartDate(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+            <input type="date" value={targetStartDate} onChange={e => setTargetStartDate(e.target.value)} className={inputClass('targetStartDate')} />
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Target End Date</label>
-            <input type="date" value={targetEndDate} onChange={e => setTargetEndDate(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+            <input type="date" value={targetEndDate} onChange={e => setTargetEndDate(e.target.value)} className={inputClass('targetEndDate')} />
+            {fieldErrors.targetEndDate && <p className="mt-1 text-sm text-red-600">{fieldErrors.targetEndDate}</p>}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- **Issue #4 (Authorization):** Adds role-based and membership-based access control to all backend controllers. Previously, any authenticated user could CRUD issues, wiki pages, time logs, and attachments across all projects.
- **Issue #11 (Frontend Validation):** Adds client-side form validation with inline error messages, 422 server error extraction, and password minimum length.

## Changes

### Backend — Authorization (Issue #4)
- **AuthHelper component** — centralized utility for getCurrentUserId, hasAnyRole, requireProjectReadAccess, requireProjectMemberOrAdminManager, requireSelfOrAdmin
- **Path traversal fix** — FilesystemStorageService now verifies resolved paths start with basePath
- **IssueController** — read requires project membership; write requires membership or ADMIN/MANAGER; delete/comment delete requires ADMIN/MANAGER; comment edit requires authorship or ADMIN/MANAGER
- **WikiPageController** — read requires project membership; write requires membership or ADMIN/MANAGER; delete requires ADMIN/MANAGER
- **TimeLogController** — list filters by user unless ADMIN/MANAGER/EXECUTIVE; get/update require ownership or ADMIN/MANAGER; delete requires ADMIN/MANAGER
- **AttachmentController** — read/download requires project membership; upload requires membership or ADMIN/MANAGER; delete requires ADMIN/MANAGER
- **BacklogController & SprintController** — read requires project membership
- **ProjectController** — read endpoints now require project membership
- **TimesheetController & ReportController** — all endpoints require ADMIN/MANAGER/EXECUTIVE
- **UserController** — changePassword now has @PreAuthorize

### Frontend — Validation (Issue #11)
- **Field component** — added error and minLength props with red border/message styling
- **API client** — added extractValidationErrors() for 422 error handling
- **CreateProjectModal** — validates key format, strategic score range, numeric budget fields, date range
- **SettingsTab** — validates strategic score, budget fields, date range with inline errors
- **LoginPage & UsersTab** — password minLength=6; deactivate button loading spinner

Resolves #4, Resolves #11
