### PR TITLE
fix(#145): use projectId from URL path in RAID creation instead of body

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/RaidItemController.java
+++ b/backend/src/main/java/com/nemo/pmo/RaidItemController.java
@@ -52,7 +52,7 @@ public class RaidItemController {
     public ResponseEntity<ApiResponse<RaidItemDto>> create(
             @PathVariable Long projectId,
             @Valid @RequestBody RaidItemDto.CreateRequest request) {
-        RaidItem created = raidItemService.create(request);
+        RaidItem created = raidItemService.create(projectId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(raidItemMapper.toDto(created)));
     }
 

--- a/backend/src/main/java/com/nemo/pmo/RaidItemDto.java
+++ b/backend/src/main/java/com/nemo/pmo/RaidItemDto.java
@@ -25,7 +25,6 @@ public record RaidItemDto(
         String updatedAt
 ) {
     public record CreateRequest(
-            @NotNull Long projectId,
             @NotNull RaidItem.RaidType type,
             @NotBlank String title,
             String description,

--- a/backend/src/main/java/com/nemo/pmo/RaidItemService.java
+++ b/backend/src/main/java/com/nemo/pmo/RaidItemService.java
@@ -43,9 +43,9 @@ public class RaidItemService {
     }
 
     @Transactional
-    public RaidItem create(RaidItemDto.CreateRequest request) {
-        Project project = projectRepository.findById(request.projectId())
-                .orElseThrow(() -> new EntityNotFoundException("Project", request.projectId()));
+    public RaidItem create(Long projectId, RaidItemDto.CreateRequest request) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new EntityNotFoundException("Project", projectId));
 
         RaidItem item = new RaidItem();
         item.setProject(project);

--- a/frontend/src/pages/project-detail/RaidTab.tsx
+++ b/frontend/src/pages/project-detail/RaidTab.tsx
@@ -39,7 +39,7 @@ export default function RaidTab({ projectId, canEdit }: { projectId: number; can
         });
       } else {
         await createRaidItem(projectId, {
-          projectId, type: form.type, title: form.title, description: form.description || undefined,
+          type: form.type, title: form.title, description: form.description || undefined,
           probability: form.probability ? Number(form.probability) : undefined,
           impact: form.impact ? Number(form.impact) : undefined,
           mitigationPlan: form.mitigationPlan || undefined, dueDate: form.dueDate || undefined,

--- a/frontend/src/types/pmo.ts
+++ b/frontend/src/types/pmo.ts
@@ -19,7 +19,6 @@ export interface RaidItemDto {
 }
 
 export interface CreateRaidItemRequest {
-  projectId: number;
   type: 'RISK' | 'ASSUMPTION' | 'TASK' | 'DEPENDENCY';
   title: string;
   description?: string;


### PR DESCRIPTION
## Summary
- Remove `projectId` from `CreateRequest` DTO and `@NotNull` validation — the project ID comes from the URL path parameter, not the request body
- Controller now passes path variable `projectId` to `RaidItemService.create(projectId, request)` instead of relying on `request.projectId()`
- Frontend `RaidTab` no longer sends redundant `projectId` in create request body

## Test plan
- [ ] `POST /api/projects/1/raid` with body `{ "type": "RISK", "title": "Test" }` returns 201 (no `projectId` in body needed)
- [ ] `POST /api/projects/1/raid` with body including `"projectId": 1` still works (backward compatible)
- [ ] Frontend RAID creation form works without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)