### PR TITLE
fix(#146): allow CONTRIBUTOR to read and submit project expenses

### DIFF
--- a/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
+++ b/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
@@ -28,7 +28,7 @@ public class ProjectExpenseController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('MANAGER', 'EXECUTIVE')")
+    @PreAuthorize("hasAnyRole('MANAGER', 'EXECUTIVE', 'CONTRIBUTOR', 'HR')")
     public ResponseEntity<ApiResponse<List<ProjectExpenseDto>>> list(
             @PathVariable Long projectId,
             @AuthenticationPrincipal UserDetails currentUser) {
@@ -37,7 +37,7 @@ public class ProjectExpenseController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyRole('MANAGER')")
+    @PreAuthorize("hasAnyRole('MANAGER', 'CONTRIBUTOR')")
     public ResponseEntity<ApiResponse<ProjectExpenseDto>> create(
             @PathVariable Long projectId,
             @RequestBody ProjectExpenseDto.CreateRequest request,


### PR DESCRIPTION
## Summary
- `GET /api/projects/{id}/expenses`: add CONTRIBUTOR and HR roles (was MANAGER/EXECUTIVE only)
- `POST /api/projects/{id}/expenses`: add CONTRIBUTOR role so they can submit expense claims (was MANAGER only)
- PUT/DELETE remain MANAGER-only (approve/manage)

This aligns expense access with RAID and time-log endpoints where CONTRIBUTOR already has read + create access.

## Test plan
- [ ] Login as CONTRIBUTOR → `GET /api/projects/1/expenses` returns 200
- [ ] Login as CONTRIBUTOR → `POST /api/projects/1/expenses` returns 201
- [ ] Login as CONTRIBUTOR → `PUT /api/projects/1/expenses/1` still returns 403
- [ ] Login as MANAGER → all expense endpoints work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)