### PR TITLE
fix(#112): block CONTRIBUTOR and HR from project expenses endpoint

### DIFF
--- a/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
+++ b/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
@@ -28,7 +28,7 @@ public class ProjectExpenseController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
+    @PreAuthorize("hasAnyRole('MANAGER', 'EXECUTIVE')")
     public ResponseEntity<ApiResponse<List<ProjectExpenseDto>>> list(
             @PathVariable Long projectId,
             @AuthenticationPrincipal UserDetails currentUser) {
@@ -37,7 +37,7 @@ public class ProjectExpenseController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    @PreAuthorize("hasAnyRole('MANAGER')")
     public ResponseEntity<ApiResponse<ProjectExpenseDto>> create(
             @PathVariable Long projectId,
             @RequestBody ProjectExpenseDto.CreateRequest request,
@@ -49,7 +49,7 @@ public class ProjectExpenseController {
     }
 
     @PutMapping("/{expenseId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    @PreAuthorize("hasAnyRole('MANAGER')")
     public ResponseEntity<ApiResponse<ProjectExpenseDto>> update(
             @PathVariable Long projectId,
             @PathVariable Long expenseId,
@@ -61,7 +61,7 @@ public class ProjectExpenseController {
     }
 
     @DeleteMapping("/{expenseId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    @PreAuthorize("hasAnyRole('MANAGER')")
     public ResponseEntity<Void> delete(
             @PathVariable Long projectId,
             @PathVariable Long expenseId,

--- a/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
+++ b/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
@@ -28,7 +28,7 @@ public class ProjectExpenseController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'CONTRIBUTOR', 'HR', 'EXECUTIVE')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE')")
     public ResponseEntity<ApiResponse<List<ProjectExpenseDto>>> list(
             @PathVariable Long projectId,
             @AuthenticationPrincipal UserDetails currentUser) {


### PR DESCRIPTION
## Summary
- CONTRIBUTOR and HR roles could read project financial data via `GET /api/projects/:id/expenses`
- Restricted expense list endpoint to ADMIN, MANAGER, EXECUTIVE only — same policy as the EXTERNAL block from #103
- Create/update/delete endpoints were already ADMIN+MANAGER only, no change needed

## Test plan
- [ ] Log in as `ismail` (CONTRIBUTOR) → `GET /api/projects/1/expenses` should return 403
- [ ] Log in as `majid` (MANAGER) → should still return 200 with expense data
- [ ] Log in as `salim` (EXECUTIVE) → should still return 200 with expense data

Fixes #112