### PR TITLE
fix(#43): align risk count between PMO Dashboard and Portfolio Report

### DIFF
--- a/frontend/src/pages/PmoDashboardPage.tsx
+++ b/frontend/src/pages/PmoDashboardPage.tsx
@@ -75,7 +75,7 @@ export default function PmoDashboardPage() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           <StatCard label="Total Projects" value={String(portfolio.totalProjects)} icon={ProjectIcon} />
           <StatCard label="Portfolio Budget" value={formatCurrency(portfolio.totalBudget)} sub={`Spent: ${formatCurrency(portfolio.totalBudgetSpent)}`} icon={BudgetIcon} />
-          <StatCard label="Open Risks" value={String(portfolio.totalOpenRisks)} sub={`${portfolio.totalMitigatingRisks} mitigating`} icon={RiskIcon} />
+          <StatCard label="Active Risks" value={String(portfolio.totalOpenRisks + portfolio.totalMitigatingRisks)} sub={`${portfolio.totalOpenRisks} open · ${portfolio.totalMitigatingRisks} mitigating`} icon={RiskIcon} />
           <StatCard label="Completion" value={`${portfolio.totalTasks > 0 ? Math.round((portfolio.totalCompleted / portfolio.totalTasks) * 100) : 0}%`} sub={`${portfolio.totalCompleted} / ${portfolio.totalTasks} tasks`} icon={ProgressIcon} />
         </div>
       )}

--- a/frontend/src/pages/reports/PortfolioReport.tsx
+++ b/frontend/src/pages/reports/PortfolioReport.tsx
@@ -63,7 +63,7 @@ export default function PortfolioReport() {
             <p className="text-xl font-bold text-gray-900">{portfolio.totalTasks > 0 ? ((portfolio.totalCompleted / portfolio.totalTasks) * 100).toFixed(0) + '%' : '-'}</p>
           </div>
           <div className="bg-white rounded-xl border border-gray-200 p-4">
-            <p className="text-xs text-gray-500">Open Risks</p>
+            <p className="text-xs text-gray-500">Active Risks</p>
             <p className="text-xl font-bold text-gray-900">{portfolio.totalOpenRisks + portfolio.totalMitigatingRisks}</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Both views now show the combined OPEN + MITIGATING risk count under the label "Active Risks"
- PMO Dashboard subtitle shows the breakdown ("X open · Y mitigating")
- Fixes the inconsistency where PMO Dashboard showed 15 (OPEN only) and Portfolio Report showed 19 (OPEN + MITIGATING)

## Test plan
- [ ] Log in as MANAGER/EXECUTIVE, navigate to PMO Dashboard → verify "Active Risks" shows combined count with breakdown subtitle
- [ ] Navigate to Reports → Portfolio → verify "Active Risks" shows the same combined count
- [ ] Company breakdown table in Portfolio Report should still show combined risk counts

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)