### PR TITLE
fix(#41): wire budgetSpent into EVM actual cost, fix portfolio summary

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/PmoService.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoService.java
@@ -93,11 +93,12 @@ public class PmoService {
         // Earned Value (EV) = completion% × plannedValue
         BigDecimal earnedValue = completionPct.multiply(plannedValue).setScale(2, RoundingMode.HALF_UP);
 
-        // Actual Cost (AC) = labor cost only (internal cost from time logs × rates)
+        // Actual Cost (AC) = labor cost + project budget spent (external costs)
         LocalDate projectStart = project.getTargetStartDate();
         LocalDate projectEnd = project.getTargetEndDate();
         BigDecimal laborCost = computeLaborCost(projectId, projectStart, projectEnd);
-        BigDecimal actualCost = laborCost.setScale(2, RoundingMode.HALF_UP);
+        BigDecimal budgetSpent = project.getBudgetSpent() != null ? project.getBudgetSpent() : BigDecimal.ZERO;
+        BigDecimal actualCost = laborCost.add(budgetSpent).setScale(2, RoundingMode.HALF_UP);
 
         // Total paid by client (sum of phase payments)
         List<Long> phaseIds = phases.stream().map(Phase::getId).toList();
@@ -233,7 +234,19 @@ public class PmoService {
             totalTasks += projTotal;
             totalCompleted += projCompleted;
 
-            if (project.getPlannedValue() != null) totalPlannedValue = totalPlannedValue.add(project.getPlannedValue());
+            // Per-project EVM aggregation
+            BigDecimal projPv = project.getPlannedValue() != null ? project.getPlannedValue() : BigDecimal.ZERO;
+            totalPlannedValue = totalPlannedValue.add(projPv);
+
+            BigDecimal projCompletion = projTotal > 0
+                    ? BigDecimal.valueOf(projCompleted).divide(BigDecimal.valueOf(projTotal), 4, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+            totalEarnedValue = totalEarnedValue.add(projCompletion.multiply(projPv).setScale(2, RoundingMode.HALF_UP));
+
+            BigDecimal projLaborCost = computeLaborCost(project.getId(), project.getTargetStartDate(), project.getTargetEndDate());
+            BigDecimal projBudgetSpent = project.getBudgetSpent() != null ? project.getBudgetSpent() : BigDecimal.ZERO;
+            totalActualCost = totalActualCost.add(projLaborCost.add(projBudgetSpent).setScale(2, RoundingMode.HALF_UP));
+
             if (project.getBudget() != null) totalBudget = totalBudget.add(project.getBudget());
             if (project.getBudgetSpent() != null) totalBudgetSpent = totalBudgetSpent.add(project.getBudgetSpent());
 

--- a/frontend/src/pages/dashboard/ExecutiveDashboard.tsx
+++ b/frontend/src/pages/dashboard/ExecutiveDashboard.tsx
@@ -46,7 +46,7 @@ function computeAlerts(
         });
       }
       if (project.budget && Number(project.budget) > 0) {
-        const spentRatio = (Number(project.budgetSpent || 0) + evm.actualCost) / Number(project.budget);
+        const spentRatio = evm.actualCost / Number(project.budget);
         if (spentRatio > 0.8) {
           alerts.push({
             projectId: project.id, projectKey: project.key, projectName: project.name,
@@ -248,7 +248,7 @@ export default function ExecutiveDashboard() {
     .filter((p) => p.budget)
     .map((p) => {
       const evm = filteredEvmMap[p.id];
-      const spent = Number(p.budgetSpent || 0) + (evm?.actualCost || 0);
+      const spent = evm?.actualCost || 0;
       const over = spent > Number(p.budget);
       return {
         label: p.key,
@@ -461,7 +461,7 @@ export default function ExecutiveDashboard() {
                   .map((project) => {
                     const evm = filteredEvmMap[project.id];
                     const budget = Number(project.budget || 0);
-                    const spent = Number(project.budgetSpent || 0) + (evm?.actualCost || 0);
+                    const spent = evm?.actualCost || 0;
                     const completionPct = evm ? (evm.completionPct * 100).toFixed(0) + '%' : '—';
                     return (
                       <tr key={project.id} className="hover:bg-gray-50">
@@ -515,7 +515,7 @@ export default function ExecutiveDashboard() {
               const tier = score >= 7 ? 'High (7-10)' : score >= 4 ? 'Medium (4-6)' : 'Low (1-3)';
               if (!acc[tier]) acc[tier] = { budget: 0, spent: 0, count: 0 };
               acc[tier].budget += Number(p.budget || 0);
-              acc[tier].spent += Number(p.budgetSpent || 0) + (filteredEvmMap[p.id]?.actualCost || 0);
+              acc[tier].spent += filteredEvmMap[p.id]?.actualCost || 0;
               acc[tier].count += 1;
               return acc;
             }, {} as Record<string, { budget: number; spent: number; count: number }>);

--- a/frontend/src/pages/dashboard/ManagerDashboard.tsx
+++ b/frontend/src/pages/dashboard/ManagerDashboard.tsx
@@ -157,7 +157,7 @@ export default function ManagerDashboard() {
                   {project.budget && (
                     <div className="flex justify-between text-xs text-gray-500 mt-2 pt-2 border-t border-gray-100">
                       <span>Budget: {formatCurrency(Number(project.budget))}</span>
-                      <span>Spent: {formatCurrency(Number(project.budgetSpent || 0) + (evm?.actualCost || 0))}</span>
+                      <span>Spent: {formatCurrency(evm?.actualCost || 0)}</span>
                     </div>
                   )}
                 </Link>

--- a/frontend/src/pages/reports/PortfolioReport.tsx
+++ b/frontend/src/pages/reports/PortfolioReport.tsx
@@ -121,7 +121,7 @@ export default function PortfolioReport() {
             {projects.map((p) => {
               const evm = evmMap[p.id];
               if (!evm) return null;
-              const spent = Number(p.budgetSpent || 0) + evm.actualCost;
+              const spent = evm.actualCost;
               const completionPct = Math.round(evm.completionPct * 100);
               return (
                 <tr key={p.id} className="hover:bg-gray-50">


### PR DESCRIPTION
## Summary
- **Backend fix**: `PmoService.computeEvm()` now computes AC as `laborCost + budgetSpent` instead of `laborCost` alone, so projects with seeded spending show correct actual costs and CPI
- **Backend fix**: `PmoService.getPortfolioSummary()` now computes per-project EV and AC in the loop (they were initialized to zero and never incremented), making portfolio-level CV/SV meaningful
- **Frontend fix**: Removed double-counting of `budgetSpent` in ExecutiveDashboard, ManagerDashboard, and PortfolioReport — these views were manually adding `budgetSpent + actualCost`, which now double-counts since `actualCost` already includes `budgetSpent`

## Root cause
AC was computed from labor costs only (time logs × rates). Projects with no time logs or user rates got AC = 0, making CPI show "—" (division by zero). Meanwhile, `budgetSpent` had real values (DH 18K, DH 45K) but was never wired into EVM.

## Test plan
- [ ] Log in as admin/executive, navigate to PMO → Project Performance
- [ ] Verify AC now shows non-zero values for projects with `budgetSpent` data
- [ ] Verify CPI and CV are now computed correctly (no longer "—" or equal to EV)
- [ ] Navigate to Reports → Portfolio → verify Total Spent and project-level AC are correct
- [ ] Check Executive Dashboard budget alerts still trigger correctly
- [ ] Verify Manager Dashboard "Spent" values are correct (no double-counting)

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)