### PR TITLE
fix(#81): group Log Time task dropdown by project name

### DIFF
--- a/frontend/src/pages/MyTimePage.tsx
+++ b/frontend/src/pages/MyTimePage.tsx
@@ -57,16 +57,22 @@ export default function MyTimePage() {
     );
   }, [myTasks]);
 
-  // Group open tasks by project for the dropdown
+  // Group open tasks by project name for the dropdown
+  const projectNames = useMemo(() => {
+    const map: Record<number, string> = {};
+    for (const p of projects) map[p.id] = p.name;
+    return map;
+  }, [projects]);
+
   const tasksByProject = useMemo(() => {
     const groups: Record<string, TaskDto[]> = {};
     for (const task of openTasks) {
-      const key = task.projectKey || `Project ${task.projectId}`;
-      if (!groups[key]) groups[key] = [];
-      groups[key].push(task);
+      const label = projectNames[task.projectId] || task.projectKey || `Project ${task.projectId}`;
+      if (!groups[label]) groups[label] = [];
+      groups[label].push(task);
     }
     return groups;
-  }, [openTasks]);
+  }, [openTasks, projectNames]);
 
   const fetchWeek = useCallback(async () => {
     if (!user) return;


### PR DESCRIPTION
## Summary

- Changed the Log Time task dropdown to group tasks by full project name (e.g., "API Gateway") instead of project key (e.g., "AG")
- Built a `projectId → projectName` map from the `projects` array in `useMyTasks` and used it for `<optgroup>` labels

## Before

Task dropdown showed groups labeled with cryptic project keys: "FSE", "AG", "MA"

## After

Task dropdown shows groups labeled with readable project names: "FSE", "API Gateway", "Mobile App"

## Test plan

- [ ] Log in as ismail (CONTRIBUTOR) → My Time → Log Time → Task dropdown shows optgroups with project names
- [ ] Log in as hanane (CONTRIBUTOR) → My Time → Log Time → Task dropdown shows tasks grouped by project
- [ ] Log in as admin → same view works correctly

Fixes #81