### PR TITLE
fix(#92): remove IS NULL fallback to prevent Global project leak for MANAGER

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/RaidItemRepository.java
+++ b/backend/src/main/java/com/nemo/pmo/RaidItemRepository.java
@@ -22,9 +22,9 @@ public interface RaidItemRepository extends JpaRepository<RaidItem, Long> {
 
     long countByProjectIdAndStatus(Long projectId, RaidItem.RaidStatus status);
 
-    @Query("SELECT r FROM RaidItem r WHERE (:companyId IS NULL OR r.project.company.id = :companyId OR r.project.company.id IS NULL)")
+    @Query("SELECT r FROM RaidItem r WHERE (:companyId IS NULL OR r.project.company.id = :companyId)")
     List<RaidItem> findByCompanyIdOrNull(@Param("companyId") Long companyId);
 
-    @Query("SELECT r FROM RaidItem r WHERE (:companyId IS NULL OR r.project.company.id = :companyId OR r.project.company.id IS NULL) AND (:type IS NULL OR r.type = :type)")
+    @Query("SELECT r FROM RaidItem r WHERE (:companyId IS NULL OR r.project.company.id = :companyId) AND (:type IS NULL OR r.type = :type)")
     List<RaidItem> findByCompanyIdAndType(@Param("companyId") Long companyId, @Param("type") RaidItem.RaidType type);
 }

--- a/backend/src/main/java/com/nemo/project/ProjectRepository.java
+++ b/backend/src/main/java/com/nemo/project/ProjectRepository.java
@@ -23,9 +23,9 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
            "AND (:companyId IS NULL OR p.company.id = :companyId OR p.company.id IS NULL)")
     Page<Project> findByMemberUserIdAndCompany(Long userId, Long companyId, Pageable pageable);
 
-    @Query("SELECT p FROM Project p WHERE (:companyId IS NULL OR p.company.id = :companyId OR p.company.id IS NULL)")
+    @Query("SELECT p FROM Project p WHERE (:companyId IS NULL OR p.company.id = :companyId)")
     Page<Project> findByCompanyIdOrNull(Long companyId, Pageable pageable);
 
-    @Query("SELECT p FROM Project p WHERE (:companyId IS NULL OR p.company.id = :companyId OR p.company.id IS NULL)")
+    @Query("SELECT p FROM Project p WHERE (:companyId IS NULL OR p.company.id = :companyId)")
     List<Project> findAllByCompanyIdOrNull(Long companyId);
 }

--- a/backend/src/main/java/com/nemo/timetracking/TimeLogRepository.java
+++ b/backend/src/main/java/com/nemo/timetracking/TimeLogRepository.java
@@ -42,6 +42,6 @@ public interface TimeLogRepository extends JpaRepository<TimeLog, Long> {
     List<TimeLog> findByPresaleId(Long presaleId);
 
     @Query("SELECT tl FROM TimeLog tl WHERE tl.logDate BETWEEN :startDate AND :endDate " +
-           "AND (:companyId IS NULL OR tl.task.project.company.id = :companyId OR tl.task.project.company.id IS NULL)")
+           "AND (:companyId IS NULL OR tl.task.project.company.id = :companyId)")
     List<TimeLog> findByDateRangeAndCompany(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate, @Param("companyId") Long companyId);
 }

--- a/backend/src/main/java/com/nemo/user/UserRepository.java
+++ b/backend/src/main/java/com/nemo/user/UserRepository.java
@@ -54,18 +54,18 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u.active, COUNT(u) FROM User u WHERE u.role <> 'EXTERNAL' GROUP BY u.active")
     List<Object[]> countByActiveStatus();
 
-    @Query("SELECT u.role, COUNT(u) FROM User u WHERE (:companyId IS NULL OR u.company.id = :companyId OR u.company.id IS NULL) GROUP BY u.role")
+    @Query("SELECT u.role, COUNT(u) FROM User u WHERE (:companyId IS NULL OR u.company.id = :companyId) GROUP BY u.role")
     List<Object[]> countByRoleByCompany(Long companyId);
 
-    @Query("SELECT u.company.name, COUNT(u) FROM User u WHERE u.role <> 'EXTERNAL' AND (:companyId IS NULL OR u.company.id = :companyId OR u.company.id IS NULL) GROUP BY u.company.name")
+    @Query("SELECT u.company.name, COUNT(u) FROM User u WHERE u.role <> 'EXTERNAL' AND (:companyId IS NULL OR u.company.id = :companyId) GROUP BY u.company.name")
     List<Object[]> countByCompanyFiltered(Long companyId);
 
-    @Query("SELECT u.active, COUNT(u) FROM User u WHERE u.role <> 'EXTERNAL' AND (:companyId IS NULL OR u.company.id = :companyId OR u.company.id IS NULL) GROUP BY u.active")
+    @Query("SELECT u.active, COUNT(u) FROM User u WHERE u.role <> 'EXTERNAL' AND (:companyId IS NULL OR u.company.id = :companyId) GROUP BY u.active")
     List<Object[]> countByActiveStatusByCompany(Long companyId);
 
-    @Query("SELECT COUNT(u) FROM User u WHERE (:companyId IS NULL OR u.company.id = :companyId OR u.company.id IS NULL)")
+    @Query("SELECT COUNT(u) FROM User u WHERE (:companyId IS NULL OR u.company.id = :companyId)")
     long countByCompanyOrNull(Long companyId);
 
-    @Query("SELECT COUNT(u) FROM User u WHERE u.active = :active AND (:companyId IS NULL OR u.company.id = :companyId OR u.company.id IS NULL)")
+    @Query("SELECT COUNT(u) FROM User u WHERE u.active = :active AND (:companyId IS NULL OR u.company.id = :companyId)")
     long countByActiveAndCompany(boolean active, Long companyId);
 }


### PR DESCRIPTION
## Summary
- Company-scoped repository queries used `OR company.id IS NULL` which leaked Global (null-companyId) projects/users to all MANAGERs
- Removed the IS NULL fallback from PMO and report-scoped queries (ProjectRepository, RaidItemRepository, TimeLogRepository, UserRepository)
- ADMIN still sees everything via `:companyId IS NULL` condition; MANAGER/EXECUTIVE/HR now see only their own company's data
- The existing `searchByCompanyOrGlobal` and `findByCompanyOrGlobal` queries intentionally keep the IS NULL fallback for People page use cases

## Test plan
- [ ] Log in as MANAGER (majid) → Portfolio report shows only Sione projects, not Global's Data Warehouse/Infrastructure Upgrade
- [ ] PMO Dashboard total projects matches only the MANAGER's company
- [ ] Time Reports show only the MANAGER's company projects
- [ ] Headcount report shows only the MANAGER's company users
- [ ] Log in as ADMIN → still sees all companies/projects

Fixes #92