### PR TITLE
feat(#137): add portfolio EVM roll-up endpoint and fix EXECUTIVE scoping

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/PmoController.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoController.java
@@ -34,7 +34,7 @@ public class PmoController {
     @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
     public ResponseEntity<ApiResponse<PmoService.PortfolioSummary>> getPortfolioSummary(
             @AuthenticationPrincipal UserDetails currentUser) {
-        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN") ? null : authHelper.getCurrentCompanyId(currentUser);
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN", "EXECUTIVE") ? null : authHelper.getCurrentCompanyId(currentUser);
         return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioSummary(companyId)));
     }
 
@@ -43,7 +43,7 @@ public class PmoController {
     public ResponseEntity<ApiResponse<List<RaidItemDto>>> getPortfolioRaidItems(
             @RequestParam(required = false) RaidItem.RaidType type,
             @AuthenticationPrincipal UserDetails currentUser) {
-        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN") ? null : authHelper.getCurrentCompanyId(currentUser);
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN", "EXECUTIVE") ? null : authHelper.getCurrentCompanyId(currentUser);
         List<RaidItem> items = pmoService.getPortfolioRaidItems(type, companyId);
         return ResponseEntity.ok(ApiResponse.of(raidItemMapper.toDtoList(items)));
     }
@@ -52,7 +52,7 @@ public class PmoController {
     @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
     public ResponseEntity<ApiResponse<List<PmoService.CompanyPortfolioSummary>>> getPortfolioByCompany(
             @AuthenticationPrincipal UserDetails currentUser) {
-        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN") ? null : authHelper.getCurrentCompanyId(currentUser);
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN", "EXECUTIVE") ? null : authHelper.getCurrentCompanyId(currentUser);
         return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioByCompany(companyId)));
     }
 
@@ -60,7 +60,15 @@ public class PmoController {
     @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
     public ResponseEntity<ApiResponse<List<PmoService.ProjectTimelineEntry>>> getPortfolioTimeline(
             @AuthenticationPrincipal UserDetails currentUser) {
-        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN") ? null : authHelper.getCurrentCompanyId(currentUser);
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN", "EXECUTIVE") ? null : authHelper.getCurrentCompanyId(currentUser);
         return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioTimeline(companyId)));
+    }
+
+    @GetMapping("/portfolio/program-evm")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
+    public ResponseEntity<ApiResponse<List<PmoService.ProgramEvmMetrics>>> getProgramEvmRollup(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN", "EXECUTIVE") ? null : authHelper.getCurrentCompanyId(currentUser);
+        return ResponseEntity.ok(ApiResponse.of(pmoService.getProgramEvmRollup(companyId)));
     }
 }

--- a/backend/src/main/java/com/nemo/pmo/PmoService.java
+++ b/backend/src/main/java/com/nemo/pmo/PmoService.java
@@ -12,6 +12,8 @@ import com.nemo.phase.ClientPaymentRepository;
 import com.nemo.phase.PhaseRepository;
 import com.nemo.project.Project;
 import com.nemo.project.ProjectRepository;
+import com.nemo.program.Program;
+import com.nemo.program.ProgramRepository;
 import com.nemo.timetracking.TimeLog;
 import com.nemo.timetracking.TimeLogRepository;
 import com.nemo.timetracking.UserRate;
@@ -30,6 +32,7 @@ import java.util.Map;
 public class PmoService {
 
     private final ProjectRepository projectRepository;
+    private final ProgramRepository programRepository;
     private final TaskRepository taskRepository;
     private final TaskStatusRepository taskStatusRepository;
     private final TimeLogRepository timeLogRepository;
@@ -41,6 +44,7 @@ public class PmoService {
     private final ProjectExpenseRepository expenseRepository;
 
     public PmoService(ProjectRepository projectRepository,
+                      ProgramRepository programRepository,
                       TaskRepository taskRepository,
                       TaskStatusRepository taskStatusRepository,
                       TimeLogRepository timeLogRepository,
@@ -51,6 +55,7 @@ public class PmoService {
                       ClientPaymentRepository clientPaymentRepository,
                       ProjectExpenseRepository expenseRepository) {
         this.projectRepository = projectRepository;
+        this.programRepository = programRepository;
         this.taskRepository = taskRepository;
         this.taskStatusRepository = taskStatusRepository;
         this.timeLogRepository = timeLogRepository;
@@ -419,10 +424,21 @@ public class PmoService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public List<ProgramEvmMetrics> getProgramEvmRollup(Long companyId) {
+        List<Program> programs = programRepository.findAllByCompanyIdOrNull(companyId);
+        return programs.stream()
+                .map(p -> computeProgramEvm(p.getId()))
+                .toList();
+    }
+
     public record CompanyPortfolioSummary(
             Long companyId, String companyName, String companyKey,
             int totalProjects, long totalTasks, long totalCompleted,
-            BigDecimal totalBudget, BigDecimal totalExpenseCost,
+            BigDecimal totalBudget, BigDecimal totalPlannedValue, BigDecimal totalEarnedValue,
+            BigDecimal totalActualCost, BigDecimal totalExpenseCost,
+            BigDecimal costVariance, BigDecimal scheduleVariance,
+            BigDecimal cpi, BigDecimal spi,
             long totalOpenRisks, long totalMitigatingRisks,
             Map<String, Long> stageDistribution
     ) {}
@@ -462,7 +478,11 @@ public class PmoService {
             long totalTasks = 0;
             long totalCompleted = 0;
             BigDecimal totalBudget = BigDecimal.ZERO;
+            BigDecimal totalPlannedValue = BigDecimal.ZERO;
+            BigDecimal totalEarnedValue = BigDecimal.ZERO;
+            BigDecimal totalActualCost = BigDecimal.ZERO;
             BigDecimal totalExpenseCost = BigDecimal.ZERO;
+            BigDecimal totalPvToday = BigDecimal.ZERO;
             long totalOpenRisks = 0;
             long totalMitigatingRisks = 0;
 
@@ -476,10 +496,53 @@ public class PmoService {
                 totalCompleted += projCompleted;
 
                 if (p.getBudget() != null) totalBudget = totalBudget.add(p.getBudget());
-                totalExpenseCost = totalExpenseCost.add(computeExpenseCost(p.getId()));
+
+                // Per-project EVM
+                List<Phase> phases = phaseRepository.findByProjectIdOrderByPositionAsc(p.getId());
+                BigDecimal derivedPv = phases.stream()
+                        .map(ph -> ph.getPlannedAmount() != null ? ph.getPlannedAmount() : BigDecimal.ZERO)
+                        .reduce(BigDecimal.ZERO, BigDecimal::add);
+                BigDecimal projPv = derivedPv.compareTo(BigDecimal.ZERO) > 0
+                        ? derivedPv
+                        : (p.getPlannedValue() != null ? p.getPlannedValue() : BigDecimal.ZERO);
+                totalPlannedValue = totalPlannedValue.add(projPv);
+
+                BigDecimal projCompletion = projTotal > 0
+                        ? BigDecimal.valueOf(projCompleted).divide(BigDecimal.valueOf(projTotal), 4, RoundingMode.HALF_UP)
+                        : BigDecimal.ZERO;
+                totalEarnedValue = totalEarnedValue.add(projCompletion.multiply(projPv).setScale(2, RoundingMode.HALF_UP));
+
+                BigDecimal projLabor = computeLaborCost(p.getId());
+                BigDecimal projExpense = computeExpenseCost(p.getId());
+                totalActualCost = totalActualCost.add(projLabor.add(projExpense).setScale(2, RoundingMode.HALF_UP));
+                totalExpenseCost = totalExpenseCost.add(projExpense);
+
+                totalPvToday = totalPvToday.add(computePlannedValueToday(p, projPv));
 
                 totalOpenRisks += raidItemRepository.countByProjectIdAndStatus(p.getId(), RaidItem.RaidStatus.OPEN);
                 totalMitigatingRisks += raidItemRepository.countByProjectIdAndStatus(p.getId(), RaidItem.RaidStatus.MITIGATING);
+            }
+
+            // Company-level EVM
+            BigDecimal costVariance = totalEarnedValue.subtract(totalActualCost).setScale(2, RoundingMode.HALF_UP);
+            BigDecimal scheduleVariance = totalEarnedValue.subtract(totalPvToday).setScale(2, RoundingMode.HALF_UP);
+
+            BigDecimal cpi;
+            if (totalEarnedValue.compareTo(BigDecimal.ZERO) > 0 && totalActualCost.compareTo(BigDecimal.ZERO) > 0) {
+                cpi = totalEarnedValue.divide(totalActualCost, 2, RoundingMode.HALF_UP);
+            } else if (totalActualCost.compareTo(BigDecimal.ZERO) > 0) {
+                cpi = BigDecimal.ZERO;
+            } else {
+                cpi = null;
+            }
+
+            BigDecimal spi;
+            if (totalEarnedValue.compareTo(BigDecimal.ZERO) > 0 && totalPvToday.compareTo(BigDecimal.ZERO) > 0) {
+                spi = totalEarnedValue.divide(totalPvToday, 2, RoundingMode.HALF_UP);
+            } else if (totalPvToday.compareTo(BigDecimal.ZERO) > 0) {
+                spi = BigDecimal.ZERO;
+            } else {
+                spi = null;
             }
 
             Map<String, Long> stageDistribution = companyProjects.stream()
@@ -490,7 +553,10 @@ public class PmoService {
             result.add(new CompanyPortfolioSummary(
                     cid == 0L ? null : cid, companyName, companyKey,
                     totalProjects, totalTasks, totalCompleted,
-                    totalBudget, totalExpenseCost,
+                    totalBudget, totalPlannedValue, totalEarnedValue,
+                    totalActualCost, totalExpenseCost,
+                    costVariance, scheduleVariance,
+                    cpi, spi,
                     totalOpenRisks, totalMitigatingRisks,
                     stageDistribution
             ));

--- a/backend/src/main/java/com/nemo/program/ProgramController.java
+++ b/backend/src/main/java/com/nemo/program/ProgramController.java
@@ -45,7 +45,7 @@ public class ProgramController {
         if (managedBy != null) {
             result = programService.searchManaged(managedBy, search, page, size, sort);
         } else {
-            Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN") ? null : authHelper.getCurrentCompanyId(currentUser);
+            Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN", "EXECUTIVE") ? null : authHelper.getCurrentCompanyId(currentUser);
             result = programService.search(search, companyId, page, size, sort);
         }
         List<ProgramDto> dtos = programService.enrichWithProjectCount(programMapper.toDtoList(result.getContent()));

--- a/backend/src/main/java/com/nemo/program/ProgramRepository.java
+++ b/backend/src/main/java/com/nemo/program/ProgramRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface ProgramRepository extends JpaRepository<Program, Long> {
     boolean existsByKey(String key);
 
@@ -21,6 +23,9 @@ public interface ProgramRepository extends JpaRepository<Program, Long> {
 
     @Query("SELECT p FROM Program p WHERE (:companyId IS NULL OR p.company.id = :companyId)")
     Page<Program> findByCompanyIdOrNull(Long companyId, Pageable pageable);
+
+    @Query("SELECT p FROM Program p WHERE (:companyId IS NULL OR p.company.id = :companyId)")
+    List<Program> findAllByCompanyIdOrNull(Long companyId);
 
     @Query("SELECT p FROM Program p WHERE p.manager.id = :managerId AND (:search IS NULL OR LOWER(p.name) LIKE LOWER(CONCAT('%', :search, '%')) OR LOWER(p.key) LIKE LOWER(CONCAT('%', :search, '%')))")
     Page<Program> findByManagerIdWithSearch(Long managerId, String search, Pageable pageable);


### PR DESCRIPTION
## Summary
- Add `GET /api/pmo/portfolio/program-evm` endpoint that returns EVM metrics for all programs at once, so EXECUTIVE can see cross-company portfolio data without querying each program individually
- Fix PmoController and ProgramController company scoping: ADMIN **and** EXECUTIVE see all companies' data (was ADMIN-only); MANAGER/HR remain scoped to their own company
- Enrich `CompanyPortfolioSummary` with EVM fields: `totalPlannedValue`, `totalEarnedValue`, `totalActualCost`, `costVariance`, `scheduleVariance`, `cpi`, `spi`
- Add `ProgramRepository.findAllByCompanyIdOrNull` for non-paginated program queries

## Test plan
- [ ] Login as EXECUTIVE (avery) → `GET /api/pmo/portfolio` returns all companies' data
- [ ] Login as EXECUTIVE → `GET /api/pmo/portfolio/by-company` returns per-company EVM metrics including CPI/SPI
- [ ] Login as EXECUTIVE → `GET /api/pmo/portfolio/program-evm` returns EVM for all programs
- [ ] Login as MANAGER (company-scoped) → portfolio endpoints return only their company's data
- [ ] Login as ADMIN → portfolio endpoints return all data

🤖 Generated with [Claude Code](https://claude.com/claude-code)