### PR TITLE
fix(#114): populate projectCount in program detail endpoint

### DIFF
--- a/backend/src/main/java/com/nemo/program/ProgramController.java
+++ b/backend/src/main/java/com/nemo/program/ProgramController.java
@@ -54,7 +54,9 @@ public class ProgramController {
 
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<ProgramDto>> get(@PathVariable Long id) {
-        return ResponseEntity.ok(ApiResponse.of(programMapper.toDto(programService.getById(id))));
+        ProgramDto dto = programMapper.toDto(programService.getById(id));
+        dto = programService.enrichWithProjectCount(List.of(dto)).getFirst();
+        return ResponseEntity.ok(ApiResponse.of(dto));
     }
 
     @PostMapping


### PR DESCRIPTION
## Summary
- `GET /api/programs/{id}` always returned `projectCount: null` because it bypassed `enrichWithProjectCount()` which is called by the list endpoint
- Applied `enrichWithProjectCount()` to the single DTO so `projectCount` is populated from `ProjectRepository.countByProgramId()`

## Test plan
- [ ] `GET /api/programs/1` → `projectCount` should be a number (e.g. 3), not null
- [ ] `GET /api/programs` (list) → projectCount should still work (no regression)

Fixes #114