### PR TITLE
fix(#77): show Access Denied page for unauthorized routes

### DIFF
--- a/frontend/src/components/common/AccessDenied.tsx
+++ b/frontend/src/components/common/AccessDenied.tsx
@@ -1,0 +1,33 @@
+import { useAuthStore } from '@/stores/authStore';
+
+interface AccessDeniedProps {
+  requiredRoles?: string[];
+}
+
+export default function AccessDenied({ requiredRoles }: AccessDeniedProps) {
+  const user = useAuthStore((s) => s.user);
+  const roleLabel = requiredRoles?.length
+    ? requiredRoles.join(', ')
+    : 'ADMIN';
+
+  return (
+    <div className="flex items-center justify-center min-h-[60vh]">
+      <div className="text-center max-w-md">
+        <div className="mx-auto w-16 h-16 rounded-full bg-red-100 flex items-center justify-center mb-4">
+          <svg className="w-8 h-8 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+          </svg>
+        </div>
+        <h2 className="text-xl font-semibold text-gray-900 mb-2">Access Denied</h2>
+        <p className="text-gray-500 mb-4">
+          You don't have permission to access this page.
+        </p>
+        {user && (
+          <p className="text-sm text-gray-400">
+            Your role ({user.role}) requires one of: {roleLabel}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/guards/AdminGuard.tsx
+++ b/frontend/src/components/guards/AdminGuard.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom';
+import AccessDenied from '@/components/common/AccessDenied';
 import { useAuthStore } from '@/stores/authStore';
 
 export default function AdminGuard({ children }: { children: React.ReactNode }) {
@@ -8,7 +8,7 @@ export default function AdminGuard({ children }: { children: React.ReactNode }) 
   if (isLoading) return null;
 
   if (user?.role !== 'ADMIN') {
-    return <Navigate to="/" replace />;
+    return <AccessDenied requiredRoles={['ADMIN']} />;
   }
 
   return <>{children}</>;

--- a/frontend/src/components/guards/RoleGuard.tsx
+++ b/frontend/src/components/guards/RoleGuard.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom';
+import AccessDenied from '@/components/common/AccessDenied';
 import { useAuthStore } from '@/stores/authStore';
 
 type Role = 'ADMIN' | 'MANAGER' | 'EXECUTIVE' | 'CONTRIBUTOR' | 'EXTERNAL' | 'HR';
@@ -15,7 +15,7 @@ export default function RoleGuard({ roles, children }: RoleGuardProps) {
   if (isLoading) return null;
 
   if (!user || !roles.includes(user.role)) {
-    return <Navigate to="/" replace />;
+    return <AccessDenied requiredRoles={roles} />;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
## Summary

- Added `AccessDenied` component that shows a clear "Access Denied" message with the user's current role and the required roles
- Updated `RoleGuard` and `AdminGuard` to render `AccessDenied` instead of silently redirecting to `/`
- Users now see explicit feedback when they navigate to a restricted URL, instead of being silently redirected

## Before

Navigating to `/reports` as CONTRIBUTOR or EXTERNAL → silent redirect to `/` with no explanation

## After

Navigating to `/reports` as CONTRIBUTOR → "Access Denied — You don't have permission to access this page. Your role (CONTRIBUTOR) requires one of: ADMIN, MANAGER, EXECUTIVE, HR"

## Test plan

- [ ] Log in as ismail (CONTRIBUTOR) → navigate to `/reports` → see Access Denied page
- [ ] Log in as basma (EXTERNAL) → navigate to `/pmo` → see Access Denied page
- [ ] Log in as admin (ADMIN) → navigate to `/reports` → see reports page (unchanged)
- [ ] Log in as salim (EXECUTIVE) → navigate to `/reports` → see reports page (unchanged)
- [ ] Unknown routes (e.g. `/foo`) still redirect to `/` (unchanged)

Fixes #77