### PR TITLE
fix(#51): compute labor cost from all time logs without date filtering

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/PmoService.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoService.java
@@ -94,9 +94,7 @@ public class PmoService {
         BigDecimal earnedValue = completionPct.multiply(plannedValue).setScale(2, RoundingMode.HALF_UP);
 
         // Actual Cost (AC) = labor cost + project budget spent (external costs)
-        LocalDate projectStart = project.getTargetStartDate();
-        LocalDate projectEnd = project.getTargetEndDate();
-        BigDecimal laborCost = computeLaborCost(projectId, projectStart, projectEnd);
+        BigDecimal laborCost = computeLaborCost(projectId);
         BigDecimal budgetSpent = project.getBudgetSpent() != null ? project.getBudgetSpent() : BigDecimal.ZERO;
         BigDecimal actualCost = laborCost.add(budgetSpent).setScale(2, RoundingMode.HALF_UP);
 
@@ -152,14 +150,8 @@ public class PmoService {
         );
     }
 
-    private BigDecimal computeLaborCost(Long projectId, LocalDate startDate, LocalDate endDate) {
-        if (startDate == null || endDate == null) {
-            // If no date range, use all time logs for the project
-            List<TimeLog> logs = timeLogRepository.findByProjectIdAndDateRange(
-                    projectId, LocalDate.of(2000, 1, 1), LocalDate.now());
-            return sumLaborCost(logs);
-        }
-        List<TimeLog> logs = timeLogRepository.findByProjectIdAndDateRange(projectId, startDate, endDate);
+    private BigDecimal computeLaborCost(Long projectId) {
+        List<TimeLog> logs = timeLogRepository.findByProjectId(projectId);
         return sumLaborCost(logs);
     }
 
@@ -243,7 +235,7 @@ public class PmoService {
                     : BigDecimal.ZERO;
             totalEarnedValue = totalEarnedValue.add(projCompletion.multiply(projPv).setScale(2, RoundingMode.HALF_UP));
 
-            BigDecimal projLaborCost = computeLaborCost(project.getId(), project.getTargetStartDate(), project.getTargetEndDate());
+            BigDecimal projLaborCost = computeLaborCost(project.getId());
             BigDecimal projBudgetSpent = project.getBudgetSpent() != null ? project.getBudgetSpent() : BigDecimal.ZERO;
             totalActualCost = totalActualCost.add(projLaborCost.add(projBudgetSpent).setScale(2, RoundingMode.HALF_UP));
 

--- a/backend/src/main/java/com/nemo/timetracking/TimeLogRepository.java
+++ b/backend/src/main/java/com/nemo/timetracking/TimeLogRepository.java
@@ -26,6 +26,9 @@ public interface TimeLogRepository extends JpaRepository<TimeLog, Long> {
     @Query("SELECT tl FROM TimeLog tl WHERE tl.task.project.id = :projectId AND tl.logDate BETWEEN :startDate AND :endDate")
     List<TimeLog> findByProjectIdAndDateRange(Long projectId, LocalDate startDate, LocalDate endDate);
 
+    @Query("SELECT tl FROM TimeLog tl WHERE tl.task.project.id = :projectId")
+    List<TimeLog> findByProjectId(Long projectId);
+
     @Query("SELECT tl FROM TimeLog tl WHERE tl.user.id = :userId AND tl.logDate BETWEEN :startDate AND :endDate")
     List<TimeLog> findByUserIdAndDateRange(Long userId, LocalDate startDate, LocalDate endDate);
 


### PR DESCRIPTION
## Summary
- **Root cause**: `PmoService.computeLaborCost()` filtered time logs by the project's `targetStartDate`/`targetEndDate` range. Since time logs are often logged outside that date range (e.g., after a project deadline), the query returned zero logs, making labor cost always DH 0.00.
- **Fix**: Removed the date range filter from labor cost computation. Actual cost (AC) should reflect total labor spend for the project regardless of when hours were logged. Added `findByProjectId()` to `TimeLogRepository` for unfiltered queries, keeping the existing date-range method for other use cases.
- Removed unused `projectStart`/`projectEnd` variables from `computeEvm()`.

## Test plan
- [ ] Restart the app (re-seed) and navigate to any project with time entries (e.g., FSE)
- [ ] Verify that the "Labor Cost" KPI in the Highlights section shows a non-zero value
- [ ] Verify that AC (Actual Cost) now includes the labor cost component
- [ ] Verify that CPI and CV are computed correctly based on the new AC
- [ ] Check the PMO Dashboard and Portfolio Report for consistent values

Fixes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)