### PR TITLE
feat(#136): add storyPoints field to tasks and sprint velocity

### DIFF
--- a/backend/src/main/java/com/nemo/config/DataSeeder.java
+++ b/backend/src/main/java/com/nemo/config/DataSeeder.java
@@ -732,6 +732,31 @@ public class DataSeeder implements CommandLineRunner {
         createTask("FTM-5", "Team lineup builder", footballTeam, done, Task.Priority.MEDIUM, dev, null, youssef, null, 4, null, ftmExec);
         createTask("FTM-6", "Injury tracking", footballTeam, done, Task.Priority.MEDIUM, dev, null, youssef, null, 5, LocalDate.of(2026, 1, 31), null);
 
+        // Story points for tasks
+        setStoryPoints(fse, "FSE-1", 5);
+        setStoryPoints(fse, "FSE-2", 3);
+        setStoryPoints(fse, "FSE-3", 8);
+        setStoryPoints(fse, "FSE-4", 5);
+        setStoryPoints(fse, "FSE-5", 3);
+        setStoryPoints(fse, "FSE-6", 8);
+        setStoryPoints(fse, "FSE-7", 13);
+        setStoryPoints(fse, "FSE-9", 3);
+        setStoryPoints(fse, "FSE-10", 5);
+        setStoryPoints(mobileApp, "MA-1", 5);
+        setStoryPoints(mobileApp, "MA-2", 3);
+        setStoryPoints(mobileApp, "MA-3", 8);
+        setStoryPoints(mobileApp, "MA-4", 13);
+        setStoryPoints(apiGateway, "AG-1", 8);
+        setStoryPoints(apiGateway, "AG-2", 5);
+        setStoryPoints(dataWarehouse, "DW-1", 5);
+        setStoryPoints(dataWarehouse, "DW-2", 8);
+        setStoryPoints(erpProject, "MER-1", 8);
+        setStoryPoints(erpProject, "MER-2", 13);
+        setStoryPoints(footballTeam, "FTM-1", 5);
+        setStoryPoints(footballTeam, "FTM-2", 8);
+        setStoryPoints(footballTeam, "FTM-3", 3);
+        setStoryPoints(footballTeam, "FTM-4", 5);
+
         // Labels
         createLabel(fse, "Frontend", "#3B82F6");
         createLabel(fse, "Backend", "#10B981");
@@ -1062,6 +1087,13 @@ public class DataSeeder implements CommandLineRunner {
         task.setDueDate(dueDate);
         task.setPhase(phase);
         return taskRepository.save(task);
+    }
+
+    private void setStoryPoints(Project project, String taskKey, int points) {
+        taskRepository.findAll().stream()
+                .filter(t -> t.getProject().getId().equals(project.getId()) && t.getTaskKey().equals(taskKey))
+                .findFirst()
+                .ifPresent(t -> { t.setStoryPoints(points); taskRepository.save(t); });
     }
 
     private Label createLabel(Project project, String name, String color) {

--- a/backend/src/main/java/com/nemo/sprint/SprintController.java
+++ b/backend/src/main/java/com/nemo/sprint/SprintController.java
@@ -99,11 +99,18 @@ public class SprintController {
         Map<Long, Long> completedBySprint = taskRepository.countCompletedBySprintIds(
                 sprintIds, List.of(TaskStatus.Category.DONE, TaskStatus.Category.CLOSED)).stream()
                 .collect(Collectors.toMap(arr -> (Long) arr[0], arr -> (Long) arr[1]));
+        Map<Long, Long> storyPointsBySprint = taskRepository.sumStoryPointsBySprintIds(sprintIds).stream()
+                .collect(Collectors.toMap(arr -> (Long) arr[0], arr -> (Long) arr[1]));
+        Map<Long, Long> completedStoryPointsBySprint = taskRepository.sumCompletedStoryPointsBySprintIds(
+                sprintIds, List.of(TaskStatus.Category.DONE, TaskStatus.Category.CLOSED)).stream()
+                .collect(Collectors.toMap(arr -> (Long) arr[0], arr -> (Long) arr[1]));
         List<SprintVelocityDto> result = sprints.stream()
                 .map(s -> new SprintVelocityDto(
                         s.getId(), s.getName(), s.getStatus().name(),
                         totalBySprint.getOrDefault(s.getId(), 0L).intValue(),
-                        completedBySprint.getOrDefault(s.getId(), 0L).intValue()))
+                        completedBySprint.getOrDefault(s.getId(), 0L).intValue(),
+                        storyPointsBySprint.getOrDefault(s.getId(), 0L).intValue(),
+                        completedStoryPointsBySprint.getOrDefault(s.getId(), 0L).intValue()))
                 .toList();
         return ResponseEntity.ok(ApiResponse.of(result));
     }

--- a/backend/src/main/java/com/nemo/sprint/SprintVelocityDto.java
+++ b/backend/src/main/java/com/nemo/sprint/SprintVelocityDto.java
@@ -5,5 +5,7 @@ public record SprintVelocityDto(
         String sprintName,
         String status,
         int totalTasks,
-        int completedTasks
+        int completedTasks,
+        int totalStoryPoints,
+        int completedStoryPoints
 ) {}

--- a/backend/src/main/java/com/nemo/task/Task.java
+++ b/backend/src/main/java/com/nemo/task/Task.java
@@ -82,6 +82,9 @@ public class Task {
     @Column(name = "due_date")
     private LocalDate dueDate;
 
+    @Column(name = "story_points")
+    private Integer storyPoints;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -123,6 +126,8 @@ public class Task {
     public void setLabels(Set<Label> labels) { this.labels = labels; }
     public LocalDate getDueDate() { return dueDate; }
     public void setDueDate(LocalDate dueDate) { this.dueDate = dueDate; }
+    public Integer getStoryPoints() { return storyPoints; }
+    public void setStoryPoints(Integer storyPoints) { this.storyPoints = storyPoints; }
     public Instant getCreatedAt() { return createdAt; }
     public Instant getUpdatedAt() { return updatedAt; }
 }

--- a/backend/src/main/java/com/nemo/task/TaskController.java
+++ b/backend/src/main/java/com/nemo/task/TaskController.java
@@ -84,7 +84,7 @@ public class TaskController {
         Long userId = authHelper.getCurrentUserId(currentUser);
         if (authHelper.isExternal(currentUser)) {
             request = new TaskDto.CreateRequest(request.title(), request.description(),
-                    request.priority(), request.typeId(), request.assigneeId(), request.phaseId(), request.labelIds(), true, request.dueDate());
+                    request.priority(), request.typeId(), request.assigneeId(), request.phaseId(), request.labelIds(), true, request.dueDate(), request.storyPoints());
         }
         Task created = taskService.create(projectId, request, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(taskMapper.toDto(created)));

--- a/backend/src/main/java/com/nemo/task/TaskDto.java
+++ b/backend/src/main/java/com/nemo/task/TaskDto.java
@@ -14,7 +14,7 @@ public record TaskDto(
         Long reporterId, String reporterName,
         Long sprintId, Long phaseId, String phaseName, int position, boolean external,
         List<Long> labelIds, List<String> labelNames,
-        String dueDate,
+        String dueDate, Integer storyPoints,
         String createdAt, String updatedAt
 ) {
     public record CreateRequest(
@@ -26,14 +26,15 @@ public record TaskDto(
             Long phaseId,
             List<Long> labelIds,
             Boolean external,
-            String dueDate
+            String dueDate,
+            Integer storyPoints
     ) {}
 
     public record UpdateRequest(
             String title, String description, String priority,
             Long typeId, Long assigneeId, Long statusId, Long sprintId, Long phaseId,
             List<Long> labelIds, Boolean external,
-            String dueDate
+            String dueDate, Integer storyPoints
     ) {}
 
     public record PositionRequest(int position, Long sprintId) {}

--- a/backend/src/main/java/com/nemo/task/TaskRepository.java
+++ b/backend/src/main/java/com/nemo/task/TaskRepository.java
@@ -43,4 +43,10 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     @Query("SELECT t.sprint.id, COUNT(t) FROM Task t WHERE t.sprint.id IN :sprintIds AND t.status.category IN :categories GROUP BY t.sprint.id")
     List<Object[]> countCompletedBySprintIds(@Param("sprintIds") List<Long> sprintIds, @Param("categories") List<TaskStatus.Category> categories);
+
+    @Query("SELECT t.sprint.id, COALESCE(SUM(t.storyPoints), 0) FROM Task t WHERE t.sprint.id IN :sprintIds GROUP BY t.sprint.id")
+    List<Object[]> sumStoryPointsBySprintIds(@Param("sprintIds") List<Long> sprintIds);
+
+    @Query("SELECT t.sprint.id, COALESCE(SUM(t.storyPoints), 0) FROM Task t WHERE t.sprint.id IN :sprintIds AND t.status.category IN :categories GROUP BY t.sprint.id")
+    List<Object[]> sumCompletedStoryPointsBySprintIds(@Param("sprintIds") List<Long> sprintIds, @Param("categories") List<TaskStatus.Category> categories);
 }

--- a/frontend/src/pages/TaskDetailPage.tsx
+++ b/frontend/src/pages/TaskDetailPage.tsx
@@ -28,6 +28,7 @@ export default function TaskDetailPage() {
   const [phaseId, setPhaseId] = useState('');
   const [selectedLabels, setSelectedLabels] = useState<number[]>([]);
   const [dueDate, setDueDate] = useState('');
+  const [storyPoints, setStoryPoints] = useState('');
 
   // Dropdown options
   const [statuses, setStatuses] = useState<TaskStatusDto[]>([]);
@@ -59,6 +60,7 @@ export default function TaskDetailPage() {
       setPhaseId(data.phaseId != null ? String(data.phaseId) : '');
       setSelectedLabels(data.labelIds);
       setDueDate(data.dueDate ?? '');
+      setStoryPoints(data.storyPoints != null ? String(data.storyPoints) : '');
     } finally {
       setLoading(false);
     }
@@ -90,6 +92,7 @@ export default function TaskDetailPage() {
         phaseId: phaseId ? Number(phaseId) : null,
         labelIds: selectedLabels,
         dueDate: dueDate || null,
+        storyPoints: storyPoints ? Number(storyPoints) : null,
       };
       const updated = await updateTask(Number(projectId), Number(taskId), req);
       setTask(updated);
@@ -184,6 +187,7 @@ export default function TaskDetailPage() {
                     ? <>{formatDate(task.dueDate)}{deadlineLabel(task.dueDate, task.statusCategory) && <span className={`inline-block ml-2 px-2 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(task.dueDate, task.statusCategory)}`}>{deadlineLabel(task.dueDate, task.statusCategory)}</span>}</>
                     : 'None'
                 } />
+                <DetailRow label="Story Points" value={task.storyPoints != null ? String(task.storyPoints) : 'None'} />
                 <DetailRow label="Sprint" value={task.sprintId ? `Sprint ${task.sprintId}` : 'Backlog'} />
                 <DetailRow label="Created" value={formatDate(task.createdAt)} />
                 <DetailRow label="Updated" value={formatDate(task.updatedAt)} />
@@ -241,6 +245,10 @@ export default function TaskDetailPage() {
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">Due Date</label>
                   <input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Story Points</label>
+                  <input type="number" min="0" placeholder="—" value={storyPoints} onChange={(e) => setStoryPoints(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
                 </div>
                 </>
                 )}

--- a/frontend/src/pages/project-detail/BoardTab.tsx
+++ b/frontend/src/pages/project-detail/BoardTab.tsx
@@ -131,6 +131,7 @@ export default function BoardTab({ projectId, projectKey, isExternal }: { projec
                   <div className="flex items-center gap-2 mb-1">
                     <span className="text-xs font-mono text-primary-600">{task.taskKey}</span>
                     <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-medium ${priorityColor(task.priority)}`}>{task.priority}</span>
+                    {task.storyPoints != null && <span className="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-100 text-indigo-700">{task.storyPoints} SP</span>}
                   </div>
                   <p className="text-sm font-medium text-gray-900 leading-snug mb-1.5">{task.title}</p>
                   <div className="flex items-center gap-2 text-xs text-gray-400">

--- a/frontend/src/pages/project-detail/CreateTaskModal.tsx
+++ b/frontend/src/pages/project-detail/CreateTaskModal.tsx
@@ -17,6 +17,7 @@ export default function CreateTaskModal({ projectId, projectKey, onClose, isExte
   const [phaseId, setPhaseId] = useState('');
   const [selectedLabels, setSelectedLabels] = useState<number[]>([]);
   const [dueDate, setDueDate] = useState('');
+  const [storyPoints, setStoryPoints] = useState('');
   const [types, setTypes] = useState<TaskTypeDto[]>([]);
   const [members, setMembers] = useState<MemberDto[]>([]);
   const [labels, setLabels] = useState<LabelDto[]>([]);
@@ -49,6 +50,7 @@ export default function CreateTaskModal({ projectId, projectKey, onClose, isExte
         phaseId: phaseId ? Number(phaseId) : undefined,
         labelIds: selectedLabels.length > 0 ? selectedLabels : undefined,
         dueDate: dueDate || undefined,
+        storyPoints: storyPoints ? Number(storyPoints) : undefined,
         ...(isExternal ? { external: true } : {}),
       });
       onClose();
@@ -118,6 +120,10 @@ export default function CreateTaskModal({ projectId, projectKey, onClose, isExte
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">Due Date</label>
           <input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Story Points</label>
+          <input type="number" min="0" placeholder="—" value={storyPoints} onChange={(e) => setStoryPoints(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
         </div>
         <div className="flex justify-end gap-3 pt-2">
           <button type="button" onClick={onClose} className="px-4 py-2 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-100">Cancel</button>

--- a/frontend/src/pages/reports/VelocityReport.tsx
+++ b/frontend/src/pages/reports/VelocityReport.tsx
@@ -29,7 +29,9 @@ export default function VelocityReport({ projectId }: { projectId: number | null
     const v = velocityMap.get(sprint.id);
     const total = v?.totalTasks ?? 0;
     const completed = v?.completedTasks ?? 0;
-    return { sprint, total, completed, remaining: total - completed };
+    const totalSP = v?.totalStoryPoints ?? 0;
+    const completedSP = v?.completedStoryPoints ?? 0;
+    return { sprint, total, completed, remaining: total - completed, totalSP, completedSP, remainingSP: totalSP - completedSP };
   });
 
   const maxTasks = Math.max(...sprintStats.map(s => s.total), 1);
@@ -46,7 +48,7 @@ export default function VelocityReport({ projectId }: { projectId: number | null
             <div className="text-center text-gray-400 py-8">No sprints found for this project</div>
           ) : (
             <div className="space-y-3">
-              {sprintStats.map(({ sprint, total, completed, remaining }) => (
+              {sprintStats.map(({ sprint, total, completed, remaining, totalSP, completedSP, remainingSP }) => (
                 <div key={sprint.id} className="bg-white rounded-xl border border-gray-200 p-4">
                   <div className="flex items-center justify-between mb-2">
                     <div>
@@ -63,7 +65,7 @@ export default function VelocityReport({ projectId }: { projectId: number | null
                       )}
                     </div>
                     <div className="text-sm text-gray-500">
-                      {completed}/{total} completed
+                      {completed}/{total} tasks · {completedSP}/{totalSP} SP
                     </div>
                   </div>
                   <div className="flex gap-1 h-6">

--- a/frontend/src/types/sprint.ts
+++ b/frontend/src/types/sprint.ts
@@ -16,6 +16,8 @@ export interface SprintVelocityDto {
   status: string;
   totalTasks: number;
   completedTasks: number;
+  totalStoryPoints: number;
+  completedStoryPoints: number;
 }
 
 export interface CreateSprintRequest {

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -27,6 +27,7 @@ export interface TaskDto {
   labelIds: number[];
   labelNames: string[];
   dueDate: string | null;
+  storyPoints: number | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -41,6 +42,7 @@ export interface CreateTaskRequest {
   labelIds?: number[];
   external?: boolean;
   dueDate?: string | null;
+  storyPoints?: number | null;
 }
 
 export interface UpdateTaskRequest {
@@ -55,6 +57,7 @@ export interface UpdateTaskRequest {
   labelIds?: number[];
   external?: boolean;
   dueDate?: string | null;
+  storyPoints?: number | null;
 }
 
 export interface CommentDto {


### PR DESCRIPTION
## Summary

Tasks had no `storyPoints` field, making sprint velocity tracking by effort impossible. This PR adds a nullable `storyPoints` integer to tasks and integrates it into the sprint velocity report.

**Backend changes:**
- `Task.java` — added `Integer storyPoints` field with getter/setter
- `TaskDto.java` — added `storyPoints` to `TaskDto`, `CreateRequest`, `UpdateRequest`
- `TaskController.java` — updated `CreateRequest` constructor call for external users
- `TaskRepository.java` — added `sumStoryPointsBySprintIds` and `sumCompletedStoryPointsBySprintIds` queries
- `SprintVelocityDto.java` — added `totalStoryPoints` and `completedStoryPoints` fields
- `SprintController.java` — velocity endpoint now aggregates story points per sprint
- `DataSeeder.java` — seeded Fibonacci story points (3,5,8,13) on key tasks

**Frontend changes:**
- `task.ts` — added `storyPoints` to `TaskDto`, `CreateTaskRequest`, `UpdateTaskRequest`
- `sprint.ts` — added `totalStoryPoints`, `completedStoryPoints` to `SprintVelocityDto`
- `BoardTab.tsx` — shows `5 SP` badge on task cards
- `CreateTaskModal.tsx` — added story points input field
- `TaskDetailPage.tsx` — shows story points in detail view, editable in edit mode
- `VelocityReport.tsx` — shows `3/8 tasks · 5/13 SP` alongside progress bars

## Test plan

- [ ] Create a task with story points → verify it saves and displays
- [ ] Create a task without story points → verify it shows "None" / "—" gracefully
- [ ] Edit a task's story points → verify the update persists
- [ ] View Kanban board → verify SP badge shows on cards that have story points
- [ ] View sprint velocity report → verify `totalStoryPoints` and `completedStoryPoints` are returned
- [ ] Verify seed data has story points on tasks (e.g., FSE-1 has 5 SP, FSE-3 has 8 SP)

Refs #136