### PR TITLE
fix(#104): CPI/SPI regression — return 0.00 for projects with costs but no progress

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/PmoService.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoService.java
@@ -127,15 +127,27 @@ public class PmoService {
         BigDecimal pvToday = computePlannedValueToday(project, plannedValue);
         BigDecimal scheduleVariance = earnedValue.subtract(pvToday).setScale(2, RoundingMode.HALF_UP);
 
-        // CPI = EV / AC (null when EV = 0 or AC = 0 — no meaningful ratio)
-        BigDecimal cpi = earnedValue.compareTo(BigDecimal.ZERO) > 0 && actualCost.compareTo(BigDecimal.ZERO) > 0
-                ? earnedValue.divide(actualCost, 2, RoundingMode.HALF_UP)
-                : null;
+        // CPI = EV / AC
+        // Both zero → null (no activity). AC>0 with EV=0 → 0.00 (spending with no delivery).
+        BigDecimal cpi;
+        if (earnedValue.compareTo(BigDecimal.ZERO) > 0 && actualCost.compareTo(BigDecimal.ZERO) > 0) {
+            cpi = earnedValue.divide(actualCost, 2, RoundingMode.HALF_UP);
+        } else if (actualCost.compareTo(BigDecimal.ZERO) > 0) {
+            cpi = BigDecimal.ZERO;
+        } else {
+            cpi = null;
+        }
 
-        // SPI = EV / PV (null when EV = 0 or PV = 0 — no meaningful ratio)
-        BigDecimal spi = earnedValue.compareTo(BigDecimal.ZERO) > 0 && pvToday.compareTo(BigDecimal.ZERO) > 0
-                ? earnedValue.divide(pvToday, 2, RoundingMode.HALF_UP)
-                : null;
+        // SPI = EV / PV
+        // Both zero → null (no activity). PV>0 with EV=0 → 0.00 (behind schedule).
+        BigDecimal spi;
+        if (earnedValue.compareTo(BigDecimal.ZERO) > 0 && pvToday.compareTo(BigDecimal.ZERO) > 0) {
+            spi = earnedValue.divide(pvToday, 2, RoundingMode.HALF_UP);
+        } else if (pvToday.compareTo(BigDecimal.ZERO) > 0) {
+            spi = BigDecimal.ZERO;
+        } else {
+            spi = null;
+        }
 
         // Risk summary
         long openRisks = raidItemRepository.countByProjectIdAndStatus(projectId, RaidItem.RaidStatus.OPEN);


### PR DESCRIPTION
## Summary
- Fixes CPI/SPI returning null for projects that have actual costs but zero progress (EV=0, AC>0)
- CPI=0.00 now correctly flags these projects as "failing" instead of hiding them with null

## Root cause
The #95 fix made CPI/SPI null whenever EV=0, regardless of AC/PV. Projects spending money with no delivery got null CPI and disappeared from "Attention Needed" alerts.

## Fix
Tiered null logic in `PmoService.computeEvm()`:
- EV > 0, AC > 0 → CPI = EV/AC (normal)
- EV = 0, AC > 0 → CPI = 0.00 (actively failing)
- EV = 0, AC = 0 → CPI = null (no activity)

Same pattern for SPI (EV vs PV).

## Test plan
- [ ] Log in as MANAGER, verify projects with costs but no progress show CPI=0.00 in Portfolio Report
- [ ] Verify "Attention Needed" section now includes projects like medERP and Mobile Payments
- [ ] Verify projects with no costs AND no progress still show CPI as "—"
- [ ] Verify normal projects (EV>0, AC>0) still show correct CPI ratios

Fixes #104