### PR TITLE
fix(#38): add overdue visual indicators to project list views

### DIFF
--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -10,7 +10,7 @@ import Field from '@/components/common/Field';
 import { listAllUsers } from '@/api/users';
 import { extractValidationErrors } from '@/api/client';
 import { useAuth } from '@/hooks/useAuth';
-import { formatDate, stageBadge } from '@/utils/format';
+import { formatDate, stageBadge, deadlineBadge, deadlineLabel } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
 
 export default function ProjectsPage() {
@@ -83,6 +83,7 @@ export default function ProjectsPage() {
                     <div className="flex items-center gap-2 mb-2">
                       <span className="font-mono text-xs text-primary-600 bg-primary-50 px-1.5 py-0.5 rounded">{p.key}</span>
                       {p.stage && <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${stageBadge(p.stage)}`}>{p.stage}</span>}
+                      {p.targetEndDate && deadlineLabel(p.targetEndDate) && <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(p.targetEndDate)}`}>{deadlineLabel(p.targetEndDate)}</span>}
                     </div>
                     <h4 className="text-base font-semibold text-gray-900 mb-1">{p.name}</h4>
                     {p.description && <p className="text-xs text-gray-500 line-clamp-2 mb-3">{p.description}</p>}
@@ -90,6 +91,7 @@ export default function ProjectsPage() {
                       <span>{p.programName ?? '—'}</span>
                       <span>{p.companyName ?? 'Global'}</span>
                       <span>{p.managerName}</span>
+                      {p.targetEndDate && <span className={deadlineBadge(p.targetEndDate) || 'text-gray-400'}>{formatDate(p.targetEndDate)}</span>}
                     </div>
                   </div>
                 ))}
@@ -107,6 +109,7 @@ export default function ProjectsPage() {
                   <th className="text-left px-2 py-3 font-medium text-gray-500">Program</th>
                   <th className="text-left px-2 py-3 font-medium text-gray-500">Company</th>
                   <th className="text-left px-2 py-3 font-medium text-gray-500">Manager</th>
+                  <th className="text-left px-2 py-3 font-medium text-gray-500">End Date</th>
                   <th className="text-left px-2 py-3 font-medium text-gray-500">Created</th>
                 </tr>
               </thead>
@@ -131,14 +134,22 @@ export default function ProjectsPage() {
                     <td className="px-2 py-3 text-gray-500">{p.programName ?? '—'}</td>
                     <td className="px-2 py-3">{p.companyName ? <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">{p.companyName}</span> : <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-700">Global</span>}</td>
                     <td className="px-2 py-3 text-gray-500">{p.managerName}</td>
+                    <td className="px-2 py-3">
+                      {p.targetEndDate ? (
+                        <span className="inline-flex items-center gap-1.5">
+                          <span className={deadlineBadge(p.targetEndDate) || 'text-gray-500'}>{formatDate(p.targetEndDate)}</span>
+                          {deadlineLabel(p.targetEndDate) && <span className={`inline-block px-1.5 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(p.targetEndDate)}`}>{deadlineLabel(p.targetEndDate)}</span>}
+                        </span>
+                      ) : <span className="text-gray-400">—</span>}
+                    </td>
                     <td className="px-2 py-3 text-gray-500">{formatDate(p.createdAt)}</td>
                   </tr>
                 ))}
                 {others.length === 0 && favorites.length === 0 && (
-                  <tr><td colSpan={6} className="px-4 py-8 text-center text-gray-500">No projects found.</td></tr>
+                  <tr><td colSpan={8} className="px-4 py-8 text-center text-gray-500">No projects found.</td></tr>
                 )}
                 {others.length === 0 && favorites.length > 0 && (
-                  <tr><td colSpan={6} className="px-4 py-6 text-center text-gray-400 text-xs">All projects are favorites</td></tr>
+                  <tr><td colSpan={8} className="px-4 py-6 text-center text-gray-400 text-xs">All projects are favorites</td></tr>
                 )}
               </tbody>
             </table>

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -170,6 +170,30 @@ export function preSaleStageLabel(stage: string): string {
   }
 }
 
+export function deadlineBadge(endDate: string | null): string {
+  if (!endDate) return '';
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const end = new Date(endDate);
+  end.setHours(0, 0, 0, 0);
+  const diffDays = (end.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+  if (diffDays < 0) return 'bg-red-100 text-red-700';
+  if (diffDays <= 14) return 'bg-amber-100 text-amber-700';
+  return '';
+}
+
+export function deadlineLabel(endDate: string | null): string | null {
+  if (!endDate) return null;
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const end = new Date(endDate);
+  end.setHours(0, 0, 0, 0);
+  if (end < now) return 'Overdue';
+  const diffDays = (end.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+  if (diffDays <= 14) return 'Due soon';
+  return null;
+}
+
 export function preSaleStageBadge(stage: string): string {
   switch (stage) {
     case 'LEAD': return 'bg-gray-100 text-gray-700';


### PR DESCRIPTION
## Summary
- Add End Date column to the projects list table with overdue visual indicators
- Dates past their end date render in **red** with an "Overdue" badge
- Dates within 2 weeks of end date render in **amber** with a "Due soon" badge
- Favorites card view also shows overdue/due-soon badges and colored dates
- Added `deadlineBadge()` and `deadlineLabel()` helpers to `format.ts` following existing badge patterns

## Test plan
- [ ] Log in as manager/executive, navigate to `/projects`
- [ ] Verify "Full-Stack E-commerce" (end date Sep 30, 2025) shows red date + "Overdue" badge
- [ ] Verify "Infrastructure Upgrade" (end date Nov 30, 2025) shows red date + "Overdue" badge
- [ ] Verify projects with future end dates > 2 weeks away show normal gray dates
- [ ] Verify projects with no end date show "—" in the End Date column
- [ ] Verify favorites cards also display overdue/due-soon badges

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)