### PR TITLE
fix(#93): deep-linking to project sub-tab URL activates correct tab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,6 +73,7 @@ export default function App() {
           <Route path="/programs/:id" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR']}><ProgramDetailPage /></RoleGuard>} />
           <Route path="/projects" element={<ProjectsPage />} />
           <Route path="/projects/:id" element={<ProjectDetailPage />} />
+          <Route path="/projects/:id/:tab" element={<ProjectDetailPage />} />
           <Route path="/projects/:projectId/tasks/:taskId" element={<TaskDetailPage />} />
           <Route path="/my-time" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'CONTRIBUTOR']}><MyTimePage /></RoleGuard>} />
           <Route path="/timesheets" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'HR']}><TimesheetsPage /></RoleGuard>} />

--- a/frontend/src/pages/project-detail/index.tsx
+++ b/frontend/src/pages/project-detail/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import type { ProjectDto, WikiTreeItem, WikiPageDto, WikiSearchHit } from '@/types';
 import { getProject } from '@/api/projects';
 import { getWikiPageTree, getWikiPage, createWikiPage, updateWikiPage, deleteWikiPage, searchWikiPages } from '@/api/wiki';
@@ -21,31 +21,17 @@ import MarkdownRenderer from '@/components/common/MarkdownRenderer';
 type Tab = 'summary' | 'tasks' | 'board' | 'docs' | 'raid' | 'phases' | 'members' | 'settings' | 'sprints';
 
 export default function ProjectDetailPage() {
-  const { id } = useParams<{ id: string }>();
+  const { id, tab: tabParam } = useParams<{ id: string; tab?: string }>();
+  const navigate = useNavigate();
   const [project, setProject] = useState<ProjectDto | null>(null);
   const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState<Tab>('summary');
   const { user } = useAuth();
   const role = user?.role;
   const canEdit = role === 'ADMIN' || role === 'MANAGER';
   const isExternal = role === 'EXTERNAL';
   const canSeeScores = canEdit || role === 'EXECUTIVE' || role === 'HR';
 
-  useEffect(() => {
-    if (!id) return;
-    setLoading(true);
-    getProject(Number(id)).then(setProject).finally(() => setLoading(false));
-  }, [id]);
-
-  if (loading) return <div className="flex items-center justify-center h-64"><Spinner className="h-8 w-8 text-primary-600" /></div>;
-  if (!project) return <div className="text-center text-gray-500 py-8">Project not found.</div>;
-
-  // Role-based tab visibility:
-  // EXECUTIVE: summary, board, raid, docs
-  // MANAGER:   summary, board, raid, tasks, docs, phases, members, settings
-  // HR:        summary, members, docs
-  // CONTRIBUTOR: tasks, board, docs
-  // EXTERNAL: tasks, board (existing behavior)
+  // Build role-based tab list
   const tabs: { key: Tab; label: string }[] = role === 'EXECUTIVE' ? [
     { key: 'summary', label: 'Summary' },
     { key: 'board', label: 'Board' },
@@ -75,6 +61,35 @@ export default function ProjectDetailPage() {
     { key: 'board', label: 'Board' },
     { key: 'sprints', label: 'Sprints' },
   ];
+
+  const validTabKeys = tabs.map((t) => t.key);
+  const resolvedTab = (tabParam && validTabKeys.includes(tabParam as Tab)) ? (tabParam as Tab) : validTabKeys[0];
+  const [activeTab, setActiveTabState] = useState<Tab>(resolvedTab);
+
+  // Sync active tab with URL param changes (e.g. browser back/forward)
+  useEffect(() => {
+    if (tabParam && validTabKeys.includes(tabParam as Tab)) {
+      setActiveTabState(tabParam as Tab);
+    } else if (!tabParam) {
+      setActiveTabState(validTabKeys[0]);
+      // Add tab segment to URL so deep links work for the current tab
+      navigate(`/projects/${id}/${validTabKeys[0]}`, { replace: true });
+    }
+  }, [tabParam, validTabKeys.join(',')]);
+
+  const setActiveTab = (tab: Tab) => {
+    setActiveTabState(tab);
+    navigate(`/projects/${id}/${tab}`, { replace: true });
+  };
+
+  useEffect(() => {
+    if (!id) return;
+    setLoading(true);
+    getProject(Number(id)).then(setProject).finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) return <div className="flex items-center justify-center h-64"><Spinner className="h-8 w-8 text-primary-600" /></div>;
+  if (!project) return <div className="text-center text-gray-500 py-8">Project not found.</div>;
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- No route existed for `/projects/:id/:tab`, so sub-tab URLs fell through to the catch-all redirect to `/`
- Added `/projects/:id/:tab` route in App.tsx
- ProjectDetailPage now reads `:tab` from URL params, syncs with browser navigation, and updates the URL on tab switch
- Invalid tab values fall back to the role's default tab; visiting `/projects/:id` (no tab) redirects to the default

## Test plan
- [ ] Navigate directly to `/projects/1/sprints` — should open project 1 with Sprints tab active
- [ ] Navigate directly to `/projects/1/budget` — should open project 1 with default tab (budget not a tab, falls back)
- [ ] Click different tabs — URL should update to `/projects/:id/:tab`
- [ ] Use browser back/forward — tab should sync with URL
- [ ] Visit `/projects/:id` (no tab) — should redirect to `/projects/:id/:defaultTab`
- [ ] All 6+ project tabs work as deep links: tasks, board, sprints, docs, phases, members, settings, raid, summary

Fixes #93