### PR TITLE
fix(#66): use Global consistently instead of Unassigned for group-level projects

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/PmoService.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoService.java
@@ -306,7 +306,7 @@ public class PmoService {
             String companyName;
             String companyKey;
             if (cid == 0L) {
-                companyName = "Unassigned";
+                companyName = "Global";
                 companyKey = "N/A";
             } else {
                 Company c = companyProjects.get(0).getCompany();

--- a/frontend/src/pages/dashboard/ExecutiveDashboard.tsx
+++ b/frontend/src/pages/dashboard/ExecutiveDashboard.tsx
@@ -288,7 +288,7 @@ export default function ExecutiveDashboard() {
             </div>
             <p className="text-sm font-bold text-gray-900">{projects.length} projects</p>
           </button>
-          {companyCards.filter((c) => c.id !== null).map((card) => {
+          {companyCards.map((card) => {
             const cs = companyData.find((c) => c.companyId === card.id);
             const isSelected = selectedCompanyId === card.id;
             return (

--- a/frontend/src/pages/reports/PortfolioReport.tsx
+++ b/frontend/src/pages/reports/PortfolioReport.tsx
@@ -106,7 +106,7 @@ export default function PortfolioReport() {
             </thead>
             <tbody className="divide-y divide-gray-100">
               {companyData.map((c) => (
-                <tr key={c.companyId ?? 'unassigned'} className="hover:bg-gray-50">
+                <tr key={c.companyId ?? 'global'} className="hover:bg-gray-50">
                   <td className="px-5 py-3 font-medium text-gray-900">{c.companyName}</td>
                   <td className="px-3 py-3 text-right text-gray-700">{c.totalProjects}</td>
                   <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(c.totalBudget)}</td>


### PR DESCRIPTION
## Summary
- Changed "Unassigned" → "Global" in `PmoService.getPortfolioByCompany()` so the Portfolio report shows the correct label
- Removed `.filter((c) => c.id !== null)` from the Executive Dashboard company selector so the "Global" tab appears
- Updated PortfolioReport row key from `'unassigned'` to `'global'`

## Test plan
- [ ] Log in as MANAGER → Reports → Portfolio tab → verify "Global" appears instead of "Unassigned" in the company table
- [ ] Log in as EXECUTIVE → Dashboard → verify "Global" company tab is visible in the selector
- [ ] Click "Global" tab → verify it filters to Global company projects
- [ ] Verify other company tabs still work
- [ ] `./gradlew :backend:compileJava` and `npx tsc --noEmit` pass

Fixes #66