### PR TITLE
fix(#138): always apply company filter in leave request listing

### DIFF
--- a/backend/src/main/java/com/nemo/leave/LeaveRequestRepository.java
+++ b/backend/src/main/java/com/nemo/leave/LeaveRequestRepository.java
@@ -30,6 +30,17 @@ public interface LeaveRequestRepository extends JpaRepository<LeaveRequest, Long
     @Query("SELECT lr FROM LeaveRequest lr WHERE lr.user.company.id = :companyId AND lr.status = :status ORDER BY lr.startDate DESC")
     List<LeaveRequest> findByCompanyIdAndStatus(Long companyId, LeaveRequest.Status status);
 
+    @Query("SELECT lr FROM LeaveRequest lr WHERE " +
+           "(:userId IS NULL OR lr.user.id = :userId) AND " +
+           "(:status IS NULL OR lr.status = :status) AND " +
+           "(:companyId IS NULL OR lr.user.company.id = :companyId) AND " +
+           "(:startDate IS NULL OR lr.startDate >= :startDate) AND " +
+           "(:endDate IS NULL OR lr.endDate <= :endDate) " +
+           "ORDER BY lr.startDate DESC")
+    List<LeaveRequest> search(@Param("userId") Long userId, @Param("status") LeaveRequest.Status status,
+                              @Param("companyId") Long companyId, @Param("startDate") LocalDate startDate,
+                              @Param("endDate") LocalDate endDate);
+
     long countByUserIdAndTypeAndStatus(Long userId, LeaveRequest.Type type, LeaveRequest.Status status);
 
     @Query("SELECT lr FROM LeaveRequest lr WHERE lr.user.id = :userId AND lr.type = :type AND lr.status = 'APPROVED' AND lr.startDate <= :yearEnd AND lr.endDate >= :yearStart")

--- a/backend/src/main/java/com/nemo/leave/LeaveRequestService.java
+++ b/backend/src/main/java/com/nemo/leave/LeaveRequestService.java
@@ -23,22 +23,7 @@ public class LeaveRequestService {
 
     @Transactional(readOnly = true)
     public List<LeaveRequest> list(Long userId, LeaveRequest.Status status, Long companyId, LocalDate startDate, LocalDate endDate) {
-        if (userId != null && status != null) {
-            return leaveRequestRepository.findByUserIdAndStatus(userId, status);
-        }
-        if (userId != null) {
-            return leaveRequestRepository.findByUserIdOrderByStartDateDesc(userId);
-        }
-        if (status != null) {
-            return leaveRequestRepository.findByStatus(status);
-        }
-        if (companyId != null) {
-            return leaveRequestRepository.findByCompanyId(companyId);
-        }
-        if (startDate != null && endDate != null) {
-            return leaveRequestRepository.findByDateRange(startDate, endDate);
-        }
-        return leaveRequestRepository.findAll();
+        return leaveRequestRepository.search(userId, status, companyId, startDate, endDate);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
- Replace priority-based dispatch in `LeaveRequestService.list()` with a unified JPQL search query that correctly combines all filter parameters (userId, status, companyId, dateRange)
- Previously, `companyId` was silently ignored when `userId` or `status` filters were active, allowing company-scoped managers to see leave requests from other companies

## Test plan
- [ ] Login as MANAGER (company-scoped) → `GET /api/leave-requests?status=PENDING` returns only requests from their company
- [ ] Login as MANAGER → `GET /api/leave-requests?userId=X&status=PENDING` returns only that user's requests within their company
- [ ] Login as CONTRIBUTOR → `GET /api/leave-requests` returns only their own requests
- [ ] Login as ADMIN → `GET /api/leave-requests` returns all requests (no company filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)