### PR TITLE
fix(#122): use relative dates for sprint seed data

### DIFF
--- a/backend/src/main/java/com/nemo/config/DataSeeder.java
+++ b/backend/src/main/java/com/nemo/config/DataSeeder.java
@@ -508,11 +508,11 @@ public class DataSeeder implements CommandLineRunner {
 
         // Sprints
         Sprint sprint1 = createSprint("Sprint 1", "FSE MVP features", fse,
-                SprintStatus.ACTIVE, LocalDate.of(2025, 4, 1), LocalDate.of(2025, 4, 14));
+                SprintStatus.ACTIVE, today.minusDays(20), today.plusDays(8));
         Sprint sprint2 = createSprint("Sprint 2", "FSE enhancements", fse,
-                SprintStatus.PLANNING, LocalDate.of(2025, 4, 15), LocalDate.of(2025, 4, 28));
+                SprintStatus.PLANNING, today.plusDays(9), today.plusDays(22));
         Sprint sprintM1 = createSprint("Mobile Sprint 1", "Core mobile features", mobileApp,
-                SprintStatus.ACTIVE, LocalDate.of(2025, 4, 1), LocalDate.of(2025, 4, 14));
+                SprintStatus.ACTIVE, today.minusDays(15), today.plusDays(10));
 
         // Tasks for FSE
         TaskStatus todo = allStatuses.stream().filter(s -> s.getCategory() == TaskStatus.Category.TODO).findFirst().orElse(allStatuses.get(0));


### PR DESCRIPTION
## Summary
- Changed sprint start/end dates in DataSeeder from hardcoded `LocalDate.of(2025, ...)` to `today`-relative values (`today.minusDays`/`plusDays`)
- Active sprints now have current date ranges so they don't appear permanently overdue
- No auto-close logic — managers close sprints manually; frontend already flags overdue sprints visually

## Test plan
- [ ] Re-seed database
- [ ] `GET /api/projects/1/sprints?status=ACTIVE` — sprints should have recent dates, not 2025
- [ ] Frontend SprintsTab shows overdue badge correctly for sprints past end date

Refs #122