### PR TITLE
feat(#52): add leave entitlement balances and working-days calculation

### DIFF
--- a/backend/src/main/java/com/nemo/config/DataSeeder.java
+++ b/backend/src/main/java/com/nemo/config/DataSeeder.java
@@ -10,6 +10,10 @@ import com.nemo.documentation.WikiPage;
 import com.nemo.documentation.WikiPageRepository;
 import com.nemo.task.Task;
 import com.nemo.task.TaskRepository;
+import com.nemo.leave.LeaveEntitlement;
+import com.nemo.leave.LeaveEntitlementRepository;
+import com.nemo.leave.LeaveRequest;
+import com.nemo.leave.LeaveRequestRepository;
 import com.nemo.location.Location;
 import com.nemo.location.LocationRepository;
 import com.nemo.phase.Deliverable;
@@ -83,6 +87,8 @@ public class DataSeeder implements CommandLineRunner {
     private final LocationRepository locationRepository;
     private final AssetRepository assetRepository;
     private final ClientRepository clientRepository;
+    private final LeaveEntitlementRepository leaveEntitlementRepository;
+    private final LeaveRequestRepository leaveRequestRepository;
 
     public DataSeeder(UserRepository userRepository,
                       PasswordEncoder passwordEncoder,
@@ -107,7 +113,9 @@ public class DataSeeder implements CommandLineRunner {
                       WikiPageRepository wikiPageRepository,
                       LocationRepository locationRepository,
                       AssetRepository assetRepository,
-                      ClientRepository clientRepository) {
+                      ClientRepository clientRepository,
+                      LeaveEntitlementRepository leaveEntitlementRepository,
+                      LeaveRequestRepository leaveRequestRepository) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.companyRepository = companyRepository;
@@ -132,6 +140,8 @@ public class DataSeeder implements CommandLineRunner {
         this.locationRepository = locationRepository;
         this.assetRepository = assetRepository;
         this.clientRepository = clientRepository;
+        this.leaveEntitlementRepository = leaveEntitlementRepository;
+        this.leaveRequestRepository = leaveRequestRepository;
     }
 
     @Override
@@ -661,6 +671,37 @@ public class DataSeeder implements CommandLineRunner {
                 "TP-T14S-001", LocalDate.of(2024, 3, 1), new BigDecimal("1400"));
         createAsset("Coffee Machine Jura", Asset.Type.OTHER, Asset.Status.IN_STOCK, null, null, company1,
                 "BEV-JURA-001", LocalDate.of(2024, 5, 1), new BigDecimal("800"));
+
+        // Leave entitlements — default allocations for current year
+        int currentYear = today.getYear();
+        User[] allUsers = {admin, majid, dev1, dev2, dev3, dev4, pmHarmony, salim, basma, younes, youssef, walid, mehdi};
+        for (User u : allUsers) {
+            createLeaveEntitlement(u, LeaveRequest.Type.VACATION, currentYear, 20);
+            createLeaveEntitlement(u, LeaveRequest.Type.SICK, currentYear, 10);
+            createLeaveEntitlement(u, LeaveRequest.Type.PERSONAL, currentYear, 5);
+            createLeaveEntitlement(u, LeaveRequest.Type.UNPAID, currentYear, 0);
+        }
+
+        // Sample approved leave requests
+        LeaveRequest lr1 = new LeaveRequest();
+        lr1.setUser(admin); lr1.setType(LeaveRequest.Type.VACATION); lr1.setStartDate(LocalDate.of(currentYear, 1, 15)); lr1.setEndDate(LocalDate.of(currentYear, 1, 17)); lr1.setStatus(LeaveRequest.Status.APPROVED); lr1.setReason("Winter break"); lr1.setApprover(majid);
+        leaveRequestRepository.save(lr1);
+
+        LeaveRequest lr2 = new LeaveRequest();
+        lr2.setUser(dev1); lr2.setType(LeaveRequest.Type.SICK); lr2.setStartDate(LocalDate.of(currentYear, 5, 5)); lr2.setEndDate(LocalDate.of(currentYear, 5, 6)); lr2.setStatus(LeaveRequest.Status.APPROVED); lr2.setReason("Flu"); lr2.setApprover(majid);
+        leaveRequestRepository.save(lr2);
+
+        LeaveRequest lr3 = new LeaveRequest();
+        lr3.setUser(dev2); lr3.setType(LeaveRequest.Type.PERSONAL); lr3.setStartDate(LocalDate.of(currentYear, 2, 14)); lr3.setEndDate(LocalDate.of(currentYear, 2, 14)); lr3.setStatus(LeaveRequest.Status.APPROVED); lr3.setReason("Valentine's Day"); lr3.setApprover(majid);
+        leaveRequestRepository.save(lr3);
+
+        LeaveRequest lr4 = new LeaveRequest();
+        lr4.setUser(majid); lr4.setType(LeaveRequest.Type.VACATION); lr4.setStartDate(LocalDate.of(currentYear, 3, 3)); lr4.setEndDate(LocalDate.of(currentYear, 3, 7)); lr4.setStatus(LeaveRequest.Status.APPROVED); lr4.setReason("Family vacation"); lr4.setApprover(salim);
+        leaveRequestRepository.save(lr4);
+
+        LeaveRequest lr5 = new LeaveRequest();
+        lr5.setUser(youssef); lr5.setType(LeaveRequest.Type.VACATION); lr5.setStartDate(LocalDate.of(currentYear, 6, 16)); lr5.setEndDate(LocalDate.of(currentYear, 6, 20)); lr5.setStatus(LeaveRequest.Status.PENDING); lr5.setReason("Summer vacation");
+        leaveRequestRepository.save(lr5);
     }
 
     private User createUser(String username, String email, String firstName, String lastName, User.Role role, Company company) {
@@ -909,5 +950,14 @@ public class DataSeeder implements CommandLineRunner {
         asset.setPurchaseCost(purchaseCost);
         asset.setActive(true);
         return assetRepository.save(asset);
+    }
+
+    private LeaveEntitlement createLeaveEntitlement(User user, LeaveRequest.Type type, int year, int totalDays) {
+        LeaveEntitlement entitlement = new LeaveEntitlement();
+        entitlement.setUser(user);
+        entitlement.setType(type);
+        entitlement.setYear(year);
+        entitlement.setTotalDays(totalDays);
+        return leaveEntitlementRepository.save(entitlement);
     }
 }

--- a/backend/src/main/java/com/nemo/leave/LeaveBalanceDto.java
+++ b/backend/src/main/java/com/nemo/leave/LeaveBalanceDto.java
@@ -1,0 +1,11 @@
+package com.nemo.leave;
+
+public record LeaveBalanceDto(
+        Long userId,
+        String userName,
+        String type,
+        int year,
+        int totalAllocated,
+        int usedDays,
+        int remainingDays
+) {}

--- a/backend/src/main/java/com/nemo/leave/LeaveEntitlement.java
+++ b/backend/src/main/java/com/nemo/leave/LeaveEntitlement.java
@@ -1,0 +1,53 @@
+package com.nemo.leave;
+
+import com.nemo.user.User;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "leave_entitlement", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "type", "year"}))
+public class LeaveEntitlement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private LeaveRequest.Type type;
+
+    @Column(nullable = false)
+    private int year;
+
+    @Column(name = "total_days", nullable = false)
+    private int totalDays;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    public LeaveEntitlement() {}
+
+    public Long getId() { return id; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+    public LeaveRequest.Type getType() { return type; }
+    public void setType(LeaveRequest.Type type) { this.type = type; }
+    public int getYear() { return year; }
+    public void setYear(int year) { this.year = year; }
+    public int getTotalDays() { return totalDays; }
+    public void setTotalDays(int totalDays) { this.totalDays = totalDays; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getUpdatedAt() { return updatedAt; }
+}

--- a/backend/src/main/java/com/nemo/leave/LeaveEntitlementDto.java
+++ b/backend/src/main/java/com/nemo/leave/LeaveEntitlementDto.java
@@ -1,0 +1,26 @@
+package com.nemo.leave;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record LeaveEntitlementDto(
+        Long id,
+        Long userId,
+        String userName,
+        String type,
+        int year,
+        int totalDays,
+        String createdAt,
+        String updatedAt
+) {
+    public record CreateRequest(
+            @NotNull Long userId,
+            @NotNull LeaveRequest.Type type,
+            @NotNull Integer year,
+            @NotNull @Min(0) Integer totalDays
+    ) {}
+
+    public record UpdateRequest(
+            @Min(0) Integer totalDays
+    ) {}
+}

--- a/backend/src/main/java/com/nemo/leave/LeaveEntitlementMapper.java
+++ b/backend/src/main/java/com/nemo/leave/LeaveEntitlementMapper.java
@@ -1,0 +1,29 @@
+package com.nemo.leave;
+
+import com.nemo.user.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface LeaveEntitlementMapper {
+
+    @Mapping(target = "userId", source = "user.id")
+    @Mapping(target = "userName", source = "user")
+    @Mapping(target = "type", source = "type")
+    @Mapping(target = "createdAt", source = "createdAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss")
+    @Mapping(target = "updatedAt", source = "updatedAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss")
+    LeaveEntitlementDto toDto(LeaveEntitlement entity);
+
+    List<LeaveEntitlementDto> toDtoList(List<LeaveEntitlement> entities);
+
+    default String map(User user) {
+        if (user == null) return null;
+        return user.getFirstName() + " " + user.getLastName();
+    }
+
+    default String mapType(LeaveRequest.Type type) {
+        return type != null ? type.name() : null;
+    }
+}

--- a/backend/src/main/java/com/nemo/leave/LeaveEntitlementRepository.java
+++ b/backend/src/main/java/com/nemo/leave/LeaveEntitlementRepository.java
@@ -1,0 +1,17 @@
+package com.nemo.leave;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LeaveEntitlementRepository extends JpaRepository<LeaveEntitlement, Long> {
+
+    List<LeaveEntitlement> findByUserIdAndYear(Long userId, int year);
+
+    Optional<LeaveEntitlement> findByUserIdAndTypeAndYear(Long userId, LeaveRequest.Type type, int year);
+
+    List<LeaveEntitlement> findByUserId(Long userId);
+
+    List<LeaveEntitlement> findByYear(int year);
+}

--- a/backend/src/main/java/com/nemo/leave/LeaveEntitlementService.java
+++ b/backend/src/main/java/com/nemo/leave/LeaveEntitlementService.java
@@ -1,0 +1,163 @@
+package com.nemo.leave;
+
+import com.nemo.common.exception.BadRequestException;
+import com.nemo.common.exception.EntityNotFoundException;
+import com.nemo.config.PublicHoliday;
+import com.nemo.config.PublicHolidayRepository;
+import com.nemo.user.User;
+import com.nemo.user.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class LeaveEntitlementService {
+
+    private final LeaveEntitlementRepository entitlementRepository;
+    private final LeaveRequestRepository leaveRequestRepository;
+    private final PublicHolidayRepository publicHolidayRepository;
+    private final UserRepository userRepository;
+
+    public LeaveEntitlementService(LeaveEntitlementRepository entitlementRepository,
+                                   LeaveRequestRepository leaveRequestRepository,
+                                   PublicHolidayRepository publicHolidayRepository,
+                                   UserRepository userRepository) {
+        this.entitlementRepository = entitlementRepository;
+        this.leaveRequestRepository = leaveRequestRepository;
+        this.publicHolidayRepository = publicHolidayRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<LeaveBalanceDto> getBalances(Long userId, int year) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User", userId));
+
+        List<LeaveEntitlement> entitlements = entitlementRepository.findByUserIdAndYear(userId, year);
+        Long companyId = user.getCompany() != null ? user.getCompany().getId() : null;
+
+        List<LeaveBalanceDto> balances = new ArrayList<>();
+        for (LeaveRequest.Type type : LeaveRequest.Type.values()) {
+            int totalAllocated = entitlements.stream()
+                    .filter(e -> e.getType() == type)
+                    .mapToInt(LeaveEntitlement::getTotalDays)
+                    .findFirst()
+                    .orElse(0);
+            int usedDays = calculateUsedDays(userId, type, year);
+            int remainingDays = totalAllocated - usedDays;
+            balances.add(new LeaveBalanceDto(
+                    userId,
+                    user.getFirstName() + " " + user.getLastName(),
+                    type.name(),
+                    year,
+                    totalAllocated,
+                    usedDays,
+                    remainingDays
+            ));
+        }
+        return balances;
+    }
+
+    @Transactional(readOnly = true)
+    public int calculateUsedDays(Long userId, LeaveRequest.Type type, int year) {
+        LocalDate yearStart = LocalDate.of(year, 1, 1);
+        LocalDate yearEnd = LocalDate.of(year, 12, 31);
+
+        List<LeaveRequest> approved = leaveRequestRepository.findApprovedByUserAndTypeInYear(
+                userId, type, yearStart, yearEnd);
+
+        int totalDays = 0;
+        for (LeaveRequest lr : approved) {
+            LocalDate start = lr.getStartDate().isBefore(yearStart) ? yearStart : lr.getStartDate();
+            LocalDate end = lr.getEndDate().isAfter(yearEnd) ? yearEnd : lr.getEndDate();
+            totalDays += (int) ChronoUnit.DAYS.between(start, end) + 1;
+        }
+        return totalDays;
+    }
+
+    @Transactional(readOnly = true)
+    public WorkingDaysResult calculateWorkingDays(LocalDate startDate, LocalDate endDate, Long companyId) {
+        if (startDate.isAfter(endDate)) {
+            throw new BadRequestException("Start date must be before or equal to end date");
+        }
+
+        int calendarDays = (int) ChronoUnit.DAYS.between(startDate, endDate) + 1;
+        int workingDays = 0;
+        Set<LocalDate> holidays = Set.of();
+
+        if (companyId != null) {
+            List<PublicHoliday> holidaysList = publicHolidayRepository
+                    .findByDateBetweenAndCompanyOrGlobal(startDate, endDate, companyId);
+            holidays = holidaysList.stream()
+                    .map(PublicHoliday::getDate)
+                    .collect(Collectors.toSet());
+        } else {
+            List<PublicHoliday> holidaysList = publicHolidayRepository
+                    .findGlobalByDateBetween(startDate, endDate);
+            holidays = holidaysList.stream()
+                    .map(PublicHoliday::getDate)
+                    .collect(Collectors.toSet());
+        }
+
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            DayOfWeek dow = date.getDayOfWeek();
+            if (dow != DayOfWeek.SATURDAY && dow != DayOfWeek.SUNDAY && !holidays.contains(date)) {
+                workingDays++;
+            }
+        }
+
+        return new WorkingDaysResult(workingDays, calendarDays);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LeaveEntitlement> listEntitlements(Long userId, Integer year) {
+        if (userId != null && year != null) {
+            return entitlementRepository.findByUserIdAndYear(userId, year);
+        }
+        if (userId != null) {
+            return entitlementRepository.findByUserId(userId);
+        }
+        if (year != null) {
+            return entitlementRepository.findByYear(year);
+        }
+        return entitlementRepository.findAll();
+    }
+
+    @Transactional
+    public LeaveEntitlement create(LeaveEntitlementDto.CreateRequest request) {
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(() -> new EntityNotFoundException("User", request.userId()));
+
+        entitlementRepository.findByUserIdAndTypeAndYear(request.userId(), request.type(), request.year())
+                .ifPresent(existing -> {
+                    throw new BadRequestException("Entitlement already exists for this user/type/year");
+                });
+
+        LeaveEntitlement entitlement = new LeaveEntitlement();
+        entitlement.setUser(user);
+        entitlement.setType(request.type());
+        entitlement.setYear(request.year());
+        entitlement.setTotalDays(request.totalDays());
+        return entitlementRepository.save(entitlement);
+    }
+
+    @Transactional
+    public LeaveEntitlement update(Long id, LeaveEntitlementDto.UpdateRequest request) {
+        LeaveEntitlement entitlement = entitlementRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("LeaveEntitlement", id));
+
+        if (request.totalDays() != null) {
+            entitlement.setTotalDays(request.totalDays());
+        }
+        return entitlementRepository.save(entitlement);
+    }
+
+    public record WorkingDaysResult(int workingDays, int calendarDays) {}
+}

--- a/backend/src/main/java/com/nemo/leave/LeaveRequestController.java
+++ b/backend/src/main/java/com/nemo/leave/LeaveRequestController.java
@@ -5,6 +5,7 @@ import com.nemo.common.exception.ForbiddenException;
 import com.nemo.security.AuthHelper;
 import com.nemo.user.User;
 import com.nemo.user.UserRepository;
+import jakarta.validation.Valid;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,12 +23,18 @@ public class LeaveRequestController {
 
     private final LeaveRequestService leaveRequestService;
     private final LeaveRequestMapper leaveRequestMapper;
+    private final LeaveEntitlementService entitlementService;
+    private final LeaveEntitlementMapper entitlementMapper;
     private final AuthHelper authHelper;
     private final UserRepository userRepository;
 
-    public LeaveRequestController(LeaveRequestService leaveRequestService, LeaveRequestMapper leaveRequestMapper, AuthHelper authHelper, UserRepository userRepository) {
+    public LeaveRequestController(LeaveRequestService leaveRequestService, LeaveRequestMapper leaveRequestMapper,
+                                   LeaveEntitlementService entitlementService, LeaveEntitlementMapper entitlementMapper,
+                                   AuthHelper authHelper, UserRepository userRepository) {
         this.leaveRequestService = leaveRequestService;
         this.leaveRequestMapper = leaveRequestMapper;
+        this.entitlementService = entitlementService;
+        this.entitlementMapper = entitlementMapper;
         this.authHelper = authHelper;
         this.userRepository = userRepository;
     }
@@ -158,6 +165,71 @@ public class LeaveRequestController {
         leaveRequestService.cancel(id, userId);
         LeaveRequest lr = leaveRequestService.getById(id);
         return ResponseEntity.ok(ApiResponse.of(leaveRequestMapper.toDto(lr)));
+    }
+
+    // --- Balance endpoints ---
+
+    @GetMapping("/balances")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<List<LeaveBalanceDto>>> getBalances(
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) Integer year,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long currentUserId = authHelper.getCurrentUserId(currentUser);
+        boolean canSeeAll = authHelper.hasAnyRole(currentUser, "ADMIN", "MANAGER", "EXECUTIVE", "HR");
+
+        Long targetUserId = userId != null ? userId : currentUserId;
+        if (!canSeeAll && !targetUserId.equals(currentUserId)) {
+            throw new ForbiddenException("You can only view your own leave balances");
+        }
+
+        int targetYear = year != null ? year : LocalDate.now().getYear();
+        List<LeaveBalanceDto> balances = entitlementService.getBalances(targetUserId, targetYear);
+        return ResponseEntity.ok(ApiResponse.of(balances));
+    }
+
+    @GetMapping("/working-days")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<LeaveEntitlementService.WorkingDaysResult>> getWorkingDays(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(required = false) Long companyId,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        if (companyId == null) {
+            Long currentUserId = authHelper.getCurrentUserId(currentUser);
+            User user = userRepository.findById(currentUserId).orElse(null);
+            companyId = user != null && user.getCompany() != null ? user.getCompany().getId() : null;
+        }
+        LeaveEntitlementService.WorkingDaysResult result = entitlementService.calculateWorkingDays(startDate, endDate, companyId);
+        return ResponseEntity.ok(ApiResponse.of(result));
+    }
+
+    // --- Entitlement management endpoints (HR only) ---
+
+    @GetMapping("/entitlements")
+    @PreAuthorize("hasRole('HR')")
+    public ResponseEntity<ApiResponse<List<LeaveEntitlementDto>>> listEntitlements(
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) Integer year) {
+        List<LeaveEntitlement> entitlements = entitlementService.listEntitlements(userId, year);
+        return ResponseEntity.ok(ApiResponse.of(entitlementMapper.toDtoList(entitlements)));
+    }
+
+    @PostMapping("/entitlements")
+    @PreAuthorize("hasRole('HR')")
+    public ResponseEntity<ApiResponse<LeaveEntitlementDto>> createEntitlement(
+            @Valid @RequestBody LeaveEntitlementDto.CreateRequest request) {
+        LeaveEntitlement created = entitlementService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(entitlementMapper.toDto(created)));
+    }
+
+    @PutMapping("/entitlements/{id}")
+    @PreAuthorize("hasRole('HR')")
+    public ResponseEntity<ApiResponse<LeaveEntitlementDto>> updateEntitlement(
+            @PathVariable Long id,
+            @Valid @RequestBody LeaveEntitlementDto.UpdateRequest request) {
+        LeaveEntitlement updated = entitlementService.update(id, request);
+        return ResponseEntity.ok(ApiResponse.of(entitlementMapper.toDto(updated)));
     }
 
     private void checkCompanyAccess(Long leaveRequestId, UserDetails currentUser) {

--- a/backend/src/main/java/com/nemo/leave/LeaveRequestRepository.java
+++ b/backend/src/main/java/com/nemo/leave/LeaveRequestRepository.java
@@ -2,6 +2,7 @@ package com.nemo.leave;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -30,4 +31,7 @@ public interface LeaveRequestRepository extends JpaRepository<LeaveRequest, Long
     List<LeaveRequest> findByCompanyIdAndStatus(Long companyId, LeaveRequest.Status status);
 
     long countByUserIdAndTypeAndStatus(Long userId, LeaveRequest.Type type, LeaveRequest.Status status);
+
+    @Query("SELECT lr FROM LeaveRequest lr WHERE lr.user.id = :userId AND lr.type = :type AND lr.status = 'APPROVED' AND lr.startDate <= :yearEnd AND lr.endDate >= :yearStart")
+    List<LeaveRequest> findApprovedByUserAndTypeInYear(@Param("userId") Long userId, @Param("type") LeaveRequest.Type type, @Param("yearStart") LocalDate yearStart, @Param("yearEnd") LocalDate yearEnd);
 }

--- a/frontend/src/api/leave.ts
+++ b/frontend/src/api/leave.ts
@@ -1,5 +1,5 @@
 import { apiGet, apiPost, apiPut } from './client';
-import type { LeaveRequestDto, CreateLeaveRequest, LeaveActionRequest } from '@/types';
+import type { LeaveRequestDto, CreateLeaveRequest, LeaveActionRequest, LeaveBalanceDto, LeaveEntitlementDto, CreateLeaveEntitlementRequest, UpdateLeaveEntitlementRequest, WorkingDaysResponse } from '@/types';
 
 export async function listLeaveRequests(params?: Record<string, string | number>): Promise<LeaveRequestDto[]> {
   return apiGet('/leave-requests', params);
@@ -33,4 +33,26 @@ export async function rejectLeaveRequest(id: number, comment?: string): Promise<
 
 export async function cancelLeaveRequest(id: number): Promise<LeaveRequestDto> {
   return apiPut(`/leave-requests/${id}/cancel`);
+}
+
+export async function getLeaveBalances(params?: Record<string, string | number>): Promise<LeaveBalanceDto[]> {
+  return apiGet('/leave-requests/balances', params);
+}
+
+export async function calculateWorkingDays(startDate: string, endDate: string, companyId?: number): Promise<WorkingDaysResponse> {
+  const params: Record<string, string | number> = { startDate, endDate };
+  if (companyId != null) params.companyId = companyId;
+  return apiGet('/leave-requests/working-days', params);
+}
+
+export async function listEntitlements(params?: Record<string, string | number>): Promise<LeaveEntitlementDto[]> {
+  return apiGet('/leave-requests/entitlements', params);
+}
+
+export async function createEntitlement(request: CreateLeaveEntitlementRequest): Promise<LeaveEntitlementDto> {
+  return apiPost('/leave-requests/entitlements', request);
+}
+
+export async function updateEntitlement(id: number, request: UpdateLeaveEntitlementRequest): Promise<LeaveEntitlementDto> {
+  return apiPut(`/leave-requests/entitlements/${id}`, request);
 }

--- a/frontend/src/pages/LeavePage.tsx
+++ b/frontend/src/pages/LeavePage.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useAuthStore } from '@/stores/authStore';
-import { listLeaveRequests, listPendingLeaveRequests, createLeaveRequest, approveLeaveRequest, rejectLeaveRequest, cancelLeaveRequest } from '@/api/leave';
-import type { LeaveRequestDto, LeaveType, LeaveStatus, CreateLeaveRequest } from '@/types';
+import { listLeaveRequests, listPendingLeaveRequests, createLeaveRequest, approveLeaveRequest, rejectLeaveRequest, cancelLeaveRequest, getLeaveBalances, calculateWorkingDays } from '@/api/leave';
+import type { LeaveRequestDto, LeaveType, LeaveStatus, CreateLeaveRequest, LeaveBalanceDto } from '@/types';
 import Modal from '@/components/common/Modal';
 import Field from '@/components/common/Field';
 import Spinner from '@/components/common/Spinner';
@@ -11,6 +11,13 @@ const leaveTypeLabels: Record<LeaveType, string> = {
   SICK: 'Sick Leave',
   PERSONAL: 'Personal',
   UNPAID: 'Unpaid Leave',
+};
+
+const leaveTypeColors: Record<LeaveType, string> = {
+  VACATION: 'bg-blue-100 text-blue-700 border-blue-200',
+  SICK: 'bg-orange-100 text-orange-700 border-orange-200',
+  PERSONAL: 'bg-purple-100 text-purple-700 border-purple-200',
+  UNPAID: 'bg-gray-100 text-gray-700 border-gray-200',
 };
 
 const statusColors: Record<LeaveStatus, string> = {
@@ -26,6 +33,7 @@ export default function LeavePage() {
 
   const [requests, setRequests] = useState<LeaveRequestDto[]>([]);
   const [pendingRequests, setPendingRequests] = useState<LeaveRequestDto[]>([]);
+  const [balances, setBalances] = useState<LeaveBalanceDto[]>([]);
   const [loading, setLoading] = useState(true);
   const [tab, setTab] = useState<'all' | 'pending'>('all');
   const [filterStatus, setFilterStatus] = useState<string>('');
@@ -35,24 +43,26 @@ export default function LeavePage() {
   const [actionComment, setActionComment] = useState('');
   const [actionType, setActionType] = useState<'approve' | 'reject' | null>(null);
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     setLoading(true);
     try {
       const params: Record<string, string | number> = {};
       if (filterStatus) params.status = filterStatus;
       if (filterType) params.type = filterType;
-      const [all, pending] = await Promise.all([
+      const [all, pending, bals] = await Promise.all([
         listLeaveRequests(params),
         canApprove ? listPendingLeaveRequests() : Promise.resolve([]),
+        getLeaveBalances(),
       ]);
       setRequests(all);
       setPendingRequests(pending);
+      setBalances(bals);
     } catch { /* ignore */ } finally {
       setLoading(false);
     }
-  };
+  }, [filterStatus, filterType, canApprove]);
 
-  useEffect(() => { fetchData(); }, [filterStatus, filterType]);
+  useEffect(() => { fetchData(); }, [fetchData]);
 
   const handleAction = async () => {
     if (!actionId || !actionType) return;
@@ -93,6 +103,22 @@ export default function LeavePage() {
           Request Leave
         </button>
       </div>
+
+      {/* Balance cards */}
+      {balances.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {balances.map((b) => (
+            <div key={b.type} className={`rounded-lg border p-3 ${leaveTypeColors[b.type] || 'bg-gray-100 text-gray-700 border-gray-200'}`}>
+              <div className="text-xs font-semibold uppercase tracking-wide opacity-75">{leaveTypeLabels[b.type] || b.type}</div>
+              <div className="mt-1 flex items-baseline gap-2">
+                <span className="text-lg font-bold">{b.remainingDays}</span>
+                <span className="text-xs opacity-75">remaining</span>
+              </div>
+              <div className="text-xs mt-0.5 opacity-75">{b.usedDays} used / {b.totalAllocated} allocated</div>
+            </div>
+          ))}
+        </div>
+      )}
 
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex border border-gray-200 rounded-lg overflow-hidden">
@@ -178,7 +204,7 @@ export default function LeavePage() {
         </div>
       )}
 
-      {showCreate && <CreateLeaveModal onClose={() => { setShowCreate(false); fetchData(); }} />}
+      {showCreate && <CreateLeaveModal balances={balances} onClose={() => { setShowCreate(false); fetchData(); }} />}
 
       {actionId && actionType && (
         <Modal title={actionType === 'approve' ? 'Approve Leave' : 'Reject Leave'} onClose={() => { setActionId(null); setActionType(null); }}>
@@ -197,13 +223,26 @@ export default function LeavePage() {
   );
 }
 
-function CreateLeaveModal({ onClose }: { onClose: () => void }) {
+function CreateLeaveModal({ balances, onClose }: { balances: LeaveBalanceDto[]; onClose: () => void }) {
   const [type, setType] = useState<LeaveType>('VACATION');
   const [startDate, setStartDate] = useState(() => new Date().toISOString().slice(0, 10));
   const [endDate, setEndDate] = useState(() => new Date().toISOString().slice(0, 10));
   const [reason, setReason] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [workingDays, setWorkingDays] = useState<number | null>(null);
+
+  const selectedBalance = balances.find(b => b.type === type);
+
+  useEffect(() => {
+    if (startDate && endDate && startDate <= endDate) {
+      calculateWorkingDays(startDate, endDate)
+        .then(res => setWorkingDays(res.workingDays))
+        .catch(() => setWorkingDays(null));
+    } else {
+      setWorkingDays(null);
+    }
+  }, [startDate, endDate]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -232,11 +271,26 @@ function CreateLeaveModal({ onClose }: { onClose: () => void }) {
             <option value="PERSONAL">Personal</option>
             <option value="UNPAID">Unpaid Leave</option>
           </select>
+          {selectedBalance && (
+            <p className={`mt-1 text-sm font-medium ${selectedBalance.remainingDays > 0 ? 'text-green-600' : 'text-red-600'}`}>
+              Remaining: {selectedBalance.remainingDays} days (of {selectedBalance.totalAllocated} allocated)
+            </p>
+          )}
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <Field label="Start Date" type="date" value={startDate} onChange={setStartDate} required />
           <Field label="End Date" type="date" value={endDate} onChange={setEndDate} required />
         </div>
+        {workingDays != null && (
+          <div className="text-sm text-gray-600">
+            Working days: <span className="font-semibold">{workingDays}</span> (excluding weekends &amp; holidays)
+          </div>
+        )}
+        {workingDays != null && selectedBalance && workingDays > selectedBalance.remainingDays && selectedBalance.totalAllocated > 0 && (
+          <div className="bg-amber-50 border border-amber-200 text-amber-700 text-sm rounded-lg px-3 py-2">
+            Warning: this request exceeds your remaining balance ({selectedBalance.remainingDays} days remaining).
+          </div>
+        )}
         <Field label="Reason (optional)" value={reason} onChange={setReason} />
         <div className="flex justify-end gap-3 pt-2">
           <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-100">Cancel</button>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,7 +12,7 @@ export type { RaidItemDto, CreateRaidItemRequest, UpdateRaidItemRequest, EvmMetr
 export type { PhaseDto, CreatePhaseRequest, UpdatePhaseRequest, PhasePaymentDto, CreatePhasePaymentRequest, UpdatePhasePaymentRequest, DeliverableDto, DeliverableAttachmentDto, CreateDeliverableRequest, UpdateDeliverableRequest } from './phase';
 export type { TaskTypeDto, TaskStatusDto, TaskStatusCategory, AuditLogDto, ActivityLogDto, OrganizationUpdateRequest, CreateUserRequest, AdminUpdateUserRequest, CreateTaskTypeRequest, CreateTaskStatusRequest } from './admin';
 export type { HolidayDto, CreateHolidayRequest, UpdateHolidayRequest } from './holiday';
-export type { LeaveRequestDto, LeaveType, LeaveStatus, CreateLeaveRequest, LeaveActionRequest } from './leave';
+export type { LeaveRequestDto, LeaveType, LeaveStatus, CreateLeaveRequest, LeaveActionRequest, LeaveBalanceDto, LeaveEntitlementDto, CreateLeaveEntitlementRequest, UpdateLeaveEntitlementRequest, WorkingDaysResponse } from './leave';
 export type { LocationDto, AssetDto, AssetType, AssetStatus, CreateLocationRequest, UpdateLocationRequest, CreateAssetRequest, UpdateAssetRequest, AssignAssetRequest } from './asset';
 export type { ClientDto, ClientContactDto, CreateClientRequest, UpdateClientRequest, CreateClientContactRequest, UpdateClientContactRequest } from './client';
 export type { PreSaleDto, PreSaleStage, CreatePreSaleRequest, UpdatePreSaleRequest, ConvertPreSaleRequest, CostSummaryDto, UserCostEntry } from './presale';

--- a/frontend/src/types/leave.ts
+++ b/frontend/src/types/leave.ts
@@ -27,3 +27,40 @@ export interface CreateLeaveRequest {
 export interface LeaveActionRequest {
   comment?: string;
 }
+
+export interface LeaveBalanceDto {
+  userId: number;
+  userName: string;
+  type: LeaveType;
+  year: number;
+  totalAllocated: number;
+  usedDays: number;
+  remainingDays: number;
+}
+
+export interface LeaveEntitlementDto {
+  id: number;
+  userId: number;
+  userName: string;
+  type: LeaveType;
+  year: number;
+  totalDays: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateLeaveEntitlementRequest {
+  userId: number;
+  type: LeaveType;
+  year: number;
+  totalDays: number;
+}
+
+export interface UpdateLeaveEntitlementRequest {
+  totalDays: number;
+}
+
+export interface WorkingDaysResponse {
+  workingDays: number;
+  calendarDays: number;
+}


### PR DESCRIPTION
## Summary
- **Backend**: Added `LeaveEntitlement` entity (per-user/type/year allocation), `LeaveBalanceDto` with computed used/remaining days, `LeaveEntitlementService` with balance calculation and working-days computation (excludes weekends + public holidays), and HR-only CRUD endpoints for entitlement management
- **Backend**: Extended `LeaveRequestController` with `GET /balances`, `GET /working-days`, and `GET/POST/PUT /entitlements` endpoints
- **Backend**: Added `findApprovedByUserAndTypeInYear` query to `LeaveRequestRepository` for efficient used-days calculation
- **Backend**: Seeded default entitlements (20 vacation, 10 sick, 5 personal, 0 unpaid) per user plus sample approved leave requests
- **Frontend**: Added balance cards above the Leave table showing Allocated / Used / Remaining per leave type with color-coded styling
- **Frontend**: Enhanced Request Leave modal to show remaining balance for the selected type and auto-calculate working days between dates

## Test plan
- [ ] Restart the app (re-seed) and navigate to /leave
- [ ] Verify balance cards show correct allocated/used/remaining for each leave type
- [ ] Click "Request Leave" — verify remaining balance displays for the selected type
- [ ] Set start and end dates — verify working days calculation appears
- [ ] Submit a leave request — verify balances update after approval
- [ ] Verify HR users can access /entitlements endpoints; non-HR users cannot

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)