### PR TITLE
fix(#135): add company-scoped authorization to time logs endpoint

### DIFF
--- a/backend/src/main/java/com/nemo/timetracking/TimeLogController.java
+++ b/backend/src/main/java/com/nemo/timetracking/TimeLogController.java
@@ -53,11 +53,31 @@ public class TimeLogController {
             @RequestParam(defaultValue = "logDate,desc") String sort,
             @AuthenticationPrincipal UserDetails currentUser) {
 
-        if (userId != null && !userId.equals(authHelper.getCurrentUserId(currentUser))
-                && !authHelper.hasAnyRole(currentUser, "ADMIN", "MANAGER", "EXECUTIVE", "HR")) {
+        Long currentUserId = authHelper.getCurrentUserId(currentUser);
+        Long companyId = authHelper.getCurrentCompanyId(currentUser);
+        boolean isAdmin = authHelper.hasAnyRole(currentUser, "ADMIN");
+        boolean isManagerOrExecOrHr = authHelper.hasAnyRole(currentUser, "MANAGER", "EXECUTIVE", "HR");
+
+        Long filterUserId = userId;
+        Long filterCompanyId = null;
+
+        if (isAdmin) {
+            // ADMIN sees everything, no company filter
+        } else if (isManagerOrExecOrHr) {
+            // MANAGER/EXECUTIVE/HR see logs within their company
+            filterCompanyId = companyId;
+        } else {
+            // CONTRIBUTOR and EXTERNAL see only their own logs
+            filterUserId = currentUserId;
+            filterCompanyId = companyId;
+        }
+
+        // Non-privileged users cannot view other users' logs
+        if (userId != null && !userId.equals(currentUserId) && !isAdmin && !isManagerOrExecOrHr) {
             throw new com.nemo.common.exception.ForbiddenException("You can only view your own time logs");
         }
-        Page<TimeLog> result = timeLogService.search(userId, taskId, projectId, presaleId, startDate, endDate, page, size, sort);
+
+        Page<TimeLog> result = timeLogService.search(filterUserId, taskId, projectId, presaleId, startDate, endDate, filterCompanyId, page, size, sort);
         return ResponseEntity.ok(PaginatedResponse.of(
                 timeLogMapper.toDtoList(result.getContent()),
                 new PaginationInfo(page, size, result.getTotalElements(), result.getTotalPages())
@@ -69,8 +89,10 @@ public class TimeLogController {
             @PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
         TimeLog timeLog = timeLogService.getById(id);
         Long currentUserId = authHelper.getCurrentUserId(currentUser);
-        if (!timeLog.getUser().getId().equals(currentUserId)
-                && !authHelper.hasAnyRole(currentUser, "ADMIN", "MANAGER", "HR")) {
+        if (timeLog.getUser().getId().equals(currentUserId)) {
+            return ResponseEntity.ok(ApiResponse.of(timeLogMapper.toDto(timeLog)));
+        }
+        if (!authHelper.canAccessUser(currentUser, timeLog.getUser())) {
             throw new com.nemo.common.exception.ForbiddenException("You can only view your own time logs");
         }
         return ResponseEntity.ok(ApiResponse.of(timeLogMapper.toDto(timeLog)));
@@ -85,6 +107,11 @@ public class TimeLogController {
         if (!timeLog.getUser().getId().equals(currentUserId)
                 && !authHelper.hasAnyRole(currentUser, "ADMIN", "MANAGER")) {
             throw new com.nemo.common.exception.ForbiddenException("You can only edit your own time logs");
+        }
+        if (!timeLog.getUser().getId().equals(currentUserId) && authHelper.hasAnyRole(currentUser, "MANAGER")) {
+            if (!authHelper.canAccessUser(currentUser, timeLog.getUser())) {
+                throw new com.nemo.common.exception.ForbiddenException("You can only edit time logs within your company");
+            }
         }
         TimeLog updated = timeLogService.update(id, request);
         return ResponseEntity.ok(ApiResponse.of(timeLogMapper.toDto(updated)));

--- a/backend/src/main/java/com/nemo/timetracking/TimeLogRepository.java
+++ b/backend/src/main/java/com/nemo/timetracking/TimeLogRepository.java
@@ -19,8 +19,9 @@ public interface TimeLogRepository extends JpaRepository<TimeLog, Long> {
            "(:projectId IS NULL OR tl.task.project.id = :projectId) AND " +
            "(:presaleId IS NULL OR tl.presale.id = :presaleId) AND " +
            "(:startDate IS NULL OR tl.logDate >= :startDate) AND " +
-           "(:endDate IS NULL OR tl.logDate <= :endDate)")
-    Page<TimeLog> search(Long userId, Long taskId, Long projectId, Long presaleId, LocalDate startDate, LocalDate endDate, Pageable pageable);
+           "(:endDate IS NULL OR tl.logDate <= :endDate) AND " +
+           "(:companyId IS NULL OR tl.task.project.company.id = :companyId)")
+    Page<TimeLog> search(Long userId, Long taskId, Long projectId, Long presaleId, LocalDate startDate, LocalDate endDate, Long companyId, Pageable pageable);
 
     List<TimeLog> findByUserIdAndLogDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 

--- a/backend/src/main/java/com/nemo/timetracking/TimeLogService.java
+++ b/backend/src/main/java/com/nemo/timetracking/TimeLogService.java
@@ -67,10 +67,10 @@ public class TimeLogService {
     }
 
     @Transactional(readOnly = true)
-    public Page<TimeLog> search(Long userId, Long taskId, Long projectId, Long presaleId, LocalDate startDate, LocalDate endDate, int page, int size, String sort) {
+    public Page<TimeLog> search(Long userId, Long taskId, Long projectId, Long presaleId, LocalDate startDate, LocalDate endDate, Long companyId, int page, int size, String sort) {
         Sort.Direction direction = Sort.Direction.fromString(sort.split(",")[1]);
         PageRequest pageRequest = PageRequest.of(page, size, direction, sort.split(",")[0]);
-        return timeLogRepository.search(userId, taskId, projectId, presaleId, startDate, endDate, pageRequest);
+        return timeLogRepository.search(userId, taskId, projectId, presaleId, startDate, endDate, companyId, pageRequest);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary

`GET /api/time-logs` was returning all time logs regardless of the caller's role or company — CONTRIBUTORS and EXTERNAL users could see every team member's hours across all companies.

This PR adds role-based, company-scoped filtering following the same pattern used by `ProjectController.list`:

| Role | Can see |
|------|---------|
| ADMIN | All time logs (no filter) |
| MANAGER/EXECUTIVE/HR | Time logs within their own company |
| CONTRIBUTOR/EXTERNAL | Only their own time logs |

**Changes:**
- `TimeLogRepository.search()` — added `companyId` parameter to filter by `tl.task.project.company.id`
- `TimeLogService.search()` — passes `companyId` through to the repository
- `TimeLogController.list()` — determines `filterUserId` and `filterCompanyId` based on role; CONTRIBUTOR/EXTERNAL are forced to their own user ID
- `TimeLogController.get()` — uses `authHelper.canAccessUser()` instead of flat role check, so MANAGERs can't view logs from other companies
- `TimeLogController.update()` — MANAGERs can only edit logs from users in their own company

## Test plan

- [ ] Login as CONTRIBUTOR → `GET /api/time-logs` returns only own logs
- [ ] Login as EXTERNAL → `GET /api/time-logs` returns only own logs
- [ ] Login as MANAGER → `GET /api/time-logs` returns all logs from own company
- [ ] Login as EXECUTIVE (global) → `GET /api/time-logs` returns all logs
- [ ] Login as ADMIN → `GET /api/time-logs` returns all logs
- [ ] CONTRIBUTOR cannot view another user's single time log (`GET /api/time-logs/{id}`)
- [ ] MANAGER cannot view/edit a time log from a different company

Refs #135