### PR TITLE
fix(#115): add phase-level spent tracking from labor costs and expenses

### DIFF
--- a/backend/src/main/java/com/nemo/expense/ProjectExpenseRepository.java
+++ b/backend/src/main/java/com/nemo/expense/ProjectExpenseRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ProjectExpenseRepository extends JpaRepository<ProjectExpense, Long> {
@@ -13,6 +14,9 @@ public interface ProjectExpenseRepository extends JpaRepository<ProjectExpense, 
 
     @Query("SELECT COALESCE(SUM(e.amount), 0) FROM ProjectExpense e WHERE e.project.id = :projectId")
     BigDecimal sumByProjectId(@Param("projectId") Long projectId);
+
+    @Query("SELECT COALESCE(SUM(e.amount), 0) FROM ProjectExpense e WHERE e.project.id = :projectId AND e.expenseDate BETWEEN :startDate AND :endDate")
+    BigDecimal sumByProjectIdAndDateRange(@Param("projectId") Long projectId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 
     void deleteByProjectId(Long projectId);
 }

--- a/backend/src/main/java/com/nemo/phase/PhaseDto.java
+++ b/backend/src/main/java/com/nemo/phase/PhaseDto.java
@@ -16,6 +16,7 @@ public record PhaseDto(
         long deliverableCount,
         String plannedAmount,
         String totalPaid,
+        String spent,
         String createdAt,
         String updatedAt
 ) {

--- a/backend/src/main/java/com/nemo/phase/PhaseMapper.java
+++ b/backend/src/main/java/com/nemo/phase/PhaseMapper.java
@@ -13,6 +13,7 @@ public interface PhaseMapper {
     @Mapping(target = "status", source = "status", qualifiedByName = "phaseStatusToString")
     @Mapping(target = "deliverableCount", ignore = true)
     @Mapping(target = "totalPaid", ignore = true)
+    @Mapping(target = "spent", ignore = true)
     @Mapping(target = "createdAt", source = "createdAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'")
     @Mapping(target = "updatedAt", source = "updatedAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'")
     PhaseDto toDto(Phase phase);

--- a/backend/src/main/java/com/nemo/phase/PhaseService.java
+++ b/backend/src/main/java/com/nemo/phase/PhaseService.java
@@ -2,12 +2,19 @@ package com.nemo.phase;
 
 import com.nemo.attachment.AttachmentService;
 import com.nemo.common.exception.EntityNotFoundException;
+import com.nemo.expense.ProjectExpenseRepository;
 import com.nemo.project.Project;
 import com.nemo.project.ProjectRepository;
+import com.nemo.timetracking.TimeLog;
+import com.nemo.timetracking.TimeLogRepository;
+import com.nemo.timetracking.UserRate;
+import com.nemo.timetracking.UserRateRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -20,17 +27,26 @@ public class PhaseService {
     private final DeliverableRepository deliverableRepository;
     private final AttachmentService attachmentService;
     private final ClientPaymentRepository clientPaymentRepository;
+    private final TimeLogRepository timeLogRepository;
+    private final UserRateRepository userRateRepository;
+    private final ProjectExpenseRepository expenseRepository;
 
     public PhaseService(PhaseRepository phaseRepository,
                         ProjectRepository projectRepository,
                         DeliverableRepository deliverableRepository,
                         AttachmentService attachmentService,
-                        ClientPaymentRepository clientPaymentRepository) {
+                        ClientPaymentRepository clientPaymentRepository,
+                        TimeLogRepository timeLogRepository,
+                        UserRateRepository userRateRepository,
+                        ProjectExpenseRepository expenseRepository) {
         this.phaseRepository = phaseRepository;
         this.projectRepository = projectRepository;
         this.deliverableRepository = deliverableRepository;
         this.attachmentService = attachmentService;
         this.clientPaymentRepository = clientPaymentRepository;
+        this.timeLogRepository = timeLogRepository;
+        this.userRateRepository = userRateRepository;
+        this.expenseRepository = expenseRepository;
     }
 
     @Transactional(readOnly = true)
@@ -121,11 +137,35 @@ public class PhaseService {
         return dtos.stream().map(dto -> {
             long dCount = deliverableCounts.getOrDefault(dto.id(), 0L);
             BigDecimal totalPaid = paidSums.getOrDefault(dto.id(), BigDecimal.ZERO);
+            BigDecimal spent = computePhaseSpent(dto);
             return new PhaseDto(dto.id(), dto.name(), dto.description(),
                     dto.projectId(), dto.startDate(), dto.endDate(),
                     dto.position(), dto.status(), dCount,
                     dto.plannedAmount(), totalPaid.toPlainString(),
+                    spent.toPlainString(),
                     dto.createdAt(), dto.updatedAt());
         }).toList();
+    }
+
+    private BigDecimal computePhaseSpent(PhaseDto dto) {
+        if (dto.projectId() == null || dto.startDate() == null || dto.endDate() == null) {
+            return BigDecimal.ZERO;
+        }
+        BigDecimal laborCost = computeLaborCostForRange(dto.projectId(), dto.startDate(), dto.endDate());
+        BigDecimal expenseCost = expenseRepository.sumByProjectIdAndDateRange(dto.projectId(), dto.startDate(), dto.endDate());
+        return laborCost.add(expenseCost).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal computeLaborCostForRange(Long projectId, LocalDate startDate, LocalDate endDate) {
+        List<TimeLog> logs = timeLogRepository.findByProjectIdAndDateRange(projectId, startDate, endDate);
+        BigDecimal total = BigDecimal.ZERO;
+        for (TimeLog log : logs) {
+            UserRate rate = userRateRepository.findEffectiveRate(
+                    log.getUser().getId(), log.getLogDate()).orElse(null);
+            if (rate != null) {
+                total = total.add(log.getHours().multiply(rate.getHourlyRate()));
+            }
+        }
+        return total.setScale(2, RoundingMode.HALF_UP);
     }
 }

--- a/frontend/src/pages/project-detail/PhasesTab.tsx
+++ b/frontend/src/pages/project-detail/PhasesTab.tsx
@@ -269,6 +269,15 @@ export default function PhasesTab({ projectId, canEdit }: { projectId: number; c
     return { planned, paid, pct, color };
   };
 
+  const spentProgress = (phase: PhaseDto) => {
+    if (!phase.plannedAmount || Number(phase.plannedAmount) === 0) return { planned: 0, spent: Number(phase.spent || 0), pct: 0, color: 'bg-gray-300' };
+    const planned = Number(phase.plannedAmount);
+    const spent = Number(phase.spent || 0);
+    const pct = Math.min(100, Math.round((spent / planned) * 100));
+    const color = pct >= 100 ? 'bg-red-500' : pct >= 80 ? 'bg-amber-500' : 'bg-blue-500';
+    return { planned, spent, pct, color };
+  };
+
   if (loading) return <div className="flex items-center justify-center h-32"><Spinner className="h-6 w-6 text-primary-600" /></div>;
 
   return (
@@ -288,6 +297,7 @@ export default function PhasesTab({ projectId, canEdit }: { projectId: number; c
             const isExpanded = expandedPhaseId === phase.id;
             const phaseDeliverables = deliverablesByPhase(phase.id);
             const progress = paymentProgress(phase);
+            const sProgress = spentProgress(phase);
             const phasePayments = payments[phase.id] || [];
             return (
               <div key={phase.id} className="bg-white rounded-xl border border-gray-200 overflow-hidden">
@@ -327,12 +337,12 @@ export default function PhasesTab({ projectId, canEdit }: { projectId: number; c
                       )}
                     </div>
                     <div className="flex items-center gap-4">
-                      {(progress.paid > 0 || progress.planned > 0) && (
+                      {(sProgress.spent > 0 || sProgress.planned > 0) && (
                         <div className="flex items-center gap-2 min-w-[140px]">
                           <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
-                            <div className={`h-full rounded-full ${progress.color}`} style={{ width: `${progress.pct}%` }} />
+                            <div className={`h-full rounded-full ${sProgress.color}`} style={{ width: `${sProgress.pct}%` }} />
                           </div>
-                          <span className="text-xs text-gray-500 whitespace-nowrap">{formatCurrency(progress.paid)}</span>
+                          <span className="text-xs text-gray-500 whitespace-nowrap">{formatCurrency(sProgress.spent)}</span>
                         </div>
                       )}
                       {(phase.startDate || phase.endDate) && (
@@ -360,6 +370,23 @@ export default function PhasesTab({ projectId, canEdit }: { projectId: number; c
 
                 {isExpanded && (
                   <div className="border-t border-gray-100 px-4 pb-4 pt-2 ml-7">
+                    {/* Budget vs Spent section */}
+                    {sProgress.planned > 0 && (
+                      <div className="mb-4">
+                        <div className="flex items-center justify-between mb-2">
+                          <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Budget vs Spent</span>
+                        </div>
+                        <div className="flex items-center gap-3 mb-2 text-xs">
+                          <span className="text-gray-500">Budget: <span className="font-medium text-gray-900">{formatCurrency(sProgress.planned)}</span></span>
+                          <span className="text-gray-500">Spent: <span className={`font-medium ${sProgress.pct >= 100 ? 'text-red-700' : sProgress.pct >= 80 ? 'text-amber-700' : 'text-gray-900'}`}>{formatCurrency(sProgress.spent)}</span></span>
+                          <span className={`font-medium ${sProgress.pct >= 100 ? 'text-red-700' : sProgress.pct >= 80 ? 'text-amber-700' : 'text-gray-500'}`}>({sProgress.pct}%)</span>
+                        </div>
+                        <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
+                          <div className={`h-full rounded-full ${sProgress.color}`} style={{ width: `${sProgress.pct}%` }} />
+                        </div>
+                      </div>
+                    )}
+
                     {/* Payments section */}
                     <div className="mb-4">
                       <div className="flex items-center justify-between mb-2">

--- a/frontend/src/types/phase.ts
+++ b/frontend/src/types/phase.ts
@@ -10,6 +10,7 @@ export interface PhaseDto {
   deliverableCount: number;
   plannedAmount: string | null;
   totalPaid: string | null;
+  spent: string | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- Added `PhaseDto.spent` field computed from labor costs (time logs × hourly rates) + project expenses where dates fall within the phase's start/end date range
- Previously, `totalPaid` (client payments) was the only financial metric per phase — no internal cost tracking existed
- Frontend now shows spent vs budget in the phase header progress bar and a detailed "Budget vs Spent" section in the expanded view, alongside the existing client payments section

## Test plan
- [ ] Navigate to `/projects/1` → Phases tab → phases should show non-zero spent values
- [ ] Spent = labor cost (time logs within phase dates) + expenses (expense dates within phase dates)
- [ ] Progress bar in collapsed header reflects spent vs budget (red >= 100%, amber >= 80%, blue < 80%)
- [ ] Expanded section shows "Budget vs Spent" with progress bar, and "Payments" section below
- [ ] Phase without date range should show DH 0.00 spent

Fixes #115