### PR TITLE
fix(#92): remove IS NULL fallback from all company-scoped search queries

### DIFF
--- a/backend/src/main/java/com/nemo/client/ClientRepository.java
+++ b/backend/src/main/java/com/nemo/client/ClientRepository.java
@@ -12,6 +12,6 @@ public interface ClientRepository extends JpaRepository<Client, Long> {
     @Query("SELECT c FROM Client c WHERE " +
             "(:search IS NULL OR LOWER(c.name) LIKE LOWER(CONCAT('%', :search, '%')) " +
             "OR LOWER(c.industry) LIKE LOWER(CONCAT('%', :search, '%'))) AND " +
-            "(:companyId IS NULL OR c.company.id = :companyId OR c.company.id IS NULL)")
+            "(:companyId IS NULL OR c.company.id = :companyId)")
     Page<Client> search(@Param("search") String search, @Param("companyId") Long companyId, Pageable pageable);
 }

--- a/backend/src/main/java/com/nemo/presale/PreSaleRepository.java
+++ b/backend/src/main/java/com/nemo/presale/PreSaleRepository.java
@@ -14,7 +14,7 @@ public interface PreSaleRepository extends JpaRepository<PreSale, Long> {
            "OR LOWER(p.client.name) LIKE LOWER(CONCAT('%', :search, '%'))) AND " +
            "(:stage IS NULL OR p.stage = :stage) AND " +
            "(:managerId IS NULL OR p.manager.id = :managerId) AND " +
-           "(:companyId IS NULL OR p.company.id = :companyId OR p.company.id IS NULL)")
+           "(:companyId IS NULL OR p.company.id = :companyId)")
     Page<PreSale> search(@Param("search") String search, @Param("stage") PreSale.PreSaleStage stage,
                          @Param("managerId") Long managerId, @Param("companyId") Long companyId, Pageable pageable);
 }

--- a/backend/src/main/java/com/nemo/program/ProgramRepository.java
+++ b/backend/src/main/java/com/nemo/program/ProgramRepository.java
@@ -14,12 +14,12 @@ public interface ProgramRepository extends JpaRepository<Program, Long> {
     Page<Program> search(String search, Pageable pageable);
 
     @Query("SELECT p FROM Program p WHERE " +
-           "(:companyId IS NULL OR p.company.id = :companyId OR p.company.id IS NULL) AND " +
+           "(:companyId IS NULL OR p.company.id = :companyId) AND " +
            "(LOWER(p.name) LIKE LOWER(CONCAT('%', :search, '%')) OR " +
            "LOWER(p.key) LIKE LOWER(CONCAT('%', :search, '%')))")
     Page<Program> searchByCompany(String search, Long companyId, Pageable pageable);
 
-    @Query("SELECT p FROM Program p WHERE (:companyId IS NULL OR p.company.id = :companyId OR p.company.id IS NULL)")
+    @Query("SELECT p FROM Program p WHERE (:companyId IS NULL OR p.company.id = :companyId)")
     Page<Program> findByCompanyIdOrNull(Long companyId, Pageable pageable);
 
     @Query("SELECT p FROM Program p WHERE p.manager.id = :managerId AND (:search IS NULL OR LOWER(p.name) LIKE LOWER(CONCAT('%', :search, '%')) OR LOWER(p.key) LIKE LOWER(CONCAT('%', :search, '%')))")

--- a/backend/src/main/java/com/nemo/project/ProjectRepository.java
+++ b/backend/src/main/java/com/nemo/project/ProjectRepository.java
@@ -16,11 +16,11 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
            "(:search IS NULL OR LOWER(p.name) LIKE LOWER(CONCAT('%', :search, '%'))) AND " +
            "(:programId IS NULL OR p.program.id = :programId) AND " +
            "(:managerId IS NULL OR p.manager.id = :managerId) AND " +
-           "(:companyId IS NULL OR p.company.id = :companyId OR p.company.id IS NULL)")
+           "(:companyId IS NULL OR p.company.id = :companyId)")
     Page<Project> search(String search, Long programId, Long managerId, Long companyId, Pageable pageable);
 
     @Query("SELECT p FROM Project p WHERE p.id IN (SELECT pm.project.id FROM ProjectMember pm WHERE pm.user.id = :userId) " +
-           "AND (:companyId IS NULL OR p.company.id = :companyId OR p.company.id IS NULL)")
+           "AND (:companyId IS NULL OR p.company.id = :companyId)")
     Page<Project> findByMemberUserIdAndCompany(Long userId, Long companyId, Pageable pageable);
 
     @Query("SELECT p FROM Project p WHERE (:companyId IS NULL OR p.company.id = :companyId)")


### PR DESCRIPTION
## Summary
- Previous fix (PR #107) removed `OR entity.company.id IS NULL` from `findByCompanyIdOrNull`/`findAllByCompanyIdOrNull` in ProjectRepository and PMO/Report repositories, but **missed the two methods that actually serve `GET /api/projects`**: `search()` and `findByMemberUserIdAndCompany()`
- This is why the test kept failing 3 times — the endpoint the tester was checking was never fixed
- Removed `OR entity.company.id IS NULL` from all remaining company-scoped search queries across ProjectRepository, ClientRepository, ProgramRepository, and PreSaleRepository
- ADMIN users (companyId=null) still see everything via the `:companyId IS NULL` condition
- Left UserRepository and PublicHolidayRepository IS NULL fallbacks intact (intentional — People page and global holidays)

## Test plan
- [ ] Log in as `majid` (MANAGER, companyId=1)
- [ ] Call `GET /api/projects` — should return only Sione company projects (3), NOT Data Warehouse/Infrastructure Upgrade (null-companyId)
- [ ] Navigate to Reports → Portfolio — should show only Sione company row
- [ ] Log in as admin — should still see all projects including null-companyId ones

Fixes #92