### PR TITLE
feat(#113): add program-level EVM rollup endpoint and UI

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/PmoService.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoService.java
@@ -304,6 +304,121 @@ public class PmoService {
             Map<String, Long> stageDistribution
     ) {}
 
+    public record ProgramEvmMetrics(
+            Long programId, String programName,
+            int totalProjects, long totalTasks, long totalCompleted, BigDecimal completionPct,
+            BigDecimal totalBudget, BigDecimal totalPlannedValue, BigDecimal totalEarnedValue,
+            BigDecimal totalActualCost, BigDecimal totalLaborCost, BigDecimal totalExpenseCost,
+            BigDecimal pvToday, BigDecimal costVariance, BigDecimal scheduleVariance,
+            BigDecimal cpi, BigDecimal spi,
+            long totalOpenRisks, long totalMitigatingRisks
+    ) {}
+
+    @Transactional(readOnly = true)
+    public ProgramEvmMetrics computeProgramEvm(Long programId) {
+        List<Project> projects = projectRepository.findByProgramId(programId);
+        if (projects.isEmpty()) {
+            return new ProgramEvmMetrics(programId, null, 0, 0, 0,
+                    BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO,
+                    BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO,
+                    BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO,
+                    null, null, 0, 0);
+        }
+
+        // Derive program name from first project's program
+        String programName = projects.get(0).getProgram() != null
+                ? projects.get(0).getProgram().getName() : null;
+
+        List<TaskStatus> completedStatuses = new java.util.ArrayList<>();
+        completedStatuses.addAll(taskStatusRepository.findByCategory(TaskStatus.Category.DONE));
+        completedStatuses.addAll(taskStatusRepository.findByCategory(TaskStatus.Category.CLOSED));
+
+        long totalTasks = 0;
+        long totalCompleted = 0;
+        BigDecimal totalBudget = BigDecimal.ZERO;
+        BigDecimal totalPlannedValue = BigDecimal.ZERO;
+        BigDecimal totalEarnedValue = BigDecimal.ZERO;
+        BigDecimal totalActualCost = BigDecimal.ZERO;
+        BigDecimal totalLaborCost = BigDecimal.ZERO;
+        BigDecimal totalExpenseCost = BigDecimal.ZERO;
+        BigDecimal totalPvToday = BigDecimal.ZERO;
+        long totalOpenRisks = 0;
+        long totalMitigatingRisks = 0;
+
+        for (Project project : projects) {
+            long projTotal = taskRepository.countByProjectId(project.getId());
+            long projCompleted = 0;
+            for (TaskStatus status : completedStatuses) {
+                projCompleted += taskRepository.countByProjectIdAndStatusId(project.getId(), status.getId());
+            }
+            totalTasks += projTotal;
+            totalCompleted += projCompleted;
+
+            if (project.getBudget() != null) totalBudget = totalBudget.add(project.getBudget());
+
+            // Derived PV from phases, fallback to project.plannedValue
+            List<Phase> phases = phaseRepository.findByProjectIdOrderByPositionAsc(project.getId());
+            BigDecimal derivedPv = phases.stream()
+                    .map(p -> p.getPlannedAmount() != null ? p.getPlannedAmount() : BigDecimal.ZERO)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+            BigDecimal projPv = derivedPv.compareTo(BigDecimal.ZERO) > 0
+                    ? derivedPv
+                    : (project.getPlannedValue() != null ? project.getPlannedValue() : BigDecimal.ZERO);
+            totalPlannedValue = totalPlannedValue.add(projPv);
+
+            BigDecimal projCompletion = projTotal > 0
+                    ? BigDecimal.valueOf(projCompleted).divide(BigDecimal.valueOf(projTotal), 4, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+            totalEarnedValue = totalEarnedValue.add(projCompletion.multiply(projPv).setScale(2, RoundingMode.HALF_UP));
+
+            BigDecimal projLabor = computeLaborCost(project.getId());
+            BigDecimal projExpense = computeExpenseCost(project.getId());
+            totalLaborCost = totalLaborCost.add(projLabor);
+            totalExpenseCost = totalExpenseCost.add(projExpense);
+            totalActualCost = totalActualCost.add(projLabor.add(projExpense).setScale(2, RoundingMode.HALF_UP));
+
+            totalPvToday = totalPvToday.add(computePlannedValueToday(project, projPv));
+
+            totalOpenRisks += raidItemRepository.countByProjectIdAndStatus(project.getId(), RaidItem.RaidStatus.OPEN);
+            totalMitigatingRisks += raidItemRepository.countByProjectIdAndStatus(project.getId(), RaidItem.RaidStatus.MITIGATING);
+        }
+
+        BigDecimal completionPct = totalTasks > 0
+                ? BigDecimal.valueOf(totalCompleted).divide(BigDecimal.valueOf(totalTasks), 4, RoundingMode.HALF_UP)
+                : BigDecimal.ZERO;
+
+        BigDecimal costVariance = totalEarnedValue.subtract(totalActualCost).setScale(2, RoundingMode.HALF_UP);
+        BigDecimal scheduleVariance = totalEarnedValue.subtract(totalPvToday).setScale(2, RoundingMode.HALF_UP);
+
+        BigDecimal cpi;
+        if (totalEarnedValue.compareTo(BigDecimal.ZERO) > 0 && totalActualCost.compareTo(BigDecimal.ZERO) > 0) {
+            cpi = totalEarnedValue.divide(totalActualCost, 2, RoundingMode.HALF_UP);
+        } else if (totalActualCost.compareTo(BigDecimal.ZERO) > 0) {
+            cpi = BigDecimal.ZERO;
+        } else {
+            cpi = null;
+        }
+
+        BigDecimal spi;
+        if (totalEarnedValue.compareTo(BigDecimal.ZERO) > 0 && totalPvToday.compareTo(BigDecimal.ZERO) > 0) {
+            spi = totalEarnedValue.divide(totalPvToday, 2, RoundingMode.HALF_UP);
+        } else if (totalPvToday.compareTo(BigDecimal.ZERO) > 0) {
+            spi = BigDecimal.ZERO;
+        } else {
+            spi = null;
+        }
+
+        return new ProgramEvmMetrics(
+                programId, programName,
+                projects.size(), totalTasks, totalCompleted, completionPct,
+                totalBudget, totalPlannedValue, totalEarnedValue,
+                totalActualCost, totalLaborCost, totalExpenseCost,
+                totalPvToday, costVariance, scheduleVariance,
+                cpi, spi,
+                totalOpenRisks, totalMitigatingRisks
+        );
+    }
+
     public record CompanyPortfolioSummary(
             Long companyId, String companyName, String companyKey,
             int totalProjects, long totalTasks, long totalCompleted,

--- a/backend/src/main/java/com/nemo/program/ProgramController.java
+++ b/backend/src/main/java/com/nemo/program/ProgramController.java
@@ -3,6 +3,7 @@ package com.nemo.program;
 import com.nemo.common.dto.ApiResponse;
 import com.nemo.common.dto.PaginatedResponse;
 import com.nemo.common.dto.PaginatedResponse.PaginationInfo;
+import com.nemo.pmo.PmoService;
 import com.nemo.security.AuthHelper;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
@@ -22,11 +23,13 @@ public class ProgramController {
     private final ProgramService programService;
     private final ProgramMapper programMapper;
     private final AuthHelper authHelper;
+    private final PmoService pmoService;
 
-    public ProgramController(ProgramService programService, ProgramMapper programMapper, AuthHelper authHelper) {
+    public ProgramController(ProgramService programService, ProgramMapper programMapper, AuthHelper authHelper, PmoService pmoService) {
         this.programService = programService;
         this.programMapper = programMapper;
         this.authHelper = authHelper;
+        this.pmoService = pmoService;
     }
 
     @GetMapping
@@ -55,6 +58,12 @@ public class ProgramController {
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<ProgramDto>> get(@PathVariable Long id) {
         return ResponseEntity.ok(ApiResponse.of(programMapper.toDto(programService.getById(id))));
+    }
+
+    @GetMapping("/{id}/evm")
+    @PreAuthorize("hasAnyRole('MANAGER', 'EXECUTIVE')")
+    public ResponseEntity<ApiResponse<PmoService.ProgramEvmMetrics>> getEvm(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.of(pmoService.computeProgramEvm(id)));
     }
 
     @PostMapping

--- a/backend/src/main/java/com/nemo/project/ProjectRepository.java
+++ b/backend/src/main/java/com/nemo/project/ProjectRepository.java
@@ -12,6 +12,8 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
 
     long countByProgramId(Long programId);
 
+    List<Project> findByProgramId(Long programId);
+
     @Query("SELECT p FROM Project p WHERE " +
            "(:search IS NULL OR LOWER(p.name) LIKE LOWER(CONCAT('%', :search, '%'))) AND " +
            "(:programId IS NULL OR p.program.id = :programId) AND " +

--- a/frontend/src/api/programs.ts
+++ b/frontend/src/api/programs.ts
@@ -1,5 +1,5 @@
 import { apiGet, apiGetPaginated } from './client';
-import type { ProgramDto } from '@/types';
+import type { ProgramDto, ProgramEvmMetrics } from '@/types';
 
 export function listPrograms(params?: Record<string, string | number>) {
   return apiGetPaginated<ProgramDto>('/programs', params);
@@ -7,4 +7,8 @@ export function listPrograms(params?: Record<string, string | number>) {
 
 export function getProgram(id: number) {
   return apiGet<ProgramDto>(`/programs/${id}`);
+}
+
+export function getProgramEvm(id: number) {
+  return apiGet<ProgramEvmMetrics>(`/programs/${id}/evm`);
 }

--- a/frontend/src/pages/ProgramDetailPage.tsx
+++ b/frontend/src/pages/ProgramDetailPage.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import type { ProgramDto, ProjectDto } from '@/types';
-import { getProgram } from '@/api/programs';
+import type { ProgramDto, ProjectDto, ProgramEvmMetrics } from '@/types';
+import { getProgram, getProgramEvm } from '@/api/programs';
 import { listProjects } from '@/api/projects';
-import { stageBadge, stageLabel, formatCurrency, formatDate, deadlineBadge, deadlineLabel } from '@/utils/format';
+import { stageBadge, stageLabel, formatCurrency, formatDate, deadlineBadge, deadlineLabel, eviColor } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
 
 export default function ProgramDetailPage() {
@@ -11,18 +11,21 @@ export default function ProgramDetailPage() {
   const navigate = useNavigate();
   const [program, setProgram] = useState<ProgramDto | null>(null);
   const [projects, setProjects] = useState<ProjectDto[]>([]);
+  const [evm, setEvm] = useState<ProgramEvmMetrics | null>(null);
   const [loading, setLoading] = useState(true);
 
   const fetchData = useCallback(async () => {
     if (!id) return;
     setLoading(true);
     try {
-      const [prog, projRes] = await Promise.all([
+      const [prog, projRes, evmData] = await Promise.all([
         getProgram(Number(id)),
         listProjects({ programId: Number(id), size: 100 }),
+        getProgramEvm(Number(id)).catch(() => null),
       ]);
       setProgram(prog);
       setProjects(projRes);
+      setEvm(evmData);
     } catch {
       setProgram(null);
     } finally {
@@ -57,6 +60,62 @@ export default function ProgramDetailPage() {
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-semibold text-gray-900">Projects ({projects.length})</h3>
       </div>
+
+      {evm && (
+        <div className="bg-white rounded-xl border border-gray-200 p-5">
+          <h4 className="text-sm font-semibold text-gray-700 mb-3">Program EVM Summary</h4>
+          <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-4">
+            <div>
+              <div className="text-[10px] text-gray-400 font-medium uppercase">Budget</div>
+              <div className="text-sm font-medium text-gray-900">{formatCurrency(evm.totalBudget)}</div>
+            </div>
+            <div>
+              <div className="text-[10px] text-gray-400 font-medium uppercase">PV</div>
+              <div className="text-sm font-medium text-gray-900">{formatCurrency(evm.totalPlannedValue)}</div>
+            </div>
+            <div>
+              <div className="text-[10px] text-gray-400 font-medium uppercase">EV</div>
+              <div className="text-sm font-medium text-gray-900">{formatCurrency(evm.totalEarnedValue)}</div>
+            </div>
+            <div>
+              <div className="text-[10px] text-gray-400 font-medium uppercase">AC</div>
+              <div className="text-sm font-medium text-gray-900">{formatCurrency(evm.totalActualCost)}</div>
+            </div>
+            <div>
+              <div className="text-[10px] text-gray-400 font-medium uppercase">CPI</div>
+              <div className={'text-sm font-semibold ' + (evm.cpi != null ? eviColor(evm.cpi) : 'text-gray-400')}>
+                {evm.cpi != null ? evm.cpi.toFixed(2) : '—'}
+              </div>
+            </div>
+            <div>
+              <div className="text-[10px] text-gray-400 font-medium uppercase">SPI</div>
+              <div className={'text-sm font-semibold ' + (evm.spi != null ? eviColor(evm.spi) : 'text-gray-400')}>
+                {evm.spi != null ? evm.spi.toFixed(2) : '—'}
+              </div>
+            </div>
+            <div>
+              <div className="text-[10px] text-gray-400 font-medium uppercase">CV</div>
+              <div className={'text-sm font-medium ' + (evm.costVariance >= 0 ? 'text-green-600' : 'text-red-600')}>
+                {formatCurrency(evm.costVariance)}
+              </div>
+            </div>
+            <div>
+              <div className="text-[10px] text-gray-400 font-medium uppercase">SV</div>
+              <div className={'text-sm font-medium ' + (evm.scheduleVariance >= 0 ? 'text-green-600' : 'text-red-600')}>
+                {formatCurrency(evm.scheduleVariance)}
+              </div>
+            </div>
+            <div>
+              <div className="text-[10px] text-gray-400 font-medium uppercase">Completion</div>
+              <div className="text-sm font-medium text-gray-900">{(evm.completionPct * 100).toFixed(1)}%</div>
+            </div>
+            <div>
+              <div className="text-[10px] text-gray-400 font-medium uppercase">Risks</div>
+              <div className="text-sm font-medium text-gray-900">{evm.totalOpenRisks} open / {evm.totalMitigatingRisks} mitigating</div>
+            </div>
+          </div>
+        </div>
+      )}
 
       {projects.length === 0 ? (
         <div className="bg-white rounded-xl border border-gray-200 p-12 text-center text-gray-500">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -3,7 +3,7 @@ export type { CompanyDto, CreateCompanyRequest, UpdateCompanyRequest } from './c
 export type { UserDto, UserRole, LoginRequest, UpdateProfileRequest, PasswordChangeRequest, AllocationSummaryDto } from './user';
 export type { ProjectDto, CreateProjectRequest, UpdateProjectRequest, MemberDto, LabelDto, LabelCreateRequest, BoardColumnDto, BoardConfigDto, BoardUpdateRequest, InstructionDto, CreateInstructionRequest, UpdateInstructionRequest, NoteDto, CreateNoteRequest, UpdateNoteRequest } from './project';
 export type { TaskDto, TaskPriority, CreateTaskRequest, UpdateTaskRequest, CommentDto, CreateCommentRequest, UpdateCommentRequest } from './task';
-export type { ProgramDto, CreateProgramRequest, UpdateProgramRequest } from './program';
+export type { ProgramDto, CreateProgramRequest, UpdateProgramRequest, ProgramEvmMetrics } from './program';
 export type { OrganizationConfig, PublicConfigResponse } from './organization';
 export type { SprintDto, CreateSprintRequest, UpdateSprintRequest } from './sprint';
 export type { TimeLogDto, CreateTimeLogRequest, UpdateTimeLogRequest } from './timeLog';

--- a/frontend/src/types/program.ts
+++ b/frontend/src/types/program.ts
@@ -25,3 +25,25 @@ export interface UpdateProgramRequest {
   description?: string;
   managerId?: number;
 }
+
+export interface ProgramEvmMetrics {
+  programId: number;
+  programName: string | null;
+  totalProjects: number;
+  totalTasks: number;
+  totalCompleted: number;
+  completionPct: number;
+  totalBudget: number;
+  totalPlannedValue: number;
+  totalEarnedValue: number;
+  totalActualCost: number;
+  totalLaborCost: number;
+  totalExpenseCost: number;
+  pvToday: number;
+  costVariance: number;
+  scheduleVariance: number;
+  cpi: number | null;
+  spi: number | null;
+  totalOpenRisks: number;
+  totalMitigatingRisks: number;
+}


### PR DESCRIPTION
## Summary
- Added `ProgramEvmMetrics` record and `computeProgramEvm()` to `PmoService` — aggregates PV, EV, AC, CPI, SPI, CV, SV, budget, labor cost, expense cost, risk counts across all projects in a program
- Added `GET /api/programs/{id}/evm` endpoint (MANAGER/EXECUTIVE only)
- Added `ProjectRepository.findByProgramId()` for program-scoped project queries
- Added EVM summary card to `ProgramDetailPage.tsx` showing budget, PV, EV, AC, CPI, SPI, CV, SV, completion %, and risk counts

## Test plan
- [ ] Call `GET /api/programs/1/evm` — should return aggregated EVM metrics (no longer 500)
- [ ] Navigate to Program detail page — should see EVM Summary card with metrics
- [ ] CPI/SPI values should be color-coded (green >= 1.0, yellow 0.9-1.0, red < 0.9)
- [ ] CV/SV should be green when positive, red when negative
- [ ] Program with no projects should return zeros/nulls gracefully

Fixes #113