### PR TITLE
fix(#42): add overdue indicators to PMO Dashboard, Portfolio Report, and Program Detail

### DIFF
--- a/frontend/src/pages/PmoDashboardPage.tsx
+++ b/frontend/src/pages/PmoDashboardPage.tsx
@@ -5,7 +5,7 @@ import { getPortfolioSummary, getEvmMetrics, listPortfolioRaidItems } from '@/ap
 import { listProjects } from '@/api/projects';
 import type { PortfolioSummary, EvmMetrics, RaidItemDto, ProjectDto } from '@/types';
 import Spinner from '@/components/common/Spinner';
-import { riskColor, riskLabel, stageBadge, formatCurrency, eviColor } from '@/utils/format';
+import { riskColor, riskLabel, stageBadge, formatCurrency, eviColor, deadlineBadge, deadlineLabel } from '@/utils/format';
 
 export default function PmoDashboardPage() {
   const user = useAuthStore((s) => s.user);
@@ -123,7 +123,10 @@ export default function PmoDashboardPage() {
                 return (
                   <tr key={p.id} className="hover:bg-gray-50">
                     <td className="px-5 py-3 font-medium"><Link to={`/projects/${p.id}`} className="text-primary-600 hover:text-primary-800">{p.name}</Link></td>
-                    <td className="px-3 py-3"><span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${stageBadge(evm.stage)}`}>{evm.stage}</span></td>
+                    <td className="px-3 py-3">
+                      <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${stageBadge(evm.stage)}`}>{evm.stage}</span>
+                      {p.targetEndDate && deadlineLabel(p.targetEndDate) && <span className={`inline-block ml-1 px-2 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(p.targetEndDate)}`}>{deadlineLabel(p.targetEndDate)}</span>}
+                    </td>
                     <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(evm.budget)}</td>
                     <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(evm.plannedValue)}</td>
                     <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(evm.earnedValue)}</td>

--- a/frontend/src/pages/ProgramDetailPage.tsx
+++ b/frontend/src/pages/ProgramDetailPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import type { ProgramDto, ProjectDto } from '@/types';
 import { getProgram } from '@/api/programs';
 import { listProjects } from '@/api/projects';
-import { stageBadge, stageLabel, formatCurrency, formatDate } from '@/utils/format';
+import { stageBadge, stageLabel, formatCurrency, formatDate, deadlineBadge, deadlineLabel } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
 
 export default function ProgramDetailPage() {
@@ -91,6 +91,11 @@ function ProjectCard({ project, onClick }: { project: ProjectDto; onClick: () =>
               {stageLabel(project.stage)}
             </span>
           )}
+          {project.targetEndDate && deadlineLabel(project.targetEndDate) && (
+            <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(project.targetEndDate)}`}>
+              {deadlineLabel(project.targetEndDate)}
+            </span>
+          )}
         </div>
       </div>
 
@@ -99,10 +104,10 @@ function ProjectCard({ project, onClick }: { project: ProjectDto; onClick: () =>
 
       {/* Dates */}
       {(project.targetStartDate || project.targetEndDate) && (
-        <div className="text-xs text-gray-500 mb-3">
-          {project.targetStartDate && <span>{formatDate(project.targetStartDate)}</span>}
-          {project.targetStartDate && project.targetEndDate && <span> → </span>}
-          {project.targetEndDate && <span>{formatDate(project.targetEndDate)}</span>}
+        <div className="text-xs mb-3">
+          {project.targetStartDate && <span className="text-gray-500">{formatDate(project.targetStartDate)}</span>}
+          {project.targetStartDate && project.targetEndDate && <span className="text-gray-500"> → </span>}
+          {project.targetEndDate && <span className={deadlineBadge(project.targetEndDate) || 'text-gray-500'}>{formatDate(project.targetEndDate)}</span>}
         </div>
       )}
 

--- a/frontend/src/pages/project-detail/SummaryTab.tsx
+++ b/frontend/src/pages/project-detail/SummaryTab.tsx
@@ -3,7 +3,7 @@ import type { ProjectDto, PhaseDto, DeliverableDto, MemberDto, InstructionDto, N
 import { listPhases, listDeliverables } from '@/api/phases';
 import { getMembers, listInstructions, createInstruction, updateInstruction, deleteInstruction, listNotes, createNote, updateNote, deleteNote } from '@/api/projects';
 import { getEvmMetrics } from '@/api/pmo';
-import { formatDate, formatCurrency, stageLabel } from '@/utils/format';
+import { formatDate, formatCurrency, stageLabel, deadlineBadge, deadlineLabel } from '@/utils/format';
 import { useAuth } from '@/hooks/useAuth';
 import MarkdownRenderer from '@/components/common/MarkdownRenderer';
 import Spinner from '@/components/common/Spinner';
@@ -72,7 +72,17 @@ export default function SummaryTab({ project, projectId, managerId, onNavigate }
     if (now <= start) return 0;
     return Math.round(((now - start) / (end - start)) * 100);
   })();
-  const timelineColor = timelinePct != null ? (timelinePct >= 100 ? 'bg-amber-500' : 'bg-blue-500') : '';
+  const timelineColor = timelinePct != null ? (timelinePct >= 100 ? 'bg-red-500' : 'bg-blue-500') : '';
+  const overdueLabel = (() => {
+    if (!project.targetEndDate) return null;
+    const now = new Date(); now.setHours(0, 0, 0, 0);
+    const end = new Date(project.targetEndDate); end.setHours(0, 0, 0, 0);
+    if (end < now) {
+      const days = Math.ceil((now.getTime() - end.getTime()) / (1000 * 60 * 60 * 24));
+      return `${days} day${days !== 1 ? 's' : ''} overdue`;
+    }
+    return null;
+  })();
   const durationLabel = (() => {
     if (!project.targetStartDate || !project.targetEndDate) return null;
     const start = new Date(project.targetStartDate);
@@ -142,9 +152,16 @@ export default function SummaryTab({ project, projectId, managerId, onNavigate }
               <span className="text-gray-900 font-medium">{project.programName || '—'}</span>
               <span className="text-gray-500">Timeline</span>
               <span className="text-gray-900 font-medium">
-                {project.targetStartDate && project.targetEndDate
-                  ? `${formatDate(project.targetStartDate)} → ${formatDate(project.targetEndDate)}`
-                  : '—'}
+                {project.targetStartDate && project.targetEndDate ? (
+                  <>
+                    <span className="text-gray-900">{formatDate(project.targetStartDate)}</span>
+                    <span className="text-gray-400 mx-1">→</span>
+                    <span className={deadlineBadge(project.targetEndDate) || 'text-gray-900'}>{formatDate(project.targetEndDate)}</span>
+                    {project.targetEndDate && deadlineLabel(project.targetEndDate) && (
+                      <span className={`ml-2 inline-block px-2 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(project.targetEndDate)}`}>{deadlineLabel(project.targetEndDate)}</span>
+                    )}
+                  </>
+                ) : '—'}
               </span>
             </div>
             {timelinePct != null && (
@@ -155,7 +172,11 @@ export default function SummaryTab({ project, projectId, managerId, onNavigate }
                   </div>
                   <span className="text-xs text-gray-500">{timelinePct}%</span>
                 </div>
-                {durationLabel && <span className="text-xs text-gray-400">{durationLabel}</span>}
+                {overdueLabel ? (
+                  <span className="text-xs font-medium text-red-600">{overdueLabel}</span>
+                ) : durationLabel ? (
+                  <span className="text-xs text-gray-400">{durationLabel}</span>
+                ) : null}
               </div>
             )}
           </div>

--- a/frontend/src/pages/reports/PortfolioReport.tsx
+++ b/frontend/src/pages/reports/PortfolioReport.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getPortfolioByCompany, getEvmMetrics, getPortfolioSummary } from '@/api/pmo';
 import { listProjects } from '@/api/projects';
-import { formatCurrency } from '@/utils/format';
+import { formatCurrency, stageBadge, deadlineBadge, deadlineLabel } from '@/utils/format';
 import type { CompanyPortfolioSummary, EvmMetrics, PortfolioSummary, ProjectDto } from '@/types';
 import Spinner from '@/components/common/Spinner';
 
@@ -127,7 +127,8 @@ export default function PortfolioReport() {
                 <tr key={p.id} className="hover:bg-gray-50">
                   <td className="px-5 py-3 font-medium text-gray-900">{p.name}</td>
                   <td className="px-3 py-3">
-                    {p.stage ? <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${stageBadgeLocal(p.stage)}`}>{p.stage}</span> : '-'}
+                    {p.stage ? <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${stageBadge(p.stage)}`}>{p.stage}</span> : '-'}
+                    {p.targetEndDate && deadlineLabel(p.targetEndDate) && <span className={`inline-block ml-1 px-2 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(p.targetEndDate)}`}>{deadlineLabel(p.targetEndDate)}</span>}
                   </td>
                   <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(Number(p.budget || 0))}</td>
                   <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(spent)}</td>
@@ -157,14 +158,4 @@ export default function PortfolioReport() {
       </div>
     </div>
   );
-}
-
-function stageBadgeLocal(stage: string): string {
-  switch (stage) {
-    case 'INITIATION': return 'bg-blue-100 text-blue-800';
-    case 'PLANNING': return 'bg-purple-100 text-purple-800';
-    case 'EXECUTION': return 'bg-amber-100 text-amber-800';
-    case 'CLOSING': return 'bg-green-100 text-green-800';
-    default: return 'bg-gray-100 text-gray-800';
-  }
 }


### PR DESCRIPTION
## Summary
- PMO Dashboard: added "Overdue"/"Due soon" badge next to stage badge in Project Performance table
- Portfolio Report: added overdue badge next to stage badge; replaced local `stageBadgeLocal` with shared `stageBadge` from format.ts
- Program Detail: added overdue badge next to stage badge in project cards; colored end dates red (overdue) or amber (due soon)

## Test plan
- [ ] Log in as admin/executive, navigate to PMO → Project Performance → overdue projects show red "Overdue" badge next to stage
- [ ] Navigate to Reports → Portfolio → Project Performance table → same overdue badges visible
- [ ] Navigate to Programs → click a program with overdue sub-projects → project cards show "Overdue" badge and red end dates

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)