### PR TITLE
fix(#103): block EXTERNAL role from expenses API

### DIFF
--- a/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
+++ b/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
@@ -28,6 +28,7 @@ public class ProjectExpenseController {
     }
 
     @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'CONTRIBUTOR', 'HR', 'EXECUTIVE')")
     public ResponseEntity<ApiResponse<List<ProjectExpenseDto>>> list(
             @PathVariable Long projectId,
             @AuthenticationPrincipal UserDetails currentUser) {

--- a/backend/src/main/java/com/nemo/pmo/PmoController.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoController.java
@@ -25,13 +25,13 @@ public class PmoController {
     }
 
     @GetMapping("/evm/{projectId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
     public ResponseEntity<ApiResponse<PmoService.EvmMetrics>> getEvmMetrics(@PathVariable Long projectId) {
         return ResponseEntity.ok(ApiResponse.of(pmoService.computeEvm(projectId)));
     }
 
     @GetMapping("/portfolio")
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
     public ResponseEntity<ApiResponse<PmoService.PortfolioSummary>> getPortfolioSummary(
             @AuthenticationPrincipal UserDetails currentUser) {
         Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN") ? null : authHelper.getCurrentCompanyId(currentUser);
@@ -39,7 +39,7 @@ public class PmoController {
     }
 
     @GetMapping("/raid")
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
     public ResponseEntity<ApiResponse<List<RaidItemDto>>> getPortfolioRaidItems(
             @RequestParam(required = false) RaidItem.RaidType type,
             @AuthenticationPrincipal UserDetails currentUser) {
@@ -49,7 +49,7 @@ public class PmoController {
     }
 
     @GetMapping("/portfolio/by-company")
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
     public ResponseEntity<ApiResponse<List<PmoService.CompanyPortfolioSummary>>> getPortfolioByCompany(
             @AuthenticationPrincipal UserDetails currentUser) {
         Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN") ? null : authHelper.getCurrentCompanyId(currentUser);
@@ -57,7 +57,7 @@ public class PmoController {
     }
 
     @GetMapping("/portfolio/timeline")
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
     public ResponseEntity<ApiResponse<List<PmoService.ProjectTimelineEntry>>> getPortfolioTimeline(
             @AuthenticationPrincipal UserDetails currentUser) {
         Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN") ? null : authHelper.getCurrentCompanyId(currentUser);


### PR DESCRIPTION
## Summary
- Blocks EXTERNAL role from reading project expenses (financial data leak)
- Adds HR role to PmoController portfolio endpoints for consistency

## Root cause
1. `ProjectExpenseController` GET endpoint had no `@PreAuthorize`, relying only on `requireProjectReadAccess()` which allows EXTERNAL users assigned to a project to read financial data.
2. PmoController portfolio endpoints only allowed ADMIN/MANAGER/EXECUTIVE — missing HR role that the Reports page frontend already permits.

## Fix
- `ProjectExpenseController.java`: Added `@PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'CONTRIBUTOR', 'HR', 'EXECUTIVE')")` to the GET endpoint, blocking EXTERNAL access
- `PmoController.java`: Added HR role to all 5 endpoints (evm, portfolio, raid, by-company, timeline)

## Test plan
- [ ] Log in as EXTERNAL user → `GET /api/projects/1/expenses` returns 403
- [ ] Log in as CONTRIBUTOR → `GET /api/projects/1/expenses` returns 200
- [ ] Log in as HR → Portfolio report loads correctly
- [ ] Log in as EXTERNAL → `GET /api/pmo/portfolio` returns 403 (not 500)

Fixes #103