### PR TITLE
fix(#95): CPI shows as 0.00 for projects with no EVM activity

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/PmoService.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoService.java
@@ -116,8 +116,8 @@ public class PmoService {
         BigDecimal pvToday = computePlannedValueToday(project, plannedValue);
         BigDecimal scheduleVariance = earnedValue.subtract(pvToday).setScale(2, RoundingMode.HALF_UP);
 
-        // CPI = EV / AC (null when AC = 0 — no costs recorded yet)
-        BigDecimal cpi = actualCost.compareTo(BigDecimal.ZERO) > 0
+        // CPI = EV / AC (null when EV = 0 or AC = 0 — no meaningful ratio)
+        BigDecimal cpi = earnedValue.compareTo(BigDecimal.ZERO) > 0 && actualCost.compareTo(BigDecimal.ZERO) > 0
                 ? earnedValue.divide(actualCost, 2, RoundingMode.HALF_UP)
                 : null;
 


### PR DESCRIPTION
## Summary
- CPI was computed as `EV/AC` which returned `0.00` when EV=0 but AC>0 (e.g. projects with budget/expenses but no completed tasks), triggering false "CPI 0.00" attention alerts on the Executive dashboard
- Changed CPI to return `null` when EV=0 (matching the existing SPI logic), so it displays as "—" and is excluded from attention alerts
- When both EV=0 and AC=0: CPI=null → shows "—", no alert
- When EV>0 and AC=0: CPI=null → shows "—" (ahead of budget, not flagged)
- When EV>0 and AC>0: CPI=EV/AC → normal behavior, flagged if <0.9

## Test plan
- [ ] Log in as EXECUTIVE — projects with no completed tasks (EV=0) no longer show "CPI 0.00" in Attention Needed
- [ ] Portfolio report shows "—" for CPI on projects with no EVM data
- [ ] Project detail Summary tab shows "—" for CPI on projects with no EVM data
- [ ] Projects with actual EVM data (EV>0, AC>0) still show CPI values and low-CPI alerts correctly

Fixes #95