### PR TITLE
fix(#106): HR Dashboard Companies count includes Global

### DIFF
--- a/frontend/src/pages/dashboard/HrDashboard.tsx
+++ b/frontend/src/pages/dashboard/HrDashboard.tsx
@@ -1,17 +1,15 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { listAllUsers } from '@/api/users';
-import { listCompanies } from '@/api/companies';
 import { listProjects, getMembers } from '@/api/projects';
 import { listHolidays } from '@/api/holidays';
 import { scoreLabel, scoreColor } from '@/utils/format';
 import BarChart from '@/pages/reports/BarChart';
-import type { UserDto, CompanyDto, ProjectDto, HolidayDto } from '@/types';
+import type { UserDto, ProjectDto, HolidayDto } from '@/types';
 import Spinner from '@/components/common/Spinner';
 
 export default function HrDashboard() {
   const [users, setUsers] = useState<UserDto[]>([]);
-  const [companies, setCompanies] = useState<CompanyDto[]>([]);
   const [projects, setProjects] = useState<ProjectDto[]>([]);
   const [holidays, setHolidays] = useState<HolidayDto[]>([]);
   const [evaluations, setEvaluations] = useState<{ projectKey: string; projectName: string; username: string; fullName: string; score: number | null }[]>([]);
@@ -21,7 +19,6 @@ export default function HrDashboard() {
   useEffect(() => {
     Promise.all([
       listAllUsers({ size: 200 }).then(setUsers).catch(() => {}),
-      listCompanies().then((res) => setCompanies(res.data)).catch(() => {}),
       listProjects().then(setProjects).catch(() => {}),
       listHolidays({ year: new Date().getFullYear() }).then(setHolidays).catch(() => {}),
     ]).finally(() => setLoading(false));
@@ -78,7 +75,7 @@ export default function HrDashboard() {
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <KpiCard label="Total Users" value={String(users.length)} />
         <KpiCard label="Active Users" value={String(activeUsers.length)} />
-        <KpiCard label="Companies" value={String(companies.length)} />
+        <KpiCard label="Companies" value={String(Object.keys(companyUserCounts).length)} />
         <KpiCard label="Upcoming Holidays" value={String(upcomingHolidays.length)} />
       </div>
 


### PR DESCRIPTION
## Summary
- Fixes HR Dashboard "Companies" KPI showing 4 instead of 5 (missing Global)
- Removes unnecessary `listCompanies` API call — count is now derived from the same user data that feeds the chart

## Root cause
The KPI card used `companies.length` from `/api/companies`, which returns only the 4 subsidiary company records. The "Users by Company" chart on the same dashboard correctly includes "Global" (users with `companyId = null`) as a 5th group, creating a visible discrepancy.

## Fix
Changed the KPI to use `Object.keys(companyUserCounts).length` — the same data structure already computed for the chart that includes Global alongside the 4 subsidiaries. Removed the unused `listCompanies` API call and `companies` state.

## Test plan
- [ ] Log in as HR → Dashboard shows "COMPANIES: 5" (matching the chart's 5 groups)
- [ ] Users by Company chart still works correctly
- [ ] Clicking a company in the chart filters users as before

Fixes #106