### PR TITLE
fix(#36): return null CPI/SPI when AC=0 instead of 0.00

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/PmoService.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoService.java
@@ -117,15 +117,15 @@ public class PmoService {
         BigDecimal pvToday = computePlannedValueToday(project, plannedValue);
         BigDecimal scheduleVariance = earnedValue.subtract(pvToday).setScale(2, RoundingMode.HALF_UP);
 
-        // CPI = EV / AC
+        // CPI = EV / AC (null when AC = 0 — no costs recorded yet)
         BigDecimal cpi = actualCost.compareTo(BigDecimal.ZERO) > 0
                 ? earnedValue.divide(actualCost, 2, RoundingMode.HALF_UP)
-                : BigDecimal.ZERO;
+                : null;
 
-        // SPI = EV / PV
+        // SPI = EV / PV (null when PV = 0 — no planned value yet)
         BigDecimal spi = pvToday.compareTo(BigDecimal.ZERO) > 0
                 ? earnedValue.divide(pvToday, 2, RoundingMode.HALF_UP)
-                : BigDecimal.ZERO;
+                : null;
 
         // Risk summary
         long openRisks = raidItemRepository.countByProjectIdAndStatus(projectId, RaidItem.RaidStatus.OPEN);

--- a/frontend/src/pages/PmoDashboardPage.tsx
+++ b/frontend/src/pages/PmoDashboardPage.tsx
@@ -128,8 +128,8 @@ export default function PmoDashboardPage() {
                     <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(evm.plannedValue)}</td>
                     <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(evm.earnedValue)}</td>
                     <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(evm.actualCost)}</td>
-                    <td className={`px-3 py-3 text-right font-semibold ${eviColor(evm.cpi)}`}>{evm.cpi.toFixed(2)}</td>
-                    <td className={`px-3 py-3 text-right font-semibold ${eviColor(evm.spi)}`}>{evm.spi.toFixed(2)}</td>
+                    <td className={`px-3 py-3 text-right font-semibold ${eviColor(evm.cpi)}`}>{evm.cpi != null ? evm.cpi.toFixed(2) : 'N/A'}</td>
+                    <td className={`px-3 py-3 text-right font-semibold ${eviColor(evm.spi)}`}>{evm.spi != null ? evm.spi.toFixed(2) : 'N/A'}</td>
                     <td className={`px-3 py-3 text-right ${evm.costVariance >= 0 ? 'text-green-600' : 'text-red-600'}`}>{formatCurrency(evm.costVariance)}</td>
                     <td className={`px-3 py-3 text-right ${evm.scheduleVariance >= 0 ? 'text-green-600' : 'text-red-600'}`}>{formatCurrency(evm.scheduleVariance)}</td>
                     <td className="px-3 py-3 text-right">

--- a/frontend/src/pages/dashboard/ExecutiveDashboard.tsx
+++ b/frontend/src/pages/dashboard/ExecutiveDashboard.tsx
@@ -31,14 +31,14 @@ function computeAlerts(
     const maxRisk = projectRisks.length > 0 ? Math.max(...projectRisks.map((r) => r.riskScore)) : 0;
 
     if (evm) {
-      if (evm.cpi < 0.9) {
+      if (evm.cpi != null && evm.cpi < 0.9) {
         alerts.push({
           projectId: project.id, projectKey: project.key, projectName: project.name,
           type: 'cpi', message: 'Cost performance below threshold',
           value: `CPI ${evm.cpi.toFixed(2)}`, severity: evm.cpi < 0.8 ? 'red' : 'yellow',
         });
       }
-      if (evm.spi < 0.9) {
+      if (evm.spi != null && evm.spi < 0.9) {
         alerts.push({
           projectId: project.id, projectKey: project.key, projectName: project.name,
           type: 'spi', message: 'Schedule performance below threshold',
@@ -194,8 +194,8 @@ export default function ExecutiveDashboard() {
     // If a specific company is selected, use CompanyPortfolioSummary
     if (selectedCompanySummary) {
       const cs = selectedCompanySummary;
-      const totalEarnedValue = Object.values(filteredEvmMap).reduce((s, e) => s + e.earnedValue, 0);
-      const totalActualCost = Object.values(filteredEvmMap).reduce((s, e) => s + e.actualCost, 0);
+      const totalEarnedValue = Object.values(filteredEvmMap).filter(e => e.actualCost > 0).reduce((s, e) => s + e.earnedValue, 0);
+      const totalActualCost = Object.values(filteredEvmMap).filter(e => e.actualCost > 0).reduce((s, e) => s + e.actualCost, 0);
       const totalPlannedValue = Object.values(filteredEvmMap).reduce((s, e) => s + e.plannedValue, 0);
       const cv = totalEarnedValue - totalActualCost;
       const sv = totalEarnedValue - totalPlannedValue;
@@ -490,15 +490,15 @@ export default function ExecutiveDashboard() {
                         <td className="px-3 py-3 text-center text-gray-700">{completionPct}</td>
                         <td className="px-3 py-3 text-center">
                           {evm ? (
-                            <span className={evm.cpi >= 1 ? 'text-green-600' : evm.cpi >= 0.9 ? 'text-yellow-600' : 'text-red-600'}>
-                              {evm.cpi.toFixed(2)}
+                            <span className={evm.cpi == null ? 'text-gray-400' : evm.cpi >= 1 ? 'text-green-600' : evm.cpi >= 0.9 ? 'text-yellow-600' : 'text-red-600'}>
+                              {evm.cpi != null ? evm.cpi.toFixed(2) : 'N/A'}
                             </span>
                           ) : '—'}
                         </td>
                         <td className="px-3 py-3 text-center">
                           {evm ? (
-                            <span className={evm.spi >= 1 ? 'text-green-600' : evm.spi >= 0.9 ? 'text-yellow-600' : 'text-red-600'}>
-                              {evm.spi.toFixed(2)}
+                            <span className={evm.spi == null ? 'text-gray-400' : evm.spi >= 1 ? 'text-green-600' : evm.spi >= 0.9 ? 'text-yellow-600' : 'text-red-600'}>
+                              {evm.spi != null ? evm.spi.toFixed(2) : 'N/A'}
                             </span>
                           ) : '—'}
                         </td>
@@ -594,8 +594,8 @@ export default function ExecutiveDashboard() {
                       <span className="text-xs font-semibold text-gray-700">{(evm.completionPct * 100).toFixed(0)}%</span>
                     </div>
                     <div className="flex gap-4 text-xs">
-                      <span>CPI: <span className={evm.cpi >= 1 ? 'text-green-600' : evm.cpi >= 0.9 ? 'text-yellow-600' : 'text-red-600'}>{evm.cpi.toFixed(2)}</span></span>
-                      <span>SPI: <span className={evm.spi >= 1 ? 'text-green-600' : evm.spi >= 0.9 ? 'text-yellow-600' : 'text-red-600'}>{evm.spi.toFixed(2)}</span></span>
+                      <span>CPI: <span className={evm.cpi == null ? 'text-gray-400' : evm.cpi >= 1 ? 'text-green-600' : evm.cpi >= 0.9 ? 'text-yellow-600' : 'text-red-600'}>{evm.cpi != null ? evm.cpi.toFixed(2) : 'N/A'}</span></span>
+                      <span>SPI: <span className={evm.spi == null ? 'text-gray-400' : evm.spi >= 1 ? 'text-green-600' : evm.spi >= 0.9 ? 'text-yellow-600' : 'text-red-600'}>{evm.spi != null ? evm.spi.toFixed(2) : 'N/A'}</span></span>
                     </div>
                   </div>
                 )}

--- a/frontend/src/pages/dashboard/ManagerDashboard.tsx
+++ b/frontend/src/pages/dashboard/ManagerDashboard.tsx
@@ -146,10 +146,10 @@ export default function ManagerDashboard() {
                       </div>
                       <div className="flex gap-4 text-xs">
                         <span>
-                          CPI: <span className={evm.cpi >= 1 ? 'text-green-600' : evm.cpi >= 0.9 ? 'text-yellow-600' : 'text-red-600'}>{evm.cpi.toFixed(2)}</span>
+                          CPI: <span className={evm.cpi == null ? 'text-gray-400' : evm.cpi >= 1 ? 'text-green-600' : evm.cpi >= 0.9 ? 'text-yellow-600' : 'text-red-600'}>{evm.cpi != null ? evm.cpi.toFixed(2) : 'N/A'}</span>
                         </span>
                         <span>
-                          SPI: <span className={evm.spi >= 1 ? 'text-green-600' : evm.spi >= 0.9 ? 'text-yellow-600' : 'text-red-600'}>{evm.spi.toFixed(2)}</span>
+                          SPI: <span className={evm.spi == null ? 'text-gray-400' : evm.spi >= 1 ? 'text-green-600' : evm.spi >= 0.9 ? 'text-yellow-600' : 'text-red-600'}>{evm.spi != null ? evm.spi.toFixed(2) : 'N/A'}</span>
                         </span>
                       </div>
                     </div>

--- a/frontend/src/pages/project-detail/SummaryTab.tsx
+++ b/frontend/src/pages/project-detail/SummaryTab.tsx
@@ -89,8 +89,8 @@ export default function SummaryTab({ project, projectId, managerId, onNavigate }
   const fmt = (v: number | null) => formatCurrency(v);
   const cvColor = evm && evm.costVariance >= 0 ? 'text-green-600' : 'text-red-600';
   const svColor = evm && evm.scheduleVariance >= 0 ? 'text-green-600' : 'text-red-600';
-  const cpiColor = evm ? (evm.cpi >= 1 ? 'text-green-600' : evm.cpi >= 0.9 ? 'text-yellow-600' : 'text-red-600') : '';
-  const spiColor = evm ? (evm.spi >= 1 ? 'text-green-600' : evm.spi >= 0.9 ? 'text-yellow-600' : 'text-red-600') : '';
+  const cpiColor = evm ? (evm.cpi == null ? 'text-gray-400' : evm.cpi >= 1 ? 'text-green-600' : evm.cpi >= 0.9 ? 'text-yellow-600' : 'text-red-600') : '';
+  const spiColor = evm ? (evm.spi == null ? 'text-gray-400' : evm.spi >= 1 ? 'text-green-600' : evm.spi >= 0.9 ? 'text-yellow-600' : 'text-red-600') : '';
 
   const handleDeleteInstruction = async (inst: InstructionDto) => {
     if (!confirm('Delete this instruction?')) return;
@@ -186,11 +186,11 @@ export default function SummaryTab({ project, projectId, managerId, onNavigate }
                 </div>
                 <div className="text-center">
                   <div className="text-xs text-gray-500 font-medium">CPI</div>
-                  <div className={`text-lg font-bold ${cpiColor}`}>{evm.cpi.toFixed(2)}</div>
+                  <div className={`text-lg font-bold ${cpiColor}`}>{evm.cpi != null ? evm.cpi.toFixed(2) : 'N/A'}</div>
                 </div>
                 <div className="text-center">
                   <div className="text-xs text-gray-500 font-medium">SPI</div>
-                  <div className={`text-lg font-bold ${spiColor}`}>{evm.spi.toFixed(2)}</div>
+                  <div className={`text-lg font-bold ${spiColor}`}>{evm.spi != null ? evm.spi.toFixed(2) : 'N/A'}</div>
                 </div>
               </div>
             </div>

--- a/frontend/src/pages/reports/PortfolioReport.tsx
+++ b/frontend/src/pages/reports/PortfolioReport.tsx
@@ -132,13 +132,13 @@ export default function PortfolioReport() {
                   <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(Number(p.budget || 0))}</td>
                   <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(spent)}</td>
                   <td className="px-3 py-3 text-right">
-                    <span className={evm.cpi >= 1 ? 'text-green-600 font-semibold' : evm.cpi >= 0.9 ? 'text-yellow-600 font-semibold' : 'text-red-600 font-semibold'}>
-                      {evm.cpi.toFixed(2)}
+                    <span className={evm.cpi == null ? 'text-gray-400 font-semibold' : evm.cpi >= 1 ? 'text-green-600 font-semibold' : evm.cpi >= 0.9 ? 'text-yellow-600 font-semibold' : 'text-red-600 font-semibold'}>
+                      {evm.cpi != null ? evm.cpi.toFixed(2) : 'N/A'}
                     </span>
                   </td>
                   <td className="px-3 py-3 text-right">
-                    <span className={evm.spi >= 1 ? 'text-green-600 font-semibold' : evm.spi >= 0.9 ? 'text-yellow-600 font-semibold' : 'text-red-600 font-semibold'}>
-                      {evm.spi.toFixed(2)}
+                    <span className={evm.spi == null ? 'text-gray-400 font-semibold' : evm.spi >= 1 ? 'text-green-600 font-semibold' : evm.spi >= 0.9 ? 'text-yellow-600 font-semibold' : 'text-red-600 font-semibold'}>
+                      {evm.spi != null ? evm.spi.toFixed(2) : 'N/A'}
                     </span>
                   </td>
                   <td className="px-3 py-3 text-right">

--- a/frontend/src/types/pmo.ts
+++ b/frontend/src/types/pmo.ts
@@ -57,8 +57,8 @@ export interface EvmMetrics {
   pvToday: number;
   costVariance: number;
   scheduleVariance: number;
-  cpi: number;
-  spi: number;
+  cpi: number | null;
+  spi: number | null;
   budget: number;
   laborCost: number;
   stage: string | null;

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -92,7 +92,8 @@ export function raidStatusBadge(status: string): string {
   }
 }
 
-export function eviColor(value: number): string {
+export function eviColor(value: number | null): string {
+  if (value == null) return 'text-gray-400';
   if (value >= 1) return 'text-green-600';
   if (value >= 0.9) return 'text-yellow-600';
   return 'text-red-600';


### PR DESCRIPTION
## Summary
- Return `null` from backend CPI/SPI calculation when the denominator (AC/PV) is zero, instead of `BigDecimal.ZERO`
- Display "N/A" with neutral grey styling in all frontend components when CPI/SPI is null
- Exclude null CPI/SPI from Executive Dashboard "Attention Needed" alerts and portfolio aggregation

## Root cause
When AC=0, `PmoService.java` returned `BigDecimal.ZERO` for CPI, which rendered as `0.00` in red and triggered false "Cost performance below threshold" alerts for every project with no costs recorded.

## Files changed
- `backend/src/main/java/com/nemo/pmo/PmoService.java` — null instead of ZERO for CPI/SPI when denominator is 0
- `frontend/src/types/pmo.ts` — cpi/spi type now `number | null`
- `frontend/src/utils/format.ts` — `eviColor()` handles null
- `frontend/src/pages/PmoDashboardPage.tsx` — N/A display for null CPI/SPI
- `frontend/src/pages/project-detail/SummaryTab.tsx` — N/A display for null CPI/SPI
- `frontend/src/pages/dashboard/ManagerDashboard.tsx` — N/A display for null CPI/SPI
- `frontend/src/pages/dashboard/ExecutiveDashboard.tsx` — N/A display, null-safe alerts, portfolio aggregation fix
- `frontend/src/pages/reports/PortfolioReport.tsx` — N/A display for null CPI/SPI

## Test plan
- [ ] Log in as `salim` (EXECUTIVE), navigate to PMO Dashboard — CPI column should show "N/A" in grey for projects with AC=0
- [ ] Executive Dashboard "Attention Needed" section should not show false CPI alerts for projects with no costs
- [ ] Project detail SummaryTab should display "N/A" for CPI/SPI when null
- [ ] Manager Dashboard and Portfolio Report should render "N/A" for null CPI/SPI
- [ ] Portfolio CPI aggregation on Executive Dashboard should only include projects with actualCost > 0

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)