### PR TITLE
fix(#59): SPI shows — for projects with no earned value

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/PmoService.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoService.java
@@ -121,8 +121,8 @@ public class PmoService {
                 ? earnedValue.divide(actualCost, 2, RoundingMode.HALF_UP)
                 : null;
 
-        // SPI = EV / PV (null when PV = 0 — no planned value yet)
-        BigDecimal spi = pvToday.compareTo(BigDecimal.ZERO) > 0
+        // SPI = EV / PV (null when EV = 0 or PV = 0 — no meaningful ratio)
+        BigDecimal spi = earnedValue.compareTo(BigDecimal.ZERO) > 0 && pvToday.compareTo(BigDecimal.ZERO) > 0
                 ? earnedValue.divide(pvToday, 2, RoundingMode.HALF_UP)
                 : null;
 

--- a/frontend/src/pages/dashboard/ExecutiveDashboard.tsx
+++ b/frontend/src/pages/dashboard/ExecutiveDashboard.tsx
@@ -203,7 +203,7 @@ export default function ExecutiveDashboard() {
         { label: 'Total Projects', value: cs.totalProjects, color: 'bg-primary-50 text-primary-700' },
         { label: 'Total Budget', value: formatCurrency(cs.totalBudget), color: 'bg-blue-50 text-blue-700' },
         { label: 'Portfolio CPI', value: totalActualCost > 0 ? (totalEarnedValue / totalActualCost).toFixed(2) : '—', color: cv >= 0 ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700' },
-        { label: 'Portfolio SPI', value: totalPlannedValue > 0 ? (totalEarnedValue / totalPlannedValue).toFixed(2) : '—', color: sv >= 0 ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700' },
+        { label: 'Portfolio SPI', value: totalEarnedValue > 0 && totalPlannedValue > 0 ? (totalEarnedValue / totalPlannedValue).toFixed(2) : '—', color: sv >= 0 ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700' },
         { label: 'Open Risks', value: cs.totalOpenRisks + cs.totalMitigatingRisks, color: 'bg-amber-50 text-amber-700' },
         { label: 'Completion', value: cs.totalTasks > 0 ? ((cs.totalCompleted / cs.totalTasks) * 100).toFixed(0) + '%' : '—', color: 'bg-emerald-50 text-emerald-700' },
       ];
@@ -213,7 +213,7 @@ export default function ExecutiveDashboard() {
     { label: 'Total Projects', value: portfolio.totalProjects, color: 'bg-primary-50 text-primary-700' },
     { label: 'Total Budget', value: formatCurrency(portfolio.totalBudget), color: 'bg-blue-50 text-blue-700' },
     { label: 'Portfolio CPI', value: portfolio.portfolioCv !== 0 ? (portfolio.totalActualCost > 0 ? (portfolio.totalEarnedValue / portfolio.totalActualCost).toFixed(2) : '—') : '—', color: portfolio.portfolioCv >= 0 ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700' },
-    { label: 'Portfolio SPI', value: portfolio.totalPlannedValue > 0 ? (portfolio.totalEarnedValue / portfolio.totalPlannedValue).toFixed(2) : '—', color: portfolio.portfolioSv >= 0 ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700' },
+    { label: 'Portfolio SPI', value: portfolio.totalEarnedValue > 0 && portfolio.totalPlannedValue > 0 ? (portfolio.totalEarnedValue / portfolio.totalPlannedValue).toFixed(2) : '—', color: portfolio.portfolioSv >= 0 ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700' },
     { label: 'Open Risks', value: portfolio.totalOpenRisks + portfolio.totalMitigatingRisks, color: 'bg-amber-50 text-amber-700' },
     { label: 'Completion', value: portfolio.totalTasks > 0 ? ((portfolio.totalCompleted / portfolio.totalTasks) * 100).toFixed(0) + '%' : '—', color: 'bg-emerald-50 text-emerald-700' },
   ] : [


### PR DESCRIPTION
## Summary
- SPI returned 0.00 (red) for projects with EV=0 but PV>0 (e.g. Initiation/Planning stage projects), creating false schedule alerts across the portfolio
- Backend now returns `null` for SPI when `earnedValue=0`, matching how CPI already returns `null` when `actualCost=0` — the frontend already renders null as "—"
- Also fixed the Executive Dashboard's client-side portfolio SPI calculation to show "—" when total earned value is zero

## Root cause
The SPI calculation in `PmoService.java` only guarded against `pvToday=0` (division by zero), but not against `earnedValue=0`. When a project hasn't started executing (EV=0), SPI=0/PV=0.00 is mathematically valid but operationally meaningless — it signals a schedule problem that doesn't exist.

## Files changed
- `backend/src/main/java/com/nemo/pmo/PmoService.java` — SPI returns null when earnedValue=0
- `frontend/src/pages/dashboard/ExecutiveDashboard.tsx` — portfolio SPI shows "—" when totalEV=0

## Test plan
- [ ] Log in as admin, go to PMO dashboard
- [ ] Verify projects in Initiation/Planning with EV=0 now show "—" for SPI instead of 0.00 red
- [ ] Verify projects with EV>0 still show correct SPI values
- [ ] Verify Executive Dashboard portfolio SPI shows "—" when no projects have earned value
- [ ] Verify CPI behavior unchanged (still shows "—" when AC=0)

Fixes #59