### PR TITLE
fix(#123): add sprint velocity endpoint

### DIFF
--- a/backend/src/main/java/com/nemo/sprint/SprintController.java
+++ b/backend/src/main/java/com/nemo/sprint/SprintController.java
@@ -1,6 +1,7 @@
 package com.nemo.sprint;
 
 import com.nemo.common.dto.ApiResponse;
+import com.nemo.config.TaskStatus;
 import com.nemo.task.Task;
 import com.nemo.task.TaskDto;
 import com.nemo.task.TaskMapper;
@@ -17,6 +18,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/projects/{projectId}/sprints")
@@ -79,5 +82,29 @@ public class SprintController {
             @Valid @RequestBody SprintDto.StatusUpdateRequest request) {
         Sprint updated = sprintService.updateStatus(sprintId, request);
         return ResponseEntity.ok(ApiResponse.of(sprintMapper.toDto(updated)));
+    }
+
+    @GetMapping("/velocity")
+    public ResponseEntity<ApiResponse<List<SprintVelocityDto>>> velocity(
+            @PathVariable Long projectId,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, projectId);
+        List<Sprint> sprints = sprintService.getByProjectId(projectId, null);
+        if (sprints.isEmpty()) {
+            return ResponseEntity.ok(ApiResponse.of(List.of()));
+        }
+        List<Long> sprintIds = sprints.stream().map(Sprint::getId).toList();
+        Map<Long, Long> totalBySprint = taskRepository.countBySprintIds(sprintIds).stream()
+                .collect(Collectors.toMap(arr -> (Long) arr[0], arr -> (Long) arr[1]));
+        Map<Long, Long> completedBySprint = taskRepository.countCompletedBySprintIds(
+                sprintIds, List.of(TaskStatus.Category.DONE, TaskStatus.Category.CLOSED)).stream()
+                .collect(Collectors.toMap(arr -> (Long) arr[0], arr -> (Long) arr[1]));
+        List<SprintVelocityDto> result = sprints.stream()
+                .map(s -> new SprintVelocityDto(
+                        s.getId(), s.getName(), s.getStatus().name(),
+                        totalBySprint.getOrDefault(s.getId(), 0L).intValue(),
+                        completedBySprint.getOrDefault(s.getId(), 0L).intValue()))
+                .toList();
+        return ResponseEntity.ok(ApiResponse.of(result));
     }
 }

--- a/backend/src/main/java/com/nemo/sprint/SprintVelocityDto.java
+++ b/backend/src/main/java/com/nemo/sprint/SprintVelocityDto.java
@@ -1,0 +1,9 @@
+package com.nemo.sprint;
+
+public record SprintVelocityDto(
+        Long sprintId,
+        String sprintName,
+        String status,
+        int totalTasks,
+        int completedTasks
+) {}

--- a/backend/src/main/java/com/nemo/task/TaskRepository.java
+++ b/backend/src/main/java/com/nemo/task/TaskRepository.java
@@ -1,11 +1,14 @@
 package com.nemo.task;
 
+import com.nemo.config.TaskStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
+import java.util.List;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
     long countByProjectIdAndStatusId(Long projectId, Long statusId);
@@ -34,4 +37,10 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
                        Boolean external, Pageable pageable);
 
     Page<Task> findByProjectIdAndSprintIdIsNull(Long projectId, Pageable pageable);
+
+    @Query("SELECT t.sprint.id, COUNT(t) FROM Task t WHERE t.sprint.id IN :sprintIds GROUP BY t.sprint.id")
+    List<Object[]> countBySprintIds(@Param("sprintIds") List<Long> sprintIds);
+
+    @Query("SELECT t.sprint.id, COUNT(t) FROM Task t WHERE t.sprint.id IN :sprintIds AND t.status.category IN :categories GROUP BY t.sprint.id")
+    List<Object[]> countCompletedBySprintIds(@Param("sprintIds") List<Long> sprintIds, @Param("categories") List<TaskStatus.Category> categories);
 }

--- a/frontend/src/api/sprints.ts
+++ b/frontend/src/api/sprints.ts
@@ -1,8 +1,12 @@
 import { apiGet, apiPost, apiPut } from './client';
-import type { SprintDto, CreateSprintRequest, UpdateSprintRequest } from '@/types';
+import type { SprintDto, SprintVelocityDto, CreateSprintRequest, UpdateSprintRequest } from '@/types';
 
 export async function listSprints(projectId: number): Promise<SprintDto[]> {
   return apiGet<SprintDto[]>(`/projects/${projectId}/sprints`);
+}
+
+export async function getSprintVelocity(projectId: number): Promise<SprintVelocityDto[]> {
+  return apiGet<SprintVelocityDto[]>(`/projects/${projectId}/sprints/velocity`);
 }
 
 export async function createSprint(projectId: number, request: CreateSprintRequest): Promise<SprintDto> {

--- a/frontend/src/pages/reports/VelocityReport.tsx
+++ b/frontend/src/pages/reports/VelocityReport.tsx
@@ -1,37 +1,38 @@
 import { useState, useEffect, useCallback } from 'react';
-import { listSprints } from '@/api/sprints';
-import { listProjectTasks } from '@/api/tasks';
-import type { SprintDto, TaskDto } from '@/types';
+import { listSprints, getSprintVelocity } from '@/api/sprints';
+import type { SprintDto, SprintVelocityDto } from '@/types';
 import { formatDate, deadlineBadge, deadlineLabel } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
 
 export default function VelocityReport({ projectId }: { projectId: number | null }) {
   const [sprints, setSprints] = useState<SprintDto[]>([]);
-  const [tasks, setTasks] = useState<TaskDto[]>([]);
+  const [velocity, setVelocity] = useState<SprintVelocityDto[]>([]);
   const [loading, setLoading] = useState(false);
 
   const fetch = useCallback(async () => {
-    if (!projectId) { setSprints([]); setTasks([]); return; }
+    if (!projectId) { setSprints([]); setVelocity([]); return; }
     setLoading(true);
     try {
-      const [sprintData, taskData] = await Promise.all([
+      const [sprintData, velocityData] = await Promise.all([
         listSprints(projectId),
-        listProjectTasks(projectId, { size: 200 }),
+        getSprintVelocity(projectId),
       ]);
       setSprints(sprintData);
-      setTasks(taskData);
-    } catch { setSprints([]); setTasks([]); } finally { setLoading(false); }
+      setVelocity(velocityData);
+    } catch { setSprints([]); setVelocity([]); } finally { setLoading(false); }
   }, [projectId]);
 
   useEffect(() => { fetch(); }, [fetch]);
 
-  const sprintStats = sprints.map((sprint) => {
-    const sprintTasks = tasks.filter((i) => i.sprintId === sprint.id);
-    const completed = sprintTasks.filter((i) => { const st = i.statusName.toLowerCase(); return st.includes('done') || st.includes('complete'); }).length;
-    return { sprint, total: sprintTasks.length, completed, remaining: sprintTasks.length - completed };
+  const velocityMap = new Map(velocity.map(v => [v.sprintId, v]));
+  const sprintStats = sprints.map(sprint => {
+    const v = velocityMap.get(sprint.id);
+    const total = v?.totalTasks ?? 0;
+    const completed = v?.completedTasks ?? 0;
+    return { sprint, total, completed, remaining: total - completed };
   });
 
-  const maxTasks = Math.max(...sprintStats.map((s) => s.total), 1);
+  const maxTasks = Math.max(...sprintStats.map(s => s.total), 1);
 
   return (
     <div className="space-y-6">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -5,7 +5,7 @@ export type { ProjectDto, CreateProjectRequest, UpdateProjectRequest, MemberDto,
 export type { TaskDto, TaskPriority, CreateTaskRequest, UpdateTaskRequest, CommentDto, CreateCommentRequest, UpdateCommentRequest } from './task';
 export type { ProgramDto, CreateProgramRequest, UpdateProgramRequest, ProgramEvmMetrics } from './program';
 export type { OrganizationConfig, PublicConfigResponse } from './organization';
-export type { SprintDto, CreateSprintRequest, UpdateSprintRequest } from './sprint';
+export type { SprintDto, SprintVelocityDto, CreateSprintRequest, UpdateSprintRequest } from './sprint';
 export type { TimeLogDto, CreateTimeLogRequest, UpdateTimeLogRequest } from './timeLog';
 export type { WikiPageDto, WikiTreeItem, CreateWikiPageRequest, UpdateWikiPageRequest, WikiSearchHit } from './wiki';
 export type { RaidItemDto, CreateRaidItemRequest, UpdateRaidItemRequest, EvmMetrics, PortfolioSummary, CompanyPortfolioSummary, PhaseTimelineEntry, ProjectTimelineEntry, UserRateDto } from './pmo';

--- a/frontend/src/types/sprint.ts
+++ b/frontend/src/types/sprint.ts
@@ -10,6 +10,14 @@ export interface SprintDto {
   updatedAt: string;
 }
 
+export interface SprintVelocityDto {
+  sprintId: number;
+  sprintName: string;
+  status: string;
+  totalTasks: number;
+  completedTasks: number;
+}
+
 export interface CreateSprintRequest {
   name: string;
   goal?: string;


### PR DESCRIPTION
## Summary
- Added `GET /api/projects/{projectId}/sprints/velocity` backend endpoint that returns velocity data (sprintId, sprintName, status, totalTasks, completedTasks) per sprint
- Added `SprintVelocityDto` record and `TaskRepository` queries for counting total and completed (DONE/CLOSED) tasks per sprint
- Updated frontend `VelocityReport` to call the velocity endpoint instead of computing client-side from paginated task data
- Endpoint uses `requireProjectReadAccess` for proper authorization

## Test plan
- [ ] `GET /api/projects/1/sprints/velocity` returns 200 with velocity data per sprint
- [ ] Velocity counts match: completed = tasks with DONE/CLOSED status category
- [ ] Frontend Sprint Velocity tab shows data correctly
- [ ] Users without project access get 403

Refs #123