### PR TITLE
fix(#79): hide budget and strategic score from EXTERNAL role

### DIFF
--- a/frontend/src/pages/project-detail/index.tsx
+++ b/frontend/src/pages/project-detail/index.tsx
@@ -85,8 +85,8 @@ export default function ProjectDetailPage() {
           <span>Manager: {project.managerName}</span>
           {project.clientName && <span>Client: {project.clientName}</span>}
           {project.programName && <span>Program: {project.programName}</span>}
-          {project.budget && <span>Budget: {formatCurrency(Number(project.budget))}</span>}
-          {project.strategicScore != null && <span>Score: {project.strategicScore}/10</span>}
+          {!isExternal && project.budget && <span>Budget: {formatCurrency(Number(project.budget))}</span>}
+          {!isExternal && project.strategicScore != null && <span>Score: {project.strategicScore}/10</span>}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- Budget and strategic score fields in the project header are now hidden from EXTERNAL role users
- Uses the existing `isExternal` flag that was already computed in the component

## Before

EXTERNAL user sees: `Budget: DH 500,000.00 | Score: 8/10` in the project header

## After

EXTERNAL user sees: `Manager: Majid Hassan | Client: CNSS | Program: eHealth` (no budget/score)

## Test plan

- [ ] Log in as basma (EXTERNAL) → FSE project → header shows no Budget or Score
- [ ] Log in as admin (ADMIN) → FSE project → header shows Budget and Score
- [ ] Log in as ismail (CONTRIBUTOR) → FSE project → header shows Budget and Score

Fixes #79