### PR TITLE
fix(#68): add overdue indicator for sprints past their end date

### DIFF
--- a/frontend/src/pages/dashboard/ManagerDashboard.tsx
+++ b/frontend/src/pages/dashboard/ManagerDashboard.tsx
@@ -5,7 +5,7 @@ import { listProjects } from '@/api/projects';
 import { getEvmMetrics } from '@/api/pmo';
 import { listSprints } from '@/api/sprints';
 import { getTimeByUser } from '@/api/timeLogs';
-import { formatCurrency, stageBadge, stageLabel, riskColor, riskLabel } from '@/utils/format';
+import { formatCurrency, stageBadge, stageLabel, riskColor, riskLabel, deadlineBadge, deadlineLabel } from '@/utils/format';
 import { currentWeekRange, filterMyProjects, aggregateRaidItems } from './dashboardUtils';
 import type { ProjectDto, EvmMetrics, RaidItemDto, SprintDto } from '@/types';
 import Spinner from '@/components/common/Spinner';
@@ -221,8 +221,13 @@ export default function ManagerDashboard() {
                 </div>
                 <p className="text-xs text-gray-500 mb-2">{sprint.projectName}</p>
                 {sprint.goal && <p className="text-sm text-gray-600 line-clamp-2 mb-2">{sprint.goal}</p>}
-                <p className="text-xs text-gray-400">
+                <p className={`text-xs ${deadlineBadge(sprint.endDate) || 'text-gray-400'}`}>
                   {sprint.startDate} → {sprint.endDate}
+                  {deadlineLabel(sprint.endDate) && (
+                    <span className={`ml-1 text-xs px-1.5 py-0.5 rounded-full font-medium ${deadlineBadge(sprint.endDate)}`}>
+                      {deadlineLabel(sprint.endDate)}
+                    </span>
+                  )}
                 </p>
               </div>
             ))}

--- a/frontend/src/pages/reports/VelocityReport.tsx
+++ b/frontend/src/pages/reports/VelocityReport.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { listSprints } from '@/api/sprints';
 import { listProjectTasks } from '@/api/tasks';
 import type { SprintDto, TaskDto } from '@/types';
-import { formatDate } from '@/utils/format';
+import { formatDate, deadlineBadge, deadlineLabel } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
 
 export default function VelocityReport({ projectId }: { projectId: number | null }) {
@@ -52,9 +52,14 @@ export default function VelocityReport({ projectId }: { projectId: number | null
                       <span className="text-sm font-medium text-gray-900">{sprint.name}</span>
                       <span className={`ml-2 text-xs px-2 py-0.5 rounded-full font-medium ${
                         sprint.status === 'ACTIVE' ? 'bg-green-100 text-green-700' :
-                        sprint.status === 'COMPLETED' ? 'bg-gray-100 text-gray-600' :
+                        sprint.status === 'CLOSED' ? 'bg-gray-100 text-gray-600' :
                         'bg-blue-100 text-blue-700'
                       }`}>{sprint.status}</span>
+                      {deadlineLabel(sprint.endDate, sprint.status === 'CLOSED' ? 'CLOSED' : undefined) && (
+                        <span className={`ml-1 text-xs px-2 py-0.5 rounded-full font-medium ${deadlineBadge(sprint.endDate, sprint.status === 'CLOSED' ? 'CLOSED' : undefined)}`}>
+                          {deadlineLabel(sprint.endDate, sprint.status === 'CLOSED' ? 'CLOSED' : undefined)}
+                        </span>
+                      )}
                     </div>
                     <div className="text-sm text-gray-500">
                       {completed}/{total} completed
@@ -69,7 +74,9 @@ export default function VelocityReport({ projectId }: { projectId: number | null
                     </div>
                   </div>
                   {sprint.startDate && sprint.endDate && (
-                    <div className="text-xs text-gray-400 mt-1">{formatDate(sprint.startDate)} — {formatDate(sprint.endDate)}</div>
+                    <div className={`text-xs mt-1 ${deadlineBadge(sprint.endDate, sprint.status === 'CLOSED' ? 'CLOSED' : undefined) || 'text-gray-400'}`}>
+                      {formatDate(sprint.startDate)} — {formatDate(sprint.endDate)}
+                    </div>
                   )}
                 </div>
               ))}


### PR DESCRIPTION
## Summary
- Added "Overdue" badge and red date styling to sprints past their end date in VelocityReport and ManagerDashboard, using the existing `deadlineBadge`/`deadlineLabel` pattern
- Fixed a bug where `'COMPLETED'` was checked instead of `'CLOSED'` (the actual enum value), causing the gray status badge to never render

## Test plan
- [ ] Log in as MANAGER → Reports → Sprint Velocity → verify overdue sprints show red "Overdue" badge
- [ ] Verify CLOSED sprints show gray badge (not green ACTIVE or blue PLANNING)
- [ ] Verify sprints due within 14 days show "Due soon" amber badge
- [ ] Manager Dashboard → Active Sprints → verify overdue sprint cards show overdue indicator
- [ ] Verify sprints with future end dates show no overdue indicator

Fixes #68