### PR TITLE
fix(#105): Portfolio Report Total Spent shows DH 0.00

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/PmoService.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoService.java
@@ -226,7 +226,7 @@ public class PmoService {
         BigDecimal totalEarnedValue = BigDecimal.ZERO;
         BigDecimal totalActualCost = BigDecimal.ZERO;
         BigDecimal totalBudget = BigDecimal.ZERO;
-        BigDecimal totalBudgetSpent = BigDecimal.ZERO;
+        BigDecimal totalExpenseCost = BigDecimal.ZERO;
         long totalOpenRisks = 0;
         long totalMitigatingRisks = 0;
 
@@ -255,7 +255,7 @@ public class PmoService {
             BigDecimal projLaborCost = computeLaborCost(project.getId());
             BigDecimal projExpenseCost = computeExpenseCost(project.getId());
             totalActualCost = totalActualCost.add(projLaborCost.add(projExpenseCost).setScale(2, RoundingMode.HALF_UP));
-            totalBudgetSpent = totalBudgetSpent.add(projExpenseCost);
+            totalExpenseCost = totalExpenseCost.add(projExpenseCost);
 
             if (project.getBudget() != null) totalBudget = totalBudget.add(project.getBudget());
 
@@ -276,7 +276,7 @@ public class PmoService {
         return new PortfolioSummary(
                 totalProjects, totalTasks, totalCompleted,
                 totalPlannedValue, totalEarnedValue, totalActualCost,
-                totalBudget, totalBudgetSpent,
+                totalBudget, totalExpenseCost,
                 portfolioCv, portfolioSv,
                 totalOpenRisks, totalMitigatingRisks,
                 stageDistribution

--- a/frontend/src/pages/reports/PortfolioReport.tsx
+++ b/frontend/src/pages/reports/PortfolioReport.tsx
@@ -47,7 +47,7 @@ export default function PortfolioReport() {
   }
 
   const totalBudget = portfolio?.totalBudget ?? projects.reduce((s, p) => s + Number(p.budget || 0), 0);
-  const totalSpent = portfolio?.totalBudgetSpent ?? projects.reduce((s, p) => s + Number(p.budgetSpent || 0), 0);
+  const totalSpent = portfolio?.totalExpenseCost ?? 0;
   const topRisks = [...risks].filter(r => r.status === 'OPEN' || r.status === 'MITIGATING').sort((a, b) => b.riskScore - a.riskScore).slice(0, 5);
 
   return (
@@ -110,7 +110,7 @@ export default function PortfolioReport() {
                   <td className="px-5 py-3 font-medium text-gray-900">{c.companyName}</td>
                   <td className="px-3 py-3 text-right text-gray-700">{c.totalProjects}</td>
                   <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(c.totalBudget)}</td>
-                  <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(c.totalBudgetSpent)}</td>
+                  <td className="px-3 py-3 text-right text-gray-700">{formatCurrency(c.totalExpenseCost)}</td>
                   <td className="px-3 py-3 text-right text-gray-700">{c.totalTasks > 0 ? ((c.totalCompleted / c.totalTasks) * 100).toFixed(0) + '%' : '-'}</td>
                   <td className="px-3 py-3 text-right">{c.totalOpenRisks + c.totalMitigatingRisks > 0 ? (
                     <span className="text-amber-600 font-medium">{c.totalOpenRisks + c.totalMitigatingRisks}</span>


### PR DESCRIPTION
## Summary
- Fixes Portfolio Report "Total Spent" always showing DH 0.00 after the `budget_spent` field was removed in #87
- Also fixes company breakdown table "Spent" column showing undefined

## Root cause
`PortfolioReport.tsx` still referenced `totalBudgetSpent` (stale field) and `p.budgetSpent` (removed from `ProjectDto`), both resolving to undefined → formatted as 0. The backend `PmoService` also had a misleading local variable `totalBudgetSpent` for what is now `totalExpenseCost`.

## Fix
- PortfolioReport.tsx: Use `portfolio?.totalExpenseCost` for the summary card, `c.totalExpenseCost` for the company breakdown table
- PmoService.java: Renamed local variable `totalBudgetSpent` → `totalExpenseCost` to match the record field name

## Test plan
- [ ] Log in as MANAGER → Reports → Portfolio
- [ ] "Total Spent" shows correct aggregated expense cost (not DH 0.00)
- [ ] Company breakdown "Spent" column shows correct per-company expense totals
- [ ] Executive dashboard still shows correct spent values (no regression)

Fixes #105