### PR TITLE
fix(#58): completed tasks no longer show false Overdue badge

### DIFF
--- a/frontend/src/pages/TaskDetailPage.tsx
+++ b/frontend/src/pages/TaskDetailPage.tsx
@@ -181,7 +181,7 @@ export default function TaskDetailPage() {
                 } />
                 <DetailRow label="Due Date" value={
                   task.dueDate
-                    ? <>{formatDate(task.dueDate)}{deadlineLabel(task.dueDate) && <span className={`inline-block ml-2 px-2 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(task.dueDate)}`}>{deadlineLabel(task.dueDate)}</span>}</>
+                    ? <>{formatDate(task.dueDate)}{deadlineLabel(task.dueDate, task.statusCategory) && <span className={`inline-block ml-2 px-2 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(task.dueDate, task.statusCategory)}`}>{deadlineLabel(task.dueDate, task.statusCategory)}</span>}</>
                     : 'None'
                 } />
                 <DetailRow label="Sprint" value={task.sprintId ? `Sprint ${task.sprintId}` : 'Backlog'} />

--- a/frontend/src/pages/project-detail/BoardTab.tsx
+++ b/frontend/src/pages/project-detail/BoardTab.tsx
@@ -137,8 +137,8 @@ export default function BoardTab({ projectId, projectKey, isExternal }: { projec
                     <span className="bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">{task.typeName}</span>
                     {task.phaseName && <span className="bg-blue-100 text-blue-700 px-1.5 py-0.5 rounded">{task.phaseName}</span>}
                     {task.assigneeName && <span>{task.assigneeName}</span>}
-                    {task.dueDate && <span className={deadlineBadge(task.dueDate) || 'text-gray-400'}>{formatDate(task.dueDate)}</span>}
-                    {task.dueDate && deadlineLabel(task.dueDate) && <span className={`px-1 py-0.5 rounded text-[10px] font-medium ${deadlineBadge(task.dueDate)}`}>{deadlineLabel(task.dueDate)}</span>}
+                    {task.dueDate && <span className={deadlineBadge(task.dueDate, task.statusCategory) || 'text-gray-400'}>{formatDate(task.dueDate)}</span>}
+                    {task.dueDate && deadlineLabel(task.dueDate, task.statusCategory) && <span className={`px-1 py-0.5 rounded text-[10px] font-medium ${deadlineBadge(task.dueDate, task.statusCategory)}`}>{deadlineLabel(task.dueDate, task.statusCategory)}</span>}
                   </div>
                 </div>
               ))}

--- a/frontend/src/pages/project-detail/TasksTab.tsx
+++ b/frontend/src/pages/project-detail/TasksTab.tsx
@@ -100,8 +100,8 @@ export default function TasksTab({ projectId, projectKey, canEdit, isExternal }:
                   <td className="px-4 py-3">
                     {task.dueDate ? (
                       <span className="flex items-center gap-1.5">
-                        <span className={deadlineBadge(task.dueDate) || 'text-gray-500'}>{formatDate(task.dueDate)}</span>
-                        {deadlineLabel(task.dueDate) && <span className={`inline-block px-1.5 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(task.dueDate)}`}>{deadlineLabel(task.dueDate)}</span>}
+                        <span className={deadlineBadge(task.dueDate, task.statusCategory) || 'text-gray-500'}>{formatDate(task.dueDate)}</span>
+                        {deadlineLabel(task.dueDate, task.statusCategory) && <span className={`inline-block px-1.5 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(task.dueDate, task.statusCategory)}`}>{deadlineLabel(task.dueDate, task.statusCategory)}</span>}
                       </span>
                     ) : <span className="text-gray-400">--</span>}
                   </td>

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -170,8 +170,11 @@ export function preSaleStageLabel(stage: string): string {
   }
 }
 
-export function deadlineBadge(endDate: string | null): string {
+const completedCategories = new Set(['DONE', 'CLOSED']);
+
+export function deadlineBadge(endDate: string | null, statusCategory?: string): string {
   if (!endDate) return '';
+  if (statusCategory && completedCategories.has(statusCategory)) return '';
   const now = new Date();
   now.setHours(0, 0, 0, 0);
   const end = new Date(endDate);
@@ -182,8 +185,9 @@ export function deadlineBadge(endDate: string | null): string {
   return '';
 }
 
-export function deadlineLabel(endDate: string | null): string | null {
+export function deadlineLabel(endDate: string | null, statusCategory?: string): string | null {
   if (!endDate) return null;
+  if (statusCategory && completedCategories.has(statusCategory)) return null;
   const now = new Date();
   now.setHours(0, 0, 0, 0);
   const end = new Date(endDate);


### PR DESCRIPTION
## Summary
- Tasks with status Done or Closed still displayed a red "Overdue" badge next to their due date, even though a completed task cannot logically be overdue
- `deadlineLabel()` and `deadlineBadge()` in `format.ts` only compared the due date to today without checking task status
- Added an optional `statusCategory` parameter to both functions; when the status is `DONE` or `CLOSED`, the overdue label and red badge are suppressed
- Updated all three call sites (TasksTab, BoardTab, TaskDetailPage) to pass `task.statusCategory`

## Root cause
The overdue badge logic only considered the date — `end < now → "Overdue"`. It never checked whether the task was still open. Any task with a past due date got flagged, including completed ones.

## Files changed
- `frontend/src/utils/format.ts` — added `statusCategory` param to `deadlineLabel`/`deadlineBadge`, skip overdue for DONE/CLOSED
- `frontend/src/pages/project-detail/TasksTab.tsx` — pass `task.statusCategory`
- `frontend/src/pages/project-detail/BoardTab.tsx` — pass `task.statusCategory`
- `frontend/src/pages/TaskDetailPage.tsx` — pass `task.statusCategory`

## Test plan
- [ ] Open a project's task list, find a Done/Closed task with a past due date → should NOT show "Overdue" badge
- [ ] Find a To Do/In Progress task with a past due date → should still show "Overdue" badge in red
- [ ] Check the Kanban board view — same behavior
- [ ] Check a task detail page — same behavior

Fixes #58