### PR TITLE
fix(#37): map login errors to user-friendly messages

### DIFF
--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import axios from 'axios';
 import type { UserDto } from '@/types';
 import * as authApi from '@/api/auth';
 
@@ -27,8 +28,15 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const user = await authApi.login({ username, password, captcha });
       set({ user, isAuthenticated: true, isLoading: false });
     } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : 'Login failed. Please check your credentials.';
+      let message = 'An error occurred. Please try again.';
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status;
+        if (!err.response) {
+          message = 'Unable to connect. Please check your connection.';
+        } else if (status === 400 || status === 401 || status === 422) {
+          message = 'Invalid username or password. Please try again.';
+        }
+      }
       set({ error: message, isLoading: false });
       throw err;
     }


### PR DESCRIPTION
## Summary
- Login error handler now uses `axios.isAxiosError()` to detect HTTP errors instead of passing raw `err.message` to the UI
- 400/401/422 responses → "Invalid username or password. Please try again."
- Network errors (no response) → "Unable to connect. Please check your connection."
- All other errors → "An error occurred. Please try again."
- No internal HTTP status codes or Axios error strings are ever exposed to users

## Test plan
- [ ] Navigate to `/login`, submit with empty fields → should show "Invalid username or password" instead of "Request failed with status code 422"
- [ ] Enter wrong credentials → same friendly message
- [ ] Disconnect network and try → should show "Unable to connect. Please check your connection."

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)