### PR TITLE
feat(#44): add due date field to tasks

### DIFF
--- a/backend/src/main/java/com/nemo/task/Task.java
+++ b/backend/src/main/java/com/nemo/task/Task.java
@@ -12,6 +12,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -78,6 +79,9 @@ public class Task {
             inverseJoinColumns = @JoinColumn(name = "label_id"))
     private Set<Label> labels = new HashSet<>();
 
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -117,6 +121,8 @@ public class Task {
     public void setExternal(boolean external) { this.external = external; }
     public Set<Label> getLabels() { return labels; }
     public void setLabels(Set<Label> labels) { this.labels = labels; }
+    public LocalDate getDueDate() { return dueDate; }
+    public void setDueDate(LocalDate dueDate) { this.dueDate = dueDate; }
     public Instant getCreatedAt() { return createdAt; }
     public Instant getUpdatedAt() { return updatedAt; }
 }

--- a/backend/src/main/java/com/nemo/task/TaskController.java
+++ b/backend/src/main/java/com/nemo/task/TaskController.java
@@ -84,7 +84,7 @@ public class TaskController {
         Long userId = authHelper.getCurrentUserId(currentUser);
         if (authHelper.isExternal(currentUser)) {
             request = new TaskDto.CreateRequest(request.title(), request.description(),
-                    request.priority(), request.typeId(), request.assigneeId(), request.phaseId(), request.labelIds(), true);
+                    request.priority(), request.typeId(), request.assigneeId(), request.phaseId(), request.labelIds(), true, request.dueDate());
         }
         Task created = taskService.create(projectId, request, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(taskMapper.toDto(created)));

--- a/backend/src/main/java/com/nemo/task/TaskDto.java
+++ b/backend/src/main/java/com/nemo/task/TaskDto.java
@@ -14,6 +14,7 @@ public record TaskDto(
         Long reporterId, String reporterName,
         Long sprintId, Long phaseId, String phaseName, int position, boolean external,
         List<Long> labelIds, List<String> labelNames,
+        String dueDate,
         String createdAt, String updatedAt
 ) {
     public record CreateRequest(
@@ -24,13 +25,15 @@ public record TaskDto(
             Long assigneeId,
             Long phaseId,
             List<Long> labelIds,
-            Boolean external
+            Boolean external,
+            String dueDate
     ) {}
 
     public record UpdateRequest(
             String title, String description, String priority,
             Long typeId, Long assigneeId, Long statusId, Long sprintId, Long phaseId,
-            List<Long> labelIds, Boolean external
+            List<Long> labelIds, Boolean external,
+            String dueDate
     ) {}
 
     public record PositionRequest(int position, Long sprintId) {}

--- a/backend/src/main/java/com/nemo/task/TaskMapper.java
+++ b/backend/src/main/java/com/nemo/task/TaskMapper.java
@@ -26,6 +26,7 @@ public interface TaskMapper {
     @Mapping(target = "labelNames", expression = "java(task.getLabels().stream().map(l -> l.getName()).toList())")
     @Mapping(target = "createdAt", source = "createdAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'")
     @Mapping(target = "updatedAt", source = "updatedAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    @Mapping(target = "dueDate", source = "dueDate", dateFormat = "yyyy-MM-dd")
     TaskDto toDto(Task task);
 
     List<TaskDto> toDtoList(List<Task> tasks);

--- a/backend/src/main/java/com/nemo/task/TaskService.java
+++ b/backend/src/main/java/com/nemo/task/TaskService.java
@@ -121,6 +121,10 @@ public class TaskService {
             task.setExternal(true);
         }
 
+        if (request.dueDate() != null) {
+            task.setDueDate(java.time.LocalDate.parse(request.dueDate()));
+        }
+
         return taskRepository.save(task);
     }
 
@@ -165,6 +169,10 @@ public class TaskService {
             }
         }
         if (request.external() != null) task.setExternal(request.external());
+
+        if (request.dueDate() != null) {
+            task.setDueDate(java.time.LocalDate.parse(request.dueDate()));
+        }
 
         return taskRepository.save(task);
     }

--- a/frontend/src/pages/TaskDetailPage.tsx
+++ b/frontend/src/pages/TaskDetailPage.tsx
@@ -7,7 +7,7 @@ import { getComments, addComment } from '@/api/tasks';
 import { listTimeLogs, createTimeLog, deleteTimeLog } from '@/api/timeLogs';
 import { listOpenPhases } from '@/api/phases';
 import { listTaskStatuses, listTaskTypes } from '@/api/admin';
-import { priorityColor, statusColor, formatDate } from '@/utils/format';
+import { priorityColor, statusColor, formatDate, deadlineBadge, deadlineLabel } from '@/utils/format';
 import { useAuth } from '@/hooks/useAuth';
 import Spinner from '@/components/common/Spinner';
 
@@ -27,6 +27,7 @@ export default function TaskDetailPage() {
   const [assigneeId, setAssigneeId] = useState('');
   const [phaseId, setPhaseId] = useState('');
   const [selectedLabels, setSelectedLabels] = useState<number[]>([]);
+  const [dueDate, setDueDate] = useState('');
 
   // Dropdown options
   const [statuses, setStatuses] = useState<TaskStatusDto[]>([]);
@@ -57,6 +58,7 @@ export default function TaskDetailPage() {
       setAssigneeId(data.assigneeId != null ? String(data.assigneeId) : '');
       setPhaseId(data.phaseId != null ? String(data.phaseId) : '');
       setSelectedLabels(data.labelIds);
+      setDueDate(data.dueDate ?? '');
     } finally {
       setLoading(false);
     }
@@ -87,6 +89,7 @@ export default function TaskDetailPage() {
         assigneeId: assigneeId ? Number(assigneeId) : null,
         phaseId: phaseId ? Number(phaseId) : null,
         labelIds: selectedLabels,
+        dueDate: dueDate || null,
       };
       const updated = await updateTask(Number(projectId), Number(taskId), req);
       setTask(updated);
@@ -176,6 +179,11 @@ export default function TaskDetailPage() {
                     ))
                     : 'None'
                 } />
+                <DetailRow label="Due Date" value={
+                  task.dueDate
+                    ? <>{formatDate(task.dueDate)}{deadlineLabel(task.dueDate) && <span className={`inline-block ml-2 px-2 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(task.dueDate)}`}>{deadlineLabel(task.dueDate)}</span>}</>
+                    : 'None'
+                } />
                 <DetailRow label="Sprint" value={task.sprintId ? `Sprint ${task.sprintId}` : 'Backlog'} />
                 <DetailRow label="Created" value={formatDate(task.createdAt)} />
                 <DetailRow label="Updated" value={formatDate(task.updatedAt)} />
@@ -229,6 +237,10 @@ export default function TaskDetailPage() {
                       </label>
                     ))}
                   </div>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Due Date</label>
+                  <input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
                 </div>
                 </>
                 )}

--- a/frontend/src/pages/project-detail/BoardTab.tsx
+++ b/frontend/src/pages/project-detail/BoardTab.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import type { TaskDto, TaskStatusDto } from '@/types';
 import { listProjectTasks, updateTask } from '@/api/tasks';
 import { listTaskStatuses } from '@/api/admin';
-import { priorityColor, statusColor } from '@/utils/format';
+import { priorityColor, statusColor, formatDate, deadlineBadge, deadlineLabel } from '@/utils/format';
 import { useAuthStore } from '@/stores/authStore';
 import Spinner from '@/components/common/Spinner';
 
@@ -137,6 +137,8 @@ export default function BoardTab({ projectId, projectKey, isExternal }: { projec
                     <span className="bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">{task.typeName}</span>
                     {task.phaseName && <span className="bg-blue-100 text-blue-700 px-1.5 py-0.5 rounded">{task.phaseName}</span>}
                     {task.assigneeName && <span>{task.assigneeName}</span>}
+                    {task.dueDate && <span className={deadlineBadge(task.dueDate) || 'text-gray-400'}>{formatDate(task.dueDate)}</span>}
+                    {task.dueDate && deadlineLabel(task.dueDate) && <span className={`px-1 py-0.5 rounded text-[10px] font-medium ${deadlineBadge(task.dueDate)}`}>{deadlineLabel(task.dueDate)}</span>}
                   </div>
                 </div>
               ))}

--- a/frontend/src/pages/project-detail/CreateTaskModal.tsx
+++ b/frontend/src/pages/project-detail/CreateTaskModal.tsx
@@ -16,6 +16,7 @@ export default function CreateTaskModal({ projectId, projectKey, onClose, isExte
   const [assigneeId, setAssigneeId] = useState('');
   const [phaseId, setPhaseId] = useState('');
   const [selectedLabels, setSelectedLabels] = useState<number[]>([]);
+  const [dueDate, setDueDate] = useState('');
   const [types, setTypes] = useState<TaskTypeDto[]>([]);
   const [members, setMembers] = useState<MemberDto[]>([]);
   const [labels, setLabels] = useState<LabelDto[]>([]);
@@ -47,6 +48,7 @@ export default function CreateTaskModal({ projectId, projectKey, onClose, isExte
         assigneeId: assigneeId ? Number(assigneeId) : undefined,
         phaseId: phaseId ? Number(phaseId) : undefined,
         labelIds: selectedLabels.length > 0 ? selectedLabels : undefined,
+        dueDate: dueDate || undefined,
         ...(isExternal ? { external: true } : {}),
       });
       onClose();
@@ -113,6 +115,10 @@ export default function CreateTaskModal({ projectId, projectKey, onClose, isExte
             </div>
           </div>
         )}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Due Date</label>
+          <input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+        </div>
         <div className="flex justify-end gap-3 pt-2">
           <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-100">Cancel</button>
           <button type="submit" disabled={saving} className="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50 flex items-center gap-2">

--- a/frontend/src/pages/project-detail/TasksTab.tsx
+++ b/frontend/src/pages/project-detail/TasksTab.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import type { TaskDto, TaskStatusDto } from '@/types';
 import { listProjectTasks } from '@/api/tasks';
 import { listTaskStatuses } from '@/api/admin';
-import { priorityColor, statusColor, formatDate } from '@/utils/format';
+import { priorityColor, statusColor, formatDate, deadlineBadge, deadlineLabel } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
 import CreateTaskModal from './CreateTaskModal';
 
@@ -76,6 +76,7 @@ export default function TasksTab({ projectId, projectKey, canEdit, isExternal }:
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Assignee</th>
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Type</th>
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Phase</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Due Date</th>
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Updated</th>
               </tr>
             </thead>
@@ -96,11 +97,19 @@ export default function TasksTab({ projectId, projectKey, canEdit, isExternal }:
                   <td className="px-4 py-3 text-gray-500">{task.assigneeName ?? 'Unassigned'}</td>
                   <td className="px-4 py-3 text-gray-500">{task.typeName}</td>
                   <td className="px-4 py-3">{task.phaseName ? <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">{task.phaseName}</span> : <span className="text-gray-400">--</span>}</td>
+                  <td className="px-4 py-3">
+                    {task.dueDate ? (
+                      <span className="flex items-center gap-1.5">
+                        <span className={deadlineBadge(task.dueDate) || 'text-gray-500'}>{formatDate(task.dueDate)}</span>
+                        {deadlineLabel(task.dueDate) && <span className={`inline-block px-1.5 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(task.dueDate)}`}>{deadlineLabel(task.dueDate)}</span>}
+                      </span>
+                    ) : <span className="text-gray-400">--</span>}
+                  </td>
                   <td className="px-4 py-3 text-gray-500">{formatDate(task.updatedAt)}</td>
                 </tr>
               ))}
               {tasks.length === 0 && (
-                <tr><td colSpan={8} className="px-4 py-8 text-center text-gray-500">No tasks found.</td></tr>
+                <tr><td colSpan={9} className="px-4 py-8 text-center text-gray-500">No tasks found.</td></tr>
               )}
             </tbody>
           </table>

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -26,6 +26,7 @@ export interface TaskDto {
   external: boolean;
   labelIds: number[];
   labelNames: string[];
+  dueDate: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -39,6 +40,7 @@ export interface CreateTaskRequest {
   phaseId?: number | null;
   labelIds?: number[];
   external?: boolean;
+  dueDate?: string | null;
 }
 
 export interface UpdateTaskRequest {
@@ -52,6 +54,7 @@ export interface UpdateTaskRequest {
   phaseId?: number | null;
   labelIds?: number[];
   external?: boolean;
+  dueDate?: string | null;
 }
 
 export interface CommentDto {


### PR DESCRIPTION
## Summary
Full-stack addition of a `dueDate` field to tasks, enabling deadline tracking and overdue indicators.

**Backend:**
- Added `dueDate` (LocalDate) column to `Task` entity
- Added to `TaskDto`, `CreateRequest`, `UpdateRequest` records
- Mapped with `dateFormat` in `TaskMapper`
- Handles parsing in `TaskService` create and update methods
- Updated external user `CreateRequest` override in `TaskController`

**Frontend:**
- Added `dueDate` to TypeScript types (`TaskDto`, `CreateTaskRequest`, `UpdateTaskRequest`)
- **CreateTaskModal**: added date picker for due date
- **TaskDetailPage**: shows due date in sidebar with overdue/due-soon badges; editable date picker in edit mode; included in save request
- **BoardTab**: task cards display due date with overdue indicators
- **TasksTab**: added "Due Date" column with overdue/due-soon badges

## Test plan
- [ ] Create a new task with a due date → verify it saves and displays
- [ ] Create a task without a due date → verify it shows "None"
- [ ] Edit a task and set/change/clear the due date → verify updates persist
- [ ] Set a past due date → verify "Overdue" badge appears in detail, board, and list views
- [ ] Set a due date within 2 weeks → verify "Due soon" badge appears
- [ ] Set a future due date → verify no badge, date shown in neutral color

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)