### PR TITLE
fix(#92): MANAGER role leaks cross-company data in Portfolio/PMO

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/PmoController.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoController.java
@@ -1,8 +1,11 @@
 package com.nemo.pmo;
 
 import com.nemo.common.dto.ApiResponse;
+import com.nemo.security.AuthHelper;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -13,10 +16,12 @@ public class PmoController {
 
     private final PmoService pmoService;
     private final RaidItemMapper raidItemMapper;
+    private final AuthHelper authHelper;
 
-    public PmoController(PmoService pmoService, RaidItemMapper raidItemMapper) {
+    public PmoController(PmoService pmoService, RaidItemMapper raidItemMapper, AuthHelper authHelper) {
         this.pmoService = pmoService;
         this.raidItemMapper = raidItemMapper;
+        this.authHelper = authHelper;
     }
 
     @GetMapping("/evm/{projectId}")
@@ -27,27 +32,35 @@ public class PmoController {
 
     @GetMapping("/portfolio")
     @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
-    public ResponseEntity<ApiResponse<PmoService.PortfolioSummary>> getPortfolioSummary() {
-        return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioSummary()));
+    public ResponseEntity<ApiResponse<PmoService.PortfolioSummary>> getPortfolioSummary(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN") ? null : authHelper.getCurrentCompanyId(currentUser);
+        return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioSummary(companyId)));
     }
 
     @GetMapping("/raid")
     @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
     public ResponseEntity<ApiResponse<List<RaidItemDto>>> getPortfolioRaidItems(
-            @RequestParam(required = false) RaidItem.RaidType type) {
-        List<RaidItem> items = pmoService.getPortfolioRaidItems(type);
+            @RequestParam(required = false) RaidItem.RaidType type,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN") ? null : authHelper.getCurrentCompanyId(currentUser);
+        List<RaidItem> items = pmoService.getPortfolioRaidItems(type, companyId);
         return ResponseEntity.ok(ApiResponse.of(raidItemMapper.toDtoList(items)));
     }
 
     @GetMapping("/portfolio/by-company")
     @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
-    public ResponseEntity<ApiResponse<List<PmoService.CompanyPortfolioSummary>>> getPortfolioByCompany() {
-        return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioByCompany()));
+    public ResponseEntity<ApiResponse<List<PmoService.CompanyPortfolioSummary>>> getPortfolioByCompany(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN") ? null : authHelper.getCurrentCompanyId(currentUser);
+        return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioByCompany(companyId)));
     }
 
     @GetMapping("/portfolio/timeline")
     @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
-    public ResponseEntity<ApiResponse<List<PmoService.ProjectTimelineEntry>>> getPortfolioTimeline() {
-        return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioTimeline()));
+    public ResponseEntity<ApiResponse<List<PmoService.ProjectTimelineEntry>>> getPortfolioTimeline(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN") ? null : authHelper.getCurrentCompanyId(currentUser);
+        return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioTimeline(companyId)));
     }
 }

--- a/backend/src/main/java/com/nemo/pmo/PmoService.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoService.java
@@ -199,8 +199,8 @@ public class PmoService {
     ) {}
 
     @Transactional(readOnly = true)
-    public PortfolioSummary getPortfolioSummary() {
-        List<Project> projects = projectRepository.findAll();
+    public PortfolioSummary getPortfolioSummary(Long companyId) {
+        List<Project> projects = projectRepository.findAllByCompanyIdOrNull(companyId);
 
         int totalProjects = projects.size();
         long totalTasks = 0;
@@ -284,8 +284,8 @@ public class PmoService {
     ) {}
 
     @Transactional(readOnly = true)
-    public List<CompanyPortfolioSummary> getPortfolioByCompany() {
-        List<Project> projects = projectRepository.findAll();
+    public List<CompanyPortfolioSummary> getPortfolioByCompany(Long companyId) {
+        List<Project> projects = projectRepository.findAllByCompanyIdOrNull(companyId);
 
         List<TaskStatus> completedStatuses = new java.util.ArrayList<>();
         completedStatuses.addAll(taskStatusRepository.findByCategory(TaskStatus.Category.DONE));
@@ -356,11 +356,11 @@ public class PmoService {
     }
 
     @Transactional(readOnly = true)
-    public List<RaidItem> getPortfolioRaidItems(RaidItem.RaidType type) {
+    public List<RaidItem> getPortfolioRaidItems(RaidItem.RaidType type, Long companyId) {
         if (type != null) {
-            return raidItemRepository.findByType(type);
+            return raidItemRepository.findByCompanyIdAndType(companyId, type);
         }
-        return raidItemRepository.findAll();
+        return raidItemRepository.findByCompanyIdOrNull(companyId);
     }
 
     public record PhaseTimelineEntry(
@@ -378,8 +378,8 @@ public class PmoService {
     ) {}
 
     @Transactional(readOnly = true)
-    public List<ProjectTimelineEntry> getPortfolioTimeline() {
-        List<Project> projects = projectRepository.findAll();
+    public List<ProjectTimelineEntry> getPortfolioTimeline(Long companyId) {
+        List<Project> projects = projectRepository.findAllByCompanyIdOrNull(companyId);
         List<Long> projectIds = projects.stream().map(Project::getId).toList();
         List<Phase> allPhases = projectIds.isEmpty() ? List.of() : phaseRepository.findByProjectIdInOrderByProjectIdAscPositionAsc(projectIds);
 

--- a/backend/src/main/java/com/nemo/pmo/RaidItemRepository.java
+++ b/backend/src/main/java/com/nemo/pmo/RaidItemRepository.java
@@ -1,6 +1,8 @@
 package com.nemo.pmo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -19,4 +21,10 @@ public interface RaidItemRepository extends JpaRepository<RaidItem, Long> {
     long countByProjectIdAndType(Long projectId, RaidItem.RaidType type);
 
     long countByProjectIdAndStatus(Long projectId, RaidItem.RaidStatus status);
+
+    @Query("SELECT r FROM RaidItem r WHERE (:companyId IS NULL OR r.project.company.id = :companyId OR r.project.company.id IS NULL)")
+    List<RaidItem> findByCompanyIdOrNull(@Param("companyId") Long companyId);
+
+    @Query("SELECT r FROM RaidItem r WHERE (:companyId IS NULL OR r.project.company.id = :companyId OR r.project.company.id IS NULL) AND (:type IS NULL OR r.type = :type)")
+    List<RaidItem> findByCompanyIdAndType(@Param("companyId") Long companyId, @Param("type") RaidItem.RaidType type);
 }

--- a/backend/src/main/java/com/nemo/project/ProjectRepository.java
+++ b/backend/src/main/java/com/nemo/project/ProjectRepository.java
@@ -25,4 +25,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
 
     @Query("SELECT p FROM Project p WHERE (:companyId IS NULL OR p.company.id = :companyId OR p.company.id IS NULL)")
     Page<Project> findByCompanyIdOrNull(Long companyId, Pageable pageable);
+
+    @Query("SELECT p FROM Project p WHERE (:companyId IS NULL OR p.company.id = :companyId OR p.company.id IS NULL)")
+    List<Project> findAllByCompanyIdOrNull(Long companyId);
 }

--- a/backend/src/main/java/com/nemo/timetracking/ReportController.java
+++ b/backend/src/main/java/com/nemo/timetracking/ReportController.java
@@ -3,11 +3,14 @@ package com.nemo.timetracking;
 import com.nemo.common.dto.ApiResponse;
 import com.nemo.project.Project;
 import com.nemo.project.ProjectRepository;
+import com.nemo.security.AuthHelper;
 import com.nemo.user.User;
 import com.nemo.user.UserRepository;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
@@ -23,11 +26,18 @@ public class ReportController {
     private final TimeLogRepository timeLogRepository;
     private final UserRepository userRepository;
     private final ProjectRepository projectRepository;
+    private final AuthHelper authHelper;
 
-    public ReportController(TimeLogRepository timeLogRepository, UserRepository userRepository, ProjectRepository projectRepository) {
+    public ReportController(TimeLogRepository timeLogRepository, UserRepository userRepository,
+                            ProjectRepository projectRepository, AuthHelper authHelper) {
         this.timeLogRepository = timeLogRepository;
         this.userRepository = userRepository;
         this.projectRepository = projectRepository;
+        this.authHelper = authHelper;
+    }
+
+    private Long resolveCompanyId(UserDetails currentUser) {
+        return authHelper.hasAnyRole(currentUser, "ADMIN") ? null : authHelper.getCurrentCompanyId(currentUser);
     }
 
     @GetMapping("/time-by-project")
@@ -36,15 +46,17 @@ public class ReportController {
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @RequestParam(required = false) Long projectId,
-            @RequestParam(required = false) Long userId) {
+            @RequestParam(required = false) Long userId,
+            @AuthenticationPrincipal UserDetails currentUser) {
 
+        Long companyId = resolveCompanyId(currentUser);
         List<TimeLog> logs;
         if (userId != null) {
             logs = timeLogRepository.findByUserIdAndDateRange(userId, startDate, endDate);
         } else if (projectId != null) {
             logs = timeLogRepository.findByProjectIdAndDateRange(projectId, startDate, endDate);
         } else {
-            logs = timeLogRepository.findByDateRange(startDate, endDate);
+            logs = timeLogRepository.findByDateRangeAndCompany(startDate, endDate, companyId);
         }
 
         Map<Long, BigDecimal> byProject = logs.stream()
@@ -75,15 +87,17 @@ public class ReportController {
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @RequestParam(required = false) Long projectId,
-            @RequestParam(required = false) Long userId) {
+            @RequestParam(required = false) Long userId,
+            @AuthenticationPrincipal UserDetails currentUser) {
 
+        Long companyId = resolveCompanyId(currentUser);
         List<TimeLog> logs;
         if (userId != null) {
             logs = timeLogRepository.findByUserIdAndDateRange(userId, startDate, endDate);
         } else if (projectId != null) {
             logs = timeLogRepository.findByProjectIdAndDateRange(projectId, startDate, endDate);
         } else {
-            logs = timeLogRepository.findByDateRange(startDate, endDate);
+            logs = timeLogRepository.findByDateRangeAndCompany(startDate, endDate, companyId);
         }
 
         Map<Long, BigDecimal> byUser = logs.stream()
@@ -136,9 +150,11 @@ public class ReportController {
     @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
     public ResponseEntity<ApiResponse<Map<String, Object>>> attendance(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @AuthenticationPrincipal UserDetails currentUser) {
 
-        List<TimeLog> logs = timeLogRepository.findByDateRange(startDate, endDate);
+        Long companyId = resolveCompanyId(currentUser);
+        List<TimeLog> logs = timeLogRepository.findByDateRangeAndCompany(startDate, endDate, companyId);
 
         // Group by user
         Map<Long, List<TimeLog>> byUser = logs.stream()
@@ -222,7 +238,7 @@ public class ReportController {
         }
 
         // Overall summary
-        long totalInternalUsers = userRepository.countByActiveStatus().stream()
+        long totalInternalUsers = userRepository.countByActiveStatusByCompany(companyId).stream()
                 .filter(r -> Boolean.TRUE.equals(r[0]))
                 .mapToLong(r -> (Long) r[1])
                 .sum();
@@ -238,14 +254,17 @@ public class ReportController {
 
     @GetMapping("/headcount")
     @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> headcount() {
+    public ResponseEntity<ApiResponse<Map<String, Object>>> headcount(
+            @AuthenticationPrincipal UserDetails currentUser) {
 
-        long totalUsers = userRepository.count();
-        long activeUsers = userRepository.countByActive(true);
-        long inactiveUsers = userRepository.countByActive(false);
+        Long companyId = resolveCompanyId(currentUser);
+
+        long totalUsers = userRepository.countByCompanyOrNull(companyId);
+        long activeUsers = userRepository.countByActiveAndCompany(true, companyId);
+        long inactiveUsers = userRepository.countByActiveAndCompany(false, companyId);
 
         // By role
-        List<Object[]> roleCounts = userRepository.countByRole();
+        List<Object[]> roleCounts = userRepository.countByRoleByCompany(companyId);
         List<Map<String, Object>> byRole = new ArrayList<>();
         for (Object[] row : roleCounts) {
             Map<String, Object> entry = new LinkedHashMap<>();
@@ -265,7 +284,7 @@ public class ReportController {
         }
 
         // By company
-        List<Object[]> companyCounts = userRepository.countByCompany();
+        List<Object[]> companyCounts = userRepository.countByCompanyFiltered(companyId);
         List<Map<String, Object>> byCompany = new ArrayList<>();
         for (Object[] row : companyCounts) {
             Map<String, Object> entry = new LinkedHashMap<>();
@@ -276,7 +295,7 @@ public class ReportController {
         }
 
         // By active status
-        List<Object[]> activeCounts = userRepository.countByActiveStatus();
+        List<Object[]> activeCounts = userRepository.countByActiveStatusByCompany(companyId);
         List<Map<String, Object>> byActiveStatus = new ArrayList<>();
         for (Object[] row : activeCounts) {
             Map<String, Object> entry = new LinkedHashMap<>();

--- a/backend/src/main/java/com/nemo/timetracking/TimeLogRepository.java
+++ b/backend/src/main/java/com/nemo/timetracking/TimeLogRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -39,4 +40,8 @@ public interface TimeLogRepository extends JpaRepository<TimeLog, Long> {
     List<Long> findDistinctUserIdsByDateRange(LocalDate startDate, LocalDate endDate);
 
     List<TimeLog> findByPresaleId(Long presaleId);
+
+    @Query("SELECT tl FROM TimeLog tl WHERE tl.logDate BETWEEN :startDate AND :endDate " +
+           "AND (:companyId IS NULL OR tl.task.project.company.id = :companyId OR tl.task.project.company.id IS NULL)")
+    List<TimeLog> findByDateRangeAndCompany(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate, @Param("companyId") Long companyId);
 }

--- a/backend/src/main/java/com/nemo/user/UserRepository.java
+++ b/backend/src/main/java/com/nemo/user/UserRepository.java
@@ -53,4 +53,19 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u.active, COUNT(u) FROM User u WHERE u.role <> 'EXTERNAL' GROUP BY u.active")
     List<Object[]> countByActiveStatus();
+
+    @Query("SELECT u.role, COUNT(u) FROM User u WHERE (:companyId IS NULL OR u.company.id = :companyId OR u.company.id IS NULL) GROUP BY u.role")
+    List<Object[]> countByRoleByCompany(Long companyId);
+
+    @Query("SELECT u.company.name, COUNT(u) FROM User u WHERE u.role <> 'EXTERNAL' AND (:companyId IS NULL OR u.company.id = :companyId OR u.company.id IS NULL) GROUP BY u.company.name")
+    List<Object[]> countByCompanyFiltered(Long companyId);
+
+    @Query("SELECT u.active, COUNT(u) FROM User u WHERE u.role <> 'EXTERNAL' AND (:companyId IS NULL OR u.company.id = :companyId OR u.company.id IS NULL) GROUP BY u.active")
+    List<Object[]> countByActiveStatusByCompany(Long companyId);
+
+    @Query("SELECT COUNT(u) FROM User u WHERE (:companyId IS NULL OR u.company.id = :companyId OR u.company.id IS NULL)")
+    long countByCompanyOrNull(Long companyId);
+
+    @Query("SELECT COUNT(u) FROM User u WHERE u.active = :active AND (:companyId IS NULL OR u.company.id = :companyId OR u.company.id IS NULL)")
+    long countByActiveAndCompany(boolean active, Long companyId);
 }


### PR DESCRIPTION
## Summary
- PMO endpoints (`/api/pmo/portfolio`, `/api/pmo/raid`, `/api/pmo/portfolio/by-company`, `/api/pmo/portfolio/timeline`) and Report endpoints (`/api/reports/time-by-project`, `/api/reports/time-by-user`, `/api/reports/attendance`, `/api/reports/headcount`) returned unscoped data to any MANAGER/EXECUTIVE/HR user, exposing cross-company data
- Added `AuthHelper` injection to both `PmoController` and `ReportController`; each endpoint now resolves the authenticated user's company and passes it to new company-scoped repository queries
- ADMIN users (companyId=null) see all data; MANAGER/EXECUTIVE/HR see only their company's data

## Changes
- `PmoController` — inject AuthHelper, resolve companyId per endpoint, pass to service
- `PmoService` — accept `Long companyId` in `getPortfolioSummary`, `getPortfolioByCompany`, `getPortfolioRaidItems`, `getPortfolioTimeline`
- `ReportController` — inject AuthHelper + `resolveCompanyId()` helper, use scoped queries in time-by-project, time-by-user, attendance, headcount
- `ProjectRepository` — added `findAllByCompanyIdOrNull(Long)` (List variant)
- `RaidItemRepository` — added `findByCompanyIdOrNull`, `findByCompanyIdAndType`
- `TimeLogRepository` — added `findByDateRangeAndCompany`
- `UserRepository` — added `countByRoleByCompany`, `countByCompanyFiltered`, `countByActiveStatusByCompany`, `countByCompanyOrNull`, `countByActiveAndCompany`

## Test plan
- [ ] Login as ADMIN → verify all PMO and report endpoints return full cross-company data
- [ ] Login as MANAGER → verify portfolio summary, RAID items, timeline, and all report endpoints return only their company's data
- [ ] Verify headcount report shows only the MANAGER's company users and counts

Fixes #92