### PR TITLE
feat: add user capacity and project allocation

### DIFF
--- a/backend/src/main/java/com/nemo/config/DataSeeder.java
+++ b/backend/src/main/java/com/nemo/config/DataSeeder.java
@@ -298,29 +298,30 @@ public class DataSeeder implements CommandLineRunner {
                 LocalDate.of(2025, 3, 1), LocalDate.of(2025, 11, 30), company3);
         footballTeam.setClient(frmf); footballTeam = projectRepository.save(footballTeam);
 
-        // Add members
-        addMember(fse, majid);
-        addMember(fse, dev1);
-        addMember(fse, dev2);
-        addMember(apiGateway, dev1);
-        addMember(apiGateway, majid);
-        addMember(mobileApp, dev3);
-        addMember(mobileApp, dev4);
-        addMember(mobileApp, pmHarmony);
-        addMember(infraUpgrade, dev1);
-        addMember(infraUpgrade, dev3);
-        addMember(infraUpgrade, salim);
-        addMember(eHealthPortal, dev2);
-        addMember(eHealthPortal, majid);
-        addMember(mobilePay, dev3);
-        addMember(mobilePay, dev4);
-        addMember(mobilePay, pmHarmony);
-        addMember(dataWarehouse, dev1);
-        addMember(dataWarehouse, salim);
-        addMember(erpProject, younes);
-        addMember(footballTeam, youssef);
-        addMember(footballTeam, walid);
-        addMember(footballTeam, dev1);
+        // Add members with allocations
+        // majid: fse 40%, apiGateway 40%, eHealthPortal 20%
+        addMember(fse, majid, 40);
+        addMember(fse, dev1, 30);
+        addMember(fse, dev2, 60);
+        addMember(apiGateway, dev1, 25);
+        addMember(apiGateway, majid, 40);
+        addMember(mobileApp, dev3, 40);
+        addMember(mobileApp, dev4, 60);
+        addMember(mobileApp, pmHarmony, 60);
+        addMember(infraUpgrade, dev1, 20);
+        addMember(infraUpgrade, dev3, 30);
+        addMember(infraUpgrade, salim, 60);
+        addMember(eHealthPortal, dev2, 40);
+        addMember(eHealthPortal, majid, 20);
+        addMember(mobilePay, dev3, 30);
+        addMember(mobilePay, dev4, 40);
+        addMember(mobilePay, pmHarmony, 40);
+        addMember(dataWarehouse, dev1, 15);
+        addMember(dataWarehouse, salim, 40);
+        addMember(erpProject, younes, 100);
+        addMember(footballTeam, youssef, 100);
+        addMember(footballTeam, walid, 100);
+        addMember(footballTeam, dev1, 10);
 
         // External user assigned to FSE
         basma.setAssignedProject(fse);
@@ -799,6 +800,12 @@ public class DataSeeder implements CommandLineRunner {
 
     private void addMember(Project project, User user) {
         projectMemberRepository.save(new ProjectMember(project, user));
+    }
+
+    private void addMember(Project project, User user, int allocation) {
+        ProjectMember pm = new ProjectMember(project, user);
+        pm.setAllocation(allocation);
+        projectMemberRepository.save(pm);
     }
 
     private void addFavorite(User user, Project project) {

--- a/backend/src/main/java/com/nemo/project/ProjectController.java
+++ b/backend/src/main/java/com/nemo/project/ProjectController.java
@@ -151,7 +151,7 @@ public class ProjectController {
                 .anyMatch(a -> Set.of("ROLE_ADMIN", "ROLE_MANAGER", "ROLE_EXECUTIVE", "ROLE_HR").contains(a.getAuthority()));
         if (!canSeeScores) {
             members = members.stream()
-                    .map(m -> new ProjectDto.MemberDto(m.id(), m.userId(), m.username(), m.fullName(), null))
+                    .map(m -> new ProjectDto.MemberDto(m.id(), m.userId(), m.username(), m.fullName(), null, m.allocation()))
                     .toList();
         }
         return ResponseEntity.ok(ApiResponse.of(members));
@@ -177,6 +177,15 @@ public class ProjectController {
             @PathVariable Long id, @PathVariable Long userId,
             @RequestBody @Valid ProjectDto.ScoreRequest request) {
         ProjectMember pm = projectService.updateMemberScore(id, userId, request.score());
+        return ResponseEntity.ok(ApiResponse.of(projectMapper.toMemberDto(pm)));
+    }
+
+    @PutMapping("/{id}/members/{userId}/allocation")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    public ResponseEntity<ApiResponse<ProjectDto.MemberDto>> updateMemberAllocation(
+            @PathVariable Long id, @PathVariable Long userId,
+            @RequestBody @Valid ProjectDto.AllocationRequest request) {
+        ProjectMember pm = projectService.updateMemberAllocation(id, userId, request.allocation());
         return ResponseEntity.ok(ApiResponse.of(projectMapper.toMemberDto(pm)));
     }
 

--- a/backend/src/main/java/com/nemo/project/ProjectDto.java
+++ b/backend/src/main/java/com/nemo/project/ProjectDto.java
@@ -53,9 +53,11 @@ public record ProjectDto(
 
     public record LabelCreateRequest(@NotBlank String name, @NotBlank String color) {}
 
-    public record MemberDto(Long id, Long userId, String username, String fullName, Integer score) {}
+    public record MemberDto(Long id, Long userId, String username, String fullName, Integer score, int allocation) {}
 
     public record ScoreRequest(@NotNull Integer score) {}
+
+    public record AllocationRequest(@NotNull Integer allocation) {}
 
     public record InstructionDto(Long id, Long projectId, Long authorId, String authorName,
             String content, boolean important,

--- a/backend/src/main/java/com/nemo/project/ProjectMapper.java
+++ b/backend/src/main/java/com/nemo/project/ProjectMapper.java
@@ -34,5 +34,6 @@ public interface ProjectMapper {
     @Mapping(target = "username", source = "user.username")
     @Mapping(target = "fullName", expression = "java(pm.getUser().getFirstName() + ' ' + pm.getUser().getLastName())")
     @Mapping(target = "score", source = "score")
+    @Mapping(target = "allocation", source = "allocation")
     ProjectDto.MemberDto toMemberDto(ProjectMember pm);
 }

--- a/backend/src/main/java/com/nemo/project/ProjectMember.java
+++ b/backend/src/main/java/com/nemo/project/ProjectMember.java
@@ -25,6 +25,9 @@ public class ProjectMember {
     @Column(name = "score")
     private Integer score;
 
+    @Column(nullable = false)
+    private int allocation = 100;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -41,5 +44,7 @@ public class ProjectMember {
     public User getUser() { return user; }
     public Integer getScore() { return score; }
     public void setScore(Integer score) { this.score = score; }
+    public int getAllocation() { return allocation; }
+    public void setAllocation(int allocation) { this.allocation = allocation; }
     public Instant getCreatedAt() { return createdAt; }
 }

--- a/backend/src/main/java/com/nemo/project/ProjectService.java
+++ b/backend/src/main/java/com/nemo/project/ProjectService.java
@@ -251,6 +251,20 @@ public class ProjectService {
         return memberRepository.existsByProjectIdAndUserId(projectId, userId);
     }
 
+    @Transactional
+    public ProjectMember updateMemberAllocation(Long projectId, Long userId, Integer allocation) {
+        if (allocation == null || allocation < 1 || allocation > 100) {
+            throw new BadRequestException("Allocation must be between 1 and 100");
+        }
+        List<ProjectMember> members = memberRepository.findByProjectId(projectId);
+        ProjectMember pm = members.stream()
+                .filter(m -> m.getUser().getId().equals(userId))
+                .findFirst()
+                .orElseThrow(() -> new EntityNotFoundException("ProjectMember", userId));
+        pm.setAllocation(allocation);
+        return memberRepository.save(pm);
+    }
+
     // Labels
     @Transactional(readOnly = true)
     public List<Label> getLabels(Long projectId) {

--- a/backend/src/main/java/com/nemo/user/AllocationSummaryDto.java
+++ b/backend/src/main/java/com/nemo/user/AllocationSummaryDto.java
@@ -1,0 +1,11 @@
+package com.nemo.user;
+
+import java.util.List;
+
+public record AllocationSummaryDto(
+        Long userId,
+        int totalAllocation,
+        List<ProjectAllocation> projects
+) {
+    public record ProjectAllocation(Long projectId, String projectName, int allocation) {}
+}

--- a/backend/src/main/java/com/nemo/user/User.java
+++ b/backend/src/main/java/com/nemo/user/User.java
@@ -64,6 +64,9 @@ public class User {
     @Column(name = "hire_date")
     private LocalDate hireDate;
 
+    @Column(name = "weekly_capacity", nullable = false)
+    private int weeklyCapacity = 40;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -105,4 +108,6 @@ public class User {
     public void setHireDate(LocalDate hireDate) { this.hireDate = hireDate; }
     public Instant getCreatedAt() { return createdAt; }
     public Instant getUpdatedAt() { return updatedAt; }
+    public int getWeeklyCapacity() { return weeklyCapacity; }
+    public void setWeeklyCapacity(int weeklyCapacity) { this.weeklyCapacity = weeklyCapacity; }
 }

--- a/backend/src/main/java/com/nemo/user/UserController.java
+++ b/backend/src/main/java/com/nemo/user/UserController.java
@@ -92,4 +92,20 @@ public class UserController {
         userService.deactivate(id);
         return ResponseEntity.noContent().build();
     }
+
+    @PutMapping("/{id}/capacity")
+    @PreAuthorize("hasAnyRole('HR', 'EXECUTIVE')")
+    public ResponseEntity<ApiResponse<UserDto>> updateCapacity(
+            @PathVariable Long id, @RequestBody CapacityRequest request) {
+        User updated = userService.updateCapacity(id, request.weeklyCapacity());
+        return ResponseEntity.ok(ApiResponse.of(userMapper.toDto(updated)));
+    }
+
+    @GetMapping("/{id}/allocation-summary")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
+    public ResponseEntity<ApiResponse<AllocationSummaryDto>> getAllocationSummary(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.of(userService.getAllocationSummary(id)));
+    }
+
+    public record CapacityRequest(int weeklyCapacity) {}
 }

--- a/backend/src/main/java/com/nemo/user/UserDto.java
+++ b/backend/src/main/java/com/nemo/user/UserDto.java
@@ -21,6 +21,7 @@ public record UserDto(
         String department,
         String phone,
         String hireDate,
+        int weeklyCapacity,
         String createdAt,
         String updatedAt
 ) {

--- a/backend/src/main/java/com/nemo/user/UserMapper.java
+++ b/backend/src/main/java/com/nemo/user/UserMapper.java
@@ -27,5 +27,6 @@ public interface UserMapper {
     @Mapping(target = "avatarUrl", ignore = true)
     @Mapping(target = "company", ignore = true)
     @Mapping(target = "assignedProject", ignore = true)
+    @Mapping(target = "weeklyCapacity", ignore = true)
     User toEntity(UserDto.CreateRequest request);
 }

--- a/backend/src/main/java/com/nemo/user/UserService.java
+++ b/backend/src/main/java/com/nemo/user/UserService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 public class UserService {
@@ -176,5 +177,29 @@ public class UserService {
         User user = getById(id);
         user.setActive(false);
         userRepository.save(user);
+    }
+
+    @Transactional
+    public User updateCapacity(Long id, int weeklyCapacity) {
+        if (weeklyCapacity < 1 || weeklyCapacity > 168) {
+            throw new BadRequestException("Weekly capacity must be between 1 and 168 hours");
+        }
+        User user = getById(id);
+        user.setWeeklyCapacity(weeklyCapacity);
+        return userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public AllocationSummaryDto getAllocationSummary(Long userId) {
+        User user = getById(userId);
+        List<ProjectMember> memberships = projectMemberRepository.findByUserId(userId);
+        List<AllocationSummaryDto.ProjectAllocation> projects = memberships.stream()
+                .map(pm -> new AllocationSummaryDto.ProjectAllocation(
+                        pm.getProject().getId(),
+                        pm.getProject().getName(),
+                        pm.getAllocation()))
+                .toList();
+        int total = memberships.stream().mapToInt(ProjectMember::getAllocation).sum();
+        return new AllocationSummaryDto(user.getId(), total, projects);
     }
 }

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -39,6 +39,10 @@ export async function updateMemberScore(projectId: number, userId: number, score
   return apiPut<MemberDto>(`/projects/${projectId}/members/${userId}/score`, { score });
 }
 
+export async function updateMemberAllocation(projectId: number, userId: number, allocation: number): Promise<MemberDto> {
+  return apiPut<MemberDto>(`/projects/${projectId}/members/${userId}/allocation`, { allocation });
+}
+
 // Labels
 export async function getLabels(projectId: number): Promise<LabelDto[]> {
   return apiGet<LabelDto[]>(`/projects/${projectId}/labels`);

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,5 +1,5 @@
 import { apiGet, apiGetPaginated, apiPut } from './client';
-import type { UserDto, UpdateProfileRequest, PasswordChangeRequest } from '@/types';
+import type { UserDto, UpdateProfileRequest, PasswordChangeRequest, AllocationSummaryDto } from '@/types';
 
 export async function listAllUsers(params?: Record<string, string | number>): Promise<UserDto[]> {
   const res = await apiGetPaginated<UserDto>('/users', { size: 100, ...params });
@@ -16,4 +16,12 @@ export async function updateUser(id: number, request: UpdateProfileRequest): Pro
 
 export async function changePassword(id: number, request: PasswordChangeRequest): Promise<void> {
   await apiPut(`/users/${id}/password`, request);
+}
+
+export async function updateUserCapacity(id: number, weeklyCapacity: number): Promise<UserDto> {
+  return apiPut<UserDto>(`/users/${id}/capacity`, { weeklyCapacity });
+}
+
+export async function getUserAllocationSummary(id: number): Promise<AllocationSummaryDto> {
+  return apiGet<AllocationSummaryDto>(`/users/${id}/allocation-summary`);
 }

--- a/frontend/src/pages/UserDetailPage.tsx
+++ b/frontend/src/pages/UserDetailPage.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import type { UserDto, ProjectDto, MemberDto, TaskDto, TimeLogDto, LeaveRequestDto, AssetDto, AssetType, AssetStatus } from '@/types';
-import { getUser, updateUserCapacity } from '@/api/users';
+import type { UserDto, ProjectDto, MemberDto, TaskDto, TimeLogDto, LeaveRequestDto, AssetDto, AssetType, AssetStatus, AllocationSummaryDto } from '@/types';
+import { getUser, updateUserCapacity, getUserAllocationSummary } from '@/api/users';
 import { listProjects, getMembers } from '@/api/projects';
 import { listProjectTasks } from '@/api/tasks';
 import { listTimeLogs } from '@/api/timeLogs';
@@ -9,6 +9,7 @@ import { listLeaveRequests } from '@/api/leave';
 import { listAssets } from '@/api/assets';
 import { useAuth } from '@/hooks/useAuth';
 import { scoreLabel, scoreColor, roleBadgeColor, formatDate } from '@/utils/format';
+import { computeAvailability, allocationColor, allocationBgColor, availableColor } from '@/utils/availability';
 import Spinner from '@/components/common/Spinner';
 
 const ASSET_TYPE_LABELS: Record<AssetType, string> = {
@@ -65,9 +66,16 @@ export default function UserDetailPage() {
   const [editingCapacity, setEditingCapacity] = useState(false);
   const [capacityValue, setCapacityValue] = useState('');
   const [savingCapacity, setSavingCapacity] = useState(false);
+  const [allocationSummary, setAllocationSummary] = useState<AllocationSummaryDto | null>(null);
 
   const canSeeScores = currentUser && (currentUser.role === 'ADMIN' || currentUser.role === 'MANAGER' || currentUser.role === 'EXECUTIVE' || currentUser.role === 'HR');
   const canManageCapacity = currentUser && (currentUser.role === 'HR' || currentUser.role === 'EXECUTIVE');
+
+  const availability = useMemo(() => {
+    if (!allocationSummary || !user) return null;
+    const approvedLeaves = leaves.filter((l) => l.status === 'APPROVED');
+    return computeAvailability(user.weeklyCapacity, allocationSummary.totalAllocation, approvedLeaves);
+  }, [allocationSummary, user, leaves]);
 
   useEffect(() => {
     if (!id) return;
@@ -113,12 +121,14 @@ export default function UserDetailPage() {
         }
         setProjectData(pData);
 
-        const [leaveReqs, userAssets] = await Promise.all([
+        const [leaveReqs, userAssets, allocSummary] = await Promise.all([
           listLeaveRequests({ userId }),
           listAssets({ userId }),
+          getUserAllocationSummary(userId).catch(() => null),
         ]);
         setLeaves(leaveReqs);
         setAssets(userAssets);
+        setAllocationSummary(allocSummary);
       } catch { /* ignore */ }
       finally { setDataLoading(false); }
     };
@@ -191,14 +201,117 @@ export default function UserDetailPage() {
 
       {dataLoading && <div className="flex items-center justify-center h-32"><Spinner className="h-6 w-6 text-primary-600" /></div>}
 
+      {/* Availability card */}
+      {!dataLoading && availability && (
+        <div className="bg-white rounded-xl border border-gray-200 p-6">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">Availability</h3>
+
+          {/* Summary line */}
+          <div className="flex items-center gap-4 mb-3">
+            <span className="text-sm text-gray-600">{availability.weeklyCapacity}h/wk capacity</span>
+            <span className="text-sm text-gray-400">·</span>
+            <span className={`text-sm font-medium ${allocationColor(availability.totalAllocation)}`}>
+              {availability.totalAllocation}% allocated ({availability.totalAllocatedHours.toFixed(0)}h/wk)
+            </span>
+          </div>
+
+          {/* Workload bar */}
+          <div className="mb-4">
+            <div className="flex items-center gap-3">
+              <div className="flex-1 h-3 bg-gray-100 rounded-full overflow-hidden relative">
+                {availability.totalAllocation <= 100 ? (
+                  <div className={`h-full rounded-full ${allocationBgColor(availability.totalAllocation)}`} style={{ width: `${availability.totalAllocation}%` }} />
+                ) : (
+                  <>
+                    <div className="absolute inset-y-0 left-0 bg-red-500 rounded-l-full" style={{ width: '100%' }} />
+                    <div className="absolute inset-y-0 bg-red-400" style={{ left: '100%', width: `${availability.totalAllocation - 100}%`, maxWidth: '50%' }} />
+                  </>
+                )}
+              </div>
+              <span className={`text-sm font-semibold ${availableColor(availability.totalAvailableHours)}`}>
+                {availability.totalAvailableHours < 0
+                  ? `${availability.totalAvailableHours.toFixed(0)}h/wk over-allocated`
+                  : availability.totalAvailableHours === 0
+                    ? 'Fully allocated'
+                    : `${availability.totalAvailableHours.toFixed(0)}h/wk available`}
+              </span>
+            </div>
+          </div>
+
+          {/* Upcoming leaves */}
+          {availability.upcomingLeaves.length > 0 && (
+            <div className="mb-4">
+              <p className="text-xs font-medium text-gray-500 mb-2">Upcoming Leave</p>
+              <div className="space-y-1.5">
+                {availability.upcomingLeaves.map((leave) => (
+                  <div key={leave.id} className="flex items-center gap-2 text-sm">
+                    <span className="text-gray-600">{formatDate(leave.startDate)}{leave.startDate !== leave.endDate ? ` – ${formatDate(leave.endDate)}` : ''}</span>
+                    <span className={`inline-block px-1.5 py-0.5 rounded text-xs font-medium ${leave.type === 'VACATION' ? 'bg-blue-100 text-blue-700' : leave.type === 'SICK' ? 'bg-red-100 text-red-700' : leave.type === 'PERSONAL' ? 'bg-purple-100 text-purple-700' : 'bg-gray-100 text-gray-700'}`}>{leave.type}</span>
+                    <span className="text-xs text-gray-400">{leave.workingDays}d</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Weekly outlook */}
+          <div>
+            <p className="text-xs font-medium text-gray-500 mb-2">Weekly Outlook</p>
+            <div className="space-y-1">
+              {availability.weeklyBreakdown.map((week) => {
+                const isThisWeek = week.weekStart.getTime() <= new Date().getTime() && new Date().getTime() < week.weekStart.getTime() + 7 * 86400000;
+                return (
+                  <div key={week.weekLabel} className={`flex items-center gap-3 text-sm px-2 py-1 rounded ${isThisWeek ? 'bg-primary-50' : ''}`}>
+                    <span className={`w-20 text-gray-500 ${isThisWeek ? 'font-semibold' : ''}`}>{week.weekLabel}{isThisWeek ? ' *' : ''}</span>
+                    {week.fullyOnLeave ? (
+                      <span className="text-blue-600 font-medium flex-1">On leave</span>
+                    ) : (
+                      <>
+                        <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
+                          <div
+                            className={`h-full rounded-full ${week.availableHours > 0 ? 'bg-green-400' : week.availableHours === 0 ? 'bg-yellow-400' : 'bg-red-400'}`}
+                            style={{ width: `${Math.min(Math.max(availability.weeklyCapacity > 0 ? (1 - week.availableHours / availability.weeklyCapacity) * 100 : 0, 0), 100)}%` }}
+                          />
+                        </div>
+                        <span className={`w-32 text-right font-medium ${availableColor(week.availableHours)}`}>
+                          {week.availableHours < 0
+                            ? `${week.availableHours.toFixed(0)}h/wk over`
+                            : `${week.availableHours.toFixed(0)}h/wk`}
+                        </span>
+                      </>
+                    )}
+                    {week.leaveDays > 0 && !week.fullyOnLeave && (
+                      <span className="text-xs text-blue-500">{week.leaveDays}d leave</span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Projects card — tasks grouped by project with evaluation and time */}
       {!dataLoading && (
         <div className="space-y-4">
-          <h3 className="text-lg font-semibold text-gray-900">Projects</h3>
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-gray-900">Projects</h3>
+            {projectData.length > 0 && user && (
+              <div className="flex items-center gap-2 text-sm">
+                <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${allocationColor(projectData.reduce((s, p) => s + p.allocation, 0))} ${projectData.reduce((s, p) => s + p.allocation, 0) > 100 ? 'bg-red-100' : projectData.reduce((s, p) => s + p.allocation, 0) > 80 ? 'bg-yellow-100' : 'bg-green-100'}`}>
+                  {projectData.reduce((s, p) => s + p.allocation, 0)}% across {projectData.length} project{projectData.length !== 1 ? 's' : ''}
+                </span>
+                <span className="text-gray-400">·</span>
+                <span className="text-gray-500">{(projectData.reduce((s, p) => s + p.allocation, 0) * user.weeklyCapacity / 100).toFixed(0)}h/wk committed · {user.weeklyCapacity}h/wk capacity</span>
+              </div>
+            )}
+          </div>
           {projectData.length === 0 ? (
             <div className="bg-white rounded-xl border border-gray-200 p-8 text-center text-gray-500">No project assignments found.</div>
           ) : (
-            projectData.map(({ project, tasks, score, allocation, totalHours, taskHours }) => (
+            projectData.map(({ project, tasks, score, allocation, totalHours, taskHours }) => {
+              const allocatedHw = user ? (allocation * user.weeklyCapacity / 100) : 0;
+              return (
               <div key={project.id} className="bg-white rounded-xl border border-gray-200">
                 {/* Project header */}
                 <Link to={`/projects/${project.id}`} className="block px-5 py-4 hover:bg-gray-50 rounded-t-xl">
@@ -209,6 +322,7 @@ export default function UserDetailPage() {
                     </div>
                     <div className="flex items-center gap-3 text-sm text-gray-500">
                       <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${allocation >= 80 ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-700'}`}>{allocation}%</span>
+                      <span className="text-xs text-gray-400">{allocatedHw.toFixed(0)}h/wk</span>
                       {canSeeScores && score != null && (
                         <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${scoreColor(score)}`}>{score} - {scoreLabel(score)}</span>
                       )}
@@ -244,7 +358,8 @@ export default function UserDetailPage() {
                   </div>
                 )}
               </div>
-            ))
+              );
+            })
           )}
         </div>
       )}

--- a/frontend/src/pages/UserDetailPage.tsx
+++ b/frontend/src/pages/UserDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import type { UserDto, ProjectDto, MemberDto, TaskDto, TimeLogDto, LeaveRequestDto, AssetDto, AssetType, AssetStatus } from '@/types';
-import { getUser } from '@/api/users';
+import { getUser, updateUserCapacity } from '@/api/users';
 import { listProjects, getMembers } from '@/api/projects';
 import { listProjectTasks } from '@/api/tasks';
 import { listTimeLogs } from '@/api/timeLogs';
@@ -48,6 +48,7 @@ interface ProjectData {
   project: ProjectDto;
   tasks: TaskDto[];
   score: number | null;
+  allocation: number;
   totalHours: number;
   taskHours: Record<number, number>;
 }
@@ -61,8 +62,12 @@ export default function UserDetailPage() {
   const [leaves, setLeaves] = useState<LeaveRequestDto[]>([]);
   const [assets, setAssets] = useState<AssetDto[]>([]);
   const [dataLoading, setDataLoading] = useState(false);
+  const [editingCapacity, setEditingCapacity] = useState(false);
+  const [capacityValue, setCapacityValue] = useState('');
+  const [savingCapacity, setSavingCapacity] = useState(false);
 
   const canSeeScores = currentUser && (currentUser.role === 'ADMIN' || currentUser.role === 'MANAGER' || currentUser.role === 'EXECUTIVE' || currentUser.role === 'HR');
+  const canManageCapacity = currentUser && (currentUser.role === 'HR' || currentUser.role === 'EXECUTIVE');
 
   useEffect(() => {
     if (!id) return;
@@ -99,6 +104,7 @@ export default function UserDetailPage() {
                 project: p,
                 tasks,
                 score: member.score,
+                allocation: member.allocation,
                 totalHours: projectHours,
                 taskHours: taskHoursMap,
               });
@@ -118,6 +124,18 @@ export default function UserDetailPage() {
     };
     fetchAll();
   }, [user]);
+
+  const handleSaveCapacity = async () => {
+    if (!user) return;
+    const val = Number(capacityValue);
+    if (val < 1 || val > 168) return;
+    setSavingCapacity(true);
+    try {
+      const updated = await updateUserCapacity(user.id, val);
+      setUser(updated);
+      setEditingCapacity(false);
+    } catch { /* ignore */ } finally { setSavingCapacity(false); }
+  };
 
   if (loading) {
     return <div className="flex items-center justify-center h-64"><Spinner className="h-8 w-8 text-primary-600" /></div>;
@@ -150,6 +168,24 @@ export default function UserDetailPage() {
           {user.email && <div><p className="text-xs text-gray-500">Email</p><p className="text-sm font-medium text-gray-900">{user.email}</p></div>}
           {user.phone && <div><p className="text-xs text-gray-500">Phone</p><p className="text-sm font-medium text-gray-900">{user.phone}</p></div>}
           {user.hireDate && <div><p className="text-xs text-gray-500">Hire Date</p><p className="text-sm font-medium text-gray-900">{formatDate(user.hireDate)}</p></div>}
+          <div>
+            <p className="text-xs text-gray-500">Weekly Capacity</p>
+            {editingCapacity ? (
+              <div className="flex items-center gap-1 mt-0.5">
+                <input type="number" min={1} max={168} value={capacityValue} onChange={(e) => setCapacityValue(e.target.value)} className="w-16 px-2 py-1 border border-gray-300 rounded text-sm" autoFocus />
+                <span className="text-xs text-gray-500">h/wk</span>
+                <button onClick={handleSaveCapacity} disabled={savingCapacity} className="text-green-600 hover:text-green-800 text-xs font-medium">{savingCapacity ? '...' : 'Save'}</button>
+                <button onClick={() => setEditingCapacity(false)} className="text-gray-400 hover:text-gray-600 text-xs">Cancel</button>
+              </div>
+            ) : (
+              <p className="text-sm font-medium text-gray-900">
+                {user.weeklyCapacity}h/wk
+                {canManageCapacity && (
+                  <button onClick={() => { setEditingCapacity(true); setCapacityValue(String(user.weeklyCapacity)); }} className="ml-1 text-primary-600 hover:text-primary-800 text-xs">Edit</button>
+                )}
+              </p>
+            )}
+          </div>
         </div>
       </div>
 
@@ -162,7 +198,7 @@ export default function UserDetailPage() {
           {projectData.length === 0 ? (
             <div className="bg-white rounded-xl border border-gray-200 p-8 text-center text-gray-500">No project assignments found.</div>
           ) : (
-            projectData.map(({ project, tasks, score, totalHours, taskHours }) => (
+            projectData.map(({ project, tasks, score, allocation, totalHours, taskHours }) => (
               <div key={project.id} className="bg-white rounded-xl border border-gray-200">
                 {/* Project header */}
                 <Link to={`/projects/${project.id}`} className="block px-5 py-4 hover:bg-gray-50 rounded-t-xl">
@@ -172,6 +208,7 @@ export default function UserDetailPage() {
                       <h4 className="font-semibold text-gray-900">{project.name}</h4>
                     </div>
                     <div className="flex items-center gap-3 text-sm text-gray-500">
+                      <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${allocation >= 80 ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-700'}`}>{allocation}%</span>
                       {canSeeScores && score != null && (
                         <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${scoreColor(score)}`}>{score} - {scoreLabel(score)}</span>
                       )}

--- a/frontend/src/pages/project-detail/MembersTab.tsx
+++ b/frontend/src/pages/project-detail/MembersTab.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { MemberDto, UserDto } from '@/types';
-import { getMembers, addMembers, removeMember, updateMemberScore } from '@/api/projects';
-import { listAllUsers } from '@/api/users';
+import type { MemberDto, UserDto, AllocationSummaryDto } from '@/types';
+import { getMembers, addMembers, removeMember, updateMemberScore, updateMemberAllocation } from '@/api/projects';
+import { listAllUsers, getUserAllocationSummary } from '@/api/users';
 import { scoreLabel, scoreColor } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
 import Modal from '@/components/common/Modal';
@@ -21,10 +21,25 @@ export default function MembersTab({ projectId, managerId, canEdit, canSeeScores
   const [scoringUserId, setScoringUserId] = useState<number | null>(null);
   const [savingScore, setSavingScore] = useState(false);
   const [scoreError, setScoreError] = useState<string | null>(null);
+  const [editingAllocUserId, setEditingAllocUserId] = useState<number | null>(null);
+  const [editAllocValue, setEditAllocValue] = useState('');
+  const [savingAlloc, setSavingAlloc] = useState(false);
+  const [allocationSummaries, setAllocationSummaries] = useState<Record<number, AllocationSummaryDto>>({});
 
   const fetchMembers = useCallback(async () => {
     setLoading(true);
-    try { setMembers(await getMembers(projectId)); } finally { setLoading(false); }
+    try {
+      const mems = await getMembers(projectId);
+      setMembers(mems);
+      // Fetch allocation summaries for all members
+      const summaries: Record<number, AllocationSummaryDto> = {};
+      await Promise.all(mems.map(async (m) => {
+        try {
+          summaries[m.userId] = await getUserAllocationSummary(m.userId);
+        } catch { /* ignore */ }
+      }));
+      setAllocationSummaries(summaries);
+    } finally { setLoading(false); }
   }, [projectId]);
 
   useEffect(() => { fetchMembers(); }, [fetchMembers]);
@@ -53,6 +68,17 @@ export default function MembersTab({ projectId, managerId, canEdit, canSeeScores
 
   const canSeeScores = canSeeScoresProp ?? canEdit;
 
+  const handleAllocationSave = async (userId: number) => {
+    const val = Number(editAllocValue);
+    if (val < 1 || val > 100) return;
+    setSavingAlloc(true);
+    try {
+      await updateMemberAllocation(projectId, userId, val);
+      setEditingAllocUserId(null);
+      fetchMembers();
+    } catch { /* ignore */ } finally { setSavingAlloc(false); }
+  };
+
   return (
     <div className="space-y-4">
       {canEdit && (
@@ -70,6 +96,7 @@ export default function MembersTab({ projectId, managerId, canEdit, canSeeScores
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Username</th>
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Full Name</th>
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Role</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Allocation</th>
                 {canSeeScores && <th className="text-left px-4 py-3 font-medium text-gray-500">Evaluation</th>}
                 {canEdit && <th className="text-left px-4 py-3 font-medium text-gray-500">Actions</th>}
               </tr>
@@ -81,6 +108,32 @@ export default function MembersTab({ projectId, managerId, canEdit, canSeeScores
                   <td className="px-4 py-3">{m.fullName}</td>
                   <td className="px-4 py-3">
                     {m.userId === managerId && <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full font-medium">Manager</span>}
+                  </td>
+                  <td className="px-4 py-3">
+                    {editingAllocUserId === m.userId ? (
+                      <div className="flex items-center gap-1">
+                        <input type="number" min={1} max={100} value={editAllocValue} onChange={(e) => setEditAllocValue(e.target.value)} className="w-16 px-2 py-1 border border-gray-300 rounded text-sm" autoFocus />
+                        <span className="text-xs text-gray-500">%</span>
+                        <button onClick={() => handleAllocationSave(m.userId)} disabled={savingAlloc} className="text-green-600 hover:text-green-800 text-xs font-medium">{savingAlloc ? '...' : 'Save'}</button>
+                        <button onClick={() => setEditingAllocUserId(null)} className="text-gray-400 hover:text-gray-600 text-xs">Cancel</button>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => { if (canEdit) { setEditingAllocUserId(m.userId); setEditAllocValue(String(m.allocation)); } }}
+                        className={`px-2 py-0.5 rounded text-xs font-medium ${
+                          (allocationSummaries[m.userId]?.totalAllocation ?? 0) > 100
+                            ? 'bg-red-100 text-red-700'
+                            : m.allocation >= 80
+                              ? 'bg-blue-100 text-blue-700'
+                              : 'bg-gray-100 text-gray-700'
+                        } ${canEdit ? 'cursor-pointer hover:opacity-80' : ''}`}
+                      >
+                        {m.allocation}%
+                      </button>
+                    )}
+                    {editingAllocUserId !== m.userId && allocationSummaries[m.userId] && allocationSummaries[m.userId].totalAllocation > 100 && (
+                      <span className="ml-1 text-xs text-red-500">({allocationSummaries[m.userId].totalAllocation}% total)</span>
+                    )}
                   </td>
                   {canSeeScores && (
                     <td className="px-4 py-3">
@@ -136,7 +189,7 @@ export default function MembersTab({ projectId, managerId, canEdit, canSeeScores
                 </tr>
               ))}
               {members.length === 0 && (
-                <tr><td colSpan={canSeeScores ? (canEdit ? 5 : 4) : (canEdit ? 4 : 3)} className="px-4 py-8 text-center text-gray-500">No members.</td></tr>
+                <tr><td colSpan={canSeeScores ? (canEdit ? 6 : 5) : (canEdit ? 5 : 4)} className="px-4 py-8 text-center text-gray-500">No members.</td></tr>
               )}
             </tbody>
           </table>
@@ -150,12 +203,32 @@ export default function MembersTab({ projectId, managerId, canEdit, canSeeScores
 function AddMembersModal({ projectId, currentMembers, onClose }: { projectId: number; currentMembers: MemberDto[]; onClose: () => void }) {
   const [allUsers, setAllUsers] = useState<UserDto[]>([]);
   const [selected, setSelected] = useState<number[]>([]);
+  const [allocations, setAllocations] = useState<Record<number, number>>({});
+  const [existingAllocations, setExistingAllocations] = useState<Record<number, number>>({});
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     listAllUsers({ active: 'true' }).then(setAllUsers);
   }, []);
+
+  useEffect(() => {
+    // Fetch allocation summaries for available users
+    const memberIds = new Set(currentMembers.map((m) => m.userId));
+    const fetchAllocs = async () => {
+      const result: Record<number, number> = {};
+      await Promise.all(allUsers.map(async (u) => {
+        if (!memberIds.has(u.id)) {
+          try {
+            const summary = await getUserAllocationSummary(u.id);
+            result[u.id] = summary.totalAllocation;
+          } catch { /* ignore */ }
+        }
+      }));
+      setExistingAllocations(result);
+    };
+    if (allUsers.length > 0) fetchAllocs();
+  }, [allUsers, currentMembers]);
 
   const memberIds = new Set(currentMembers.map((m) => m.userId));
   const available = allUsers.filter((u) => !memberIds.has(u.id));
@@ -167,6 +240,13 @@ function AddMembersModal({ projectId, currentMembers, onClose }: { projectId: nu
     setError(null);
     try {
       await addMembers(projectId, selected);
+      // Set allocations for each added member
+      await Promise.all(selected.map(async (userId) => {
+        const alloc = allocations[userId] ?? 100;
+        if (alloc !== 100) {
+          try { await updateMemberAllocation(projectId, userId, alloc); } catch { /* ignore */ }
+        }
+      }));
       onClose();
     } catch {
       setError('Failed to add members.');
@@ -179,20 +259,50 @@ function AddMembersModal({ projectId, currentMembers, onClose }: { projectId: nu
     setSelected((prev) => prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]);
   };
 
+  const getTotalForUser = (userId: number) => {
+    const existing = existingAllocations[userId] ?? 0;
+    const newAlloc = selected.includes(userId) ? (allocations[userId] ?? 100) : 0;
+    return existing + newAlloc;
+  };
+
   return (
     <Modal title="Add Members" onClose={onClose}>
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-3 py-2">{error}</div>}
-        <div className="max-h-60 overflow-y-auto border border-gray-300 rounded-lg p-2 space-y-1">
+        <div className="max-h-72 overflow-y-auto border border-gray-300 rounded-lg p-2 space-y-1">
           {available.length === 0 && <p className="text-sm text-gray-500 p-2">All users are already members.</p>}
-          {available.map((u) => (
-            <label key={u.id} className="flex items-center gap-2 text-sm py-1 cursor-pointer">
-              <input type="checkbox" checked={selected.includes(u.id)} onChange={() => toggle(u.id)} className="rounded border-gray-300" />
-              <span>{u.firstName} {u.lastName}</span>
-              <span className="text-gray-400 text-xs">({u.username})</span>
-              <span className="text-xs text-gray-400 ml-auto">{u.role}</span>
-            </label>
-          ))}
+          {available.map((u) => {
+            const isSelected = selected.includes(u.id);
+            const existingTotal = existingAllocations[u.id] ?? 0;
+            const newTotal = getTotalForUser(u.id);
+            return (
+              <label key={u.id} className={`flex items-center gap-2 text-sm py-1.5 px-1 rounded cursor-pointer ${isSelected ? 'bg-primary-50' : ''}`}>
+                <input type="checkbox" checked={isSelected} onChange={() => toggle(u.id)} className="rounded border-gray-300 shrink-0" />
+                <span className="truncate">{u.firstName} {u.lastName}</span>
+                <span className="text-gray-400 text-xs shrink-0">({u.username})</span>
+                {existingTotal > 0 && (
+                  <span className={`text-xs shrink-0 ml-1 ${existingTotal > 100 ? 'text-red-500 font-medium' : 'text-gray-400'}`}>
+                    {existingTotal}% allocated
+                  </span>
+                )}
+                {isSelected && (
+                  <div className="flex items-center gap-1 ml-auto shrink-0">
+                    <input
+                      type="number" min={1} max={100}
+                      value={allocations[u.id] ?? 100}
+                      onChange={(e) => setAllocations((prev) => ({ ...prev, [u.id]: Number(e.target.value) }))}
+                      className="w-14 px-1.5 py-0.5 border border-gray-300 rounded text-xs text-center"
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                    <span className="text-xs text-gray-500">%</span>
+                    {newTotal > 100 && (
+                      <span className="text-xs text-red-500 font-medium">{newTotal}% total</span>
+                    )}
+                  </div>
+                )}
+              </label>
+            );
+          })}
         </div>
         <div className="flex justify-end gap-3 pt-2">
           <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-100">Cancel</button>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,6 @@
 export type { ApiResponse, PaginatedResponse, PaginationInfo, ApiError, ValidationError, FieldError } from './api';
 export type { CompanyDto, CreateCompanyRequest, UpdateCompanyRequest } from './company';
-export type { UserDto, UserRole, LoginRequest, UpdateProfileRequest, PasswordChangeRequest } from './user';
+export type { UserDto, UserRole, LoginRequest, UpdateProfileRequest, PasswordChangeRequest, AllocationSummaryDto } from './user';
 export type { ProjectDto, CreateProjectRequest, UpdateProjectRequest, MemberDto, LabelDto, LabelCreateRequest, BoardColumnDto, BoardConfigDto, BoardUpdateRequest, InstructionDto, CreateInstructionRequest, UpdateInstructionRequest, NoteDto, CreateNoteRequest, UpdateNoteRequest } from './project';
 export type { TaskDto, TaskPriority, CreateTaskRequest, UpdateTaskRequest, CommentDto, CreateCommentRequest, UpdateCommentRequest } from './task';
 export type { ProgramDto, CreateProgramRequest, UpdateProgramRequest } from './program';

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -57,6 +57,7 @@ export interface MemberDto {
   username: string;
   fullName: string;
   score: number | null;
+  allocation: number;
 }
 
 export interface LabelDto {

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -15,6 +15,7 @@ export interface UserDto {
   department: string | null;
   phone: string | null;
   hireDate: string | null;
+  weeklyCapacity: number;
   avatarUrl: string | null;
   active: boolean;
   createdAt: string;
@@ -36,4 +37,10 @@ export interface UpdateProfileRequest {
 export interface PasswordChangeRequest {
   currentPassword: string;
   newPassword: string;
+}
+
+export interface AllocationSummaryDto {
+  userId: number;
+  totalAllocation: number;
+  projects: { projectId: number; projectName: string; allocation: number }[];
 }

--- a/frontend/src/utils/availability.ts
+++ b/frontend/src/utils/availability.ts
@@ -1,0 +1,164 @@
+export interface UpcomingLeave {
+  id: number;
+  type: string;
+  startDate: string;
+  endDate: string;
+  workingDays: number;
+}
+
+export interface WeeklyAvailability {
+  weekStart: Date;
+  weekLabel: string;
+  allocatedHours: number;
+  leaveDays: number;
+  leaveHours: number;
+  availableHours: number;
+  fullyOnLeave: boolean;
+}
+
+export interface AvailabilityData {
+  weeklyCapacity: number;
+  dailyHours: number;
+  totalAllocation: number;
+  totalAllocatedHours: number;
+  totalAvailableHours: number;
+  upcomingLeaves: UpcomingLeave[];
+  weeklyBreakdown: WeeklyAvailability[];
+}
+
+const DAYS_PER_WEEK = 5;
+const WEEKS_AHEAD = 8;
+
+export function countWorkingDaysInRange(start: Date, end: Date): number {
+  let count = 0;
+  const current = new Date(start);
+  current.setHours(0, 0, 0, 0);
+  const endDate = new Date(end);
+  endDate.setHours(0, 0, 0, 0);
+
+  while (current <= endDate) {
+    const day = current.getDay();
+    if (day !== 0 && day !== 6) count++;
+    current.setDate(current.getDate() + 1);
+  }
+  return count;
+}
+
+function getWeekStart(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  return d;
+}
+
+function getWeekEnd(weekStart: Date): Date {
+  const d = new Date(weekStart);
+  d.setDate(d.getDate() + 4);
+  d.setHours(23, 59, 59, 999);
+  return d;
+}
+
+function formatWeekLabel(date: Date): string {
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export function computeAvailability(
+  weeklyCapacity: number,
+  totalAllocation: number,
+  approvedLeaves: { id: number; type: string; startDate: string; endDate: string }[]
+): AvailabilityData {
+  const dailyHours = weeklyCapacity / DAYS_PER_WEEK;
+  const totalAllocatedHours = weeklyCapacity * totalAllocation / 100;
+  const totalAvailableHours = weeklyCapacity - totalAllocatedHours;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const upcomingLeaves: UpcomingLeave[] = approvedLeaves
+    .filter((leave) => {
+      const end = new Date(leave.endDate);
+      end.setHours(0, 0, 0, 0);
+      return end >= today;
+    })
+    .map((leave) => ({
+      id: leave.id,
+      type: leave.type,
+      startDate: leave.startDate,
+      endDate: leave.endDate,
+      workingDays: countWorkingDaysInRange(new Date(leave.startDate), new Date(leave.endDate)),
+    }));
+
+  const weeklyBreakdown: WeeklyAvailability[] = [];
+  const currentWeekStart = getWeekStart(today);
+
+  for (let i = 0; i < WEEKS_AHEAD; i++) {
+    const weekStart = new Date(currentWeekStart);
+    weekStart.setDate(weekStart.getDate() + i * 7);
+
+    const weekEnd = getWeekEnd(weekStart);
+
+    let leaveDaysThisWeek = 0;
+    for (const leave of upcomingLeaves) {
+      const leaveStart = new Date(leave.startDate);
+      leaveStart.setHours(0, 0, 0, 0);
+      const leaveEnd = new Date(leave.endDate);
+      leaveEnd.setHours(23, 59, 59, 999);
+
+      if (leaveStart <= weekEnd && leaveEnd >= weekStart) {
+        const overlapStart = leaveStart > weekStart ? leaveStart : weekStart;
+        const overlapEnd = leaveEnd < weekEnd ? leaveEnd : weekEnd;
+        leaveDaysThisWeek += countWorkingDaysInRange(overlapStart, overlapEnd);
+      }
+    }
+
+    const leaveHours = leaveDaysThisWeek * dailyHours;
+    const availableHours = weeklyCapacity - totalAllocatedHours - leaveHours;
+    const fullyOnLeave = leaveDaysThisWeek >= DAYS_PER_WEEK;
+
+    weeklyBreakdown.push({
+      weekStart,
+      weekLabel: formatWeekLabel(weekStart),
+      allocatedHours: totalAllocatedHours,
+      leaveDays: leaveDaysThisWeek,
+      leaveHours,
+      availableHours,
+      fullyOnLeave,
+    });
+  }
+
+  return {
+    weeklyCapacity,
+    dailyHours,
+    totalAllocation,
+    totalAllocatedHours,
+    totalAvailableHours,
+    upcomingLeaves,
+    weeklyBreakdown,
+  };
+}
+
+export function allocationColor(allocation: number): string {
+  if (allocation > 100) return 'text-red-600';
+  if (allocation > 80) return 'text-yellow-600';
+  return 'text-green-600';
+}
+
+export function allocationBgColor(allocation: number): string {
+  if (allocation > 100) return 'bg-red-500';
+  if (allocation > 80) return 'bg-yellow-500';
+  return 'bg-green-500';
+}
+
+export function availableColor(available: number): string {
+  if (available < 0) return 'text-red-600';
+  if (available === 0) return 'text-yellow-600';
+  return 'text-green-600';
+}
+
+export function availableBgColor(available: number, capacity: number): string {
+  if (available < 0) return 'bg-red-100';
+  if (available === 0) return 'bg-yellow-50';
+  return 'bg-green-50';
+}


### PR DESCRIPTION
## Summary
- Add `weeklyCapacity` field to User entity (default 40h/week), editable by HR and Executive only
- Add `allocation` percentage to ProjectMember (1-100%), set by PM at add-time
- Backend endpoints: `PUT /members/{userId}/allocation`, `PUT /users/{id}/capacity`, `GET /users/{id}/allocation-summary`
- Allocation column in MembersTab with inline editing and red warning badge when total >100%
- AddMembersModal shows existing allocation per user and lets PM set allocation %
- UserDetailPage shows weekly capacity (editable by HR/Executive) and allocation % per project
- DataSeeder seeds realistic allocations for users in multiple projects

## Test plan
- [ ] Log in as manager, go to a project's Members tab — see Allocation column with % badges
- [ ] Add a member already in other projects — modal shows existing allocation, set desired %
- [ ] Edit allocation inline — persists correctly, over-allocation shows red warning
- [ ] Log in as HR, go to User Detail page — see weekly capacity, edit it
- [ ] Log in as Executive — can also edit capacity
- [ ] Verify allocation % appears per project on User Detail page
- [ ] Verify allocation-summary API returns correct cross-project totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)