### PR TITLE
fix(#70): add overdue indicator to project phases and deliverables

### DIFF
--- a/frontend/src/pages/project-detail/PhasesTab.tsx
+++ b/frontend/src/pages/project-detail/PhasesTab.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import type { PhaseDto, PhasePaymentDto, DeliverableDto } from '@/types';
 import { listPhases, createPhase, updatePhase, deletePhase, listDeliverables, createDeliverable, updateDeliverable, deleteDeliverable, uploadDeliverableAttachment, deleteDeliverableAttachment, getDeliverableAttachmentDownloadUrl, listPhasePayments, createPhasePayment, updatePhasePayment, deletePhasePayment } from '@/api/phases';
 import axios from 'axios';
-import { formatDate, formatCurrency, deliverableStateBadge, deliverableStateLabel } from '@/utils/format';
+import { formatDate, formatCurrency, deliverableStateBadge, deliverableStateLabel, deadlineBadge, deadlineLabel } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
 import Modal from '@/components/common/Modal';
 
@@ -336,10 +336,15 @@ export default function PhasesTab({ projectId, canEdit }: { projectId: number; c
                         </div>
                       )}
                       {(phase.startDate || phase.endDate) && (
-                        <span className="text-xs text-gray-400">
+                        <span className={`text-xs ${deadlineBadge(phase.endDate, phase.status === 'CLOSED' ? 'CLOSED' : undefined) || 'text-gray-400'}`}>
                           {phase.startDate && formatDate(phase.startDate)}
                           {phase.startDate && phase.endDate && ' → '}
                           {phase.endDate && formatDate(phase.endDate)}
+                        </span>
+                      )}
+                      {deadlineLabel(phase.endDate, phase.status === 'CLOSED' ? 'CLOSED' : undefined) && (
+                        <span className={`ml-1 text-xs px-2 py-0.5 rounded-full font-medium ${deadlineBadge(phase.endDate, phase.status === 'CLOSED' ? 'CLOSED' : undefined)}`}>
+                          {deadlineLabel(phase.endDate, phase.status === 'CLOSED' ? 'CLOSED' : undefined)}
                         </span>
                       )}
                       {canEdit && (
@@ -434,7 +439,12 @@ export default function PhasesTab({ projectId, canEdit }: { projectId: number; c
                                     {deliverableStateLabel(d.state)}
                                   </button>
                                   <span className="text-sm text-gray-900 truncate">{d.name}</span>
-                                  {d.dueDate && <span className="text-xs text-gray-400">Due: {formatDate(d.dueDate)}</span>}
+                                  {d.dueDate && <span className={`text-xs ${deadlineBadge(d.dueDate, d.state === 'VALIDATED' || d.state === 'DELIVERED' ? 'CLOSED' : undefined) || 'text-gray-400'}`}>Due: {formatDate(d.dueDate)}</span>}
+                                  {d.dueDate && deadlineLabel(d.dueDate, d.state === 'VALIDATED' || d.state === 'DELIVERED' ? 'CLOSED' : undefined) && (
+                                    <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${deadlineBadge(d.dueDate, d.state === 'VALIDATED' || d.state === 'DELIVERED' ? 'CLOSED' : undefined)}`}>
+                                      {deadlineLabel(d.dueDate, d.state === 'VALIDATED' || d.state === 'DELIVERED' ? 'CLOSED' : undefined)}
+                                    </span>
+                                  )}
                                 </div>
                                 <div className="flex items-center gap-2">
                                   {canEdit && (


### PR DESCRIPTION
## Summary
- Added `deadlineBadge`/`deadlineLabel` to phase end dates, showing "Overdue" (red) or "Due soon" (amber) badges on past-due phases
- Added the same overdue indicators to deliverable due dates
- CLOSED phases and VALIDATED/DELIVERED deliverables suppress the overdue badge (completed work shouldn't show overdue)
- Uses the same `deadlineBadge`/`deadlineLabel` utility already used by tasks, projects, and sprints

## Test plan
- [ ] Log in as MANAGER → FSE project → Phases tab
- [ ] Verify past-due phases show red "Overdue" badge and red date styling
- [ ] Verify phases due within 14 days show amber "Due soon" badge
- [ ] Verify CLOSED phases do NOT show overdue indicators
- [ ] Verify deliverable due dates also show overdue indicators
- [ ] Verify VALIDATED/DELIVERED deliverables suppress overdue badges
- [ ] `npx tsc --noEmit` passes

Fixes #70