### PR TITLE
fix(#137): add portfolio and reports endpoint aliases for EXECUTIVE access

### DIFF
--- a/backend/src/main/java/com/nemo/portfolio/PortfolioController.java
+++ b/backend/src/main/java/com/nemo/portfolio/PortfolioController.java
@@ -1,0 +1,71 @@
+package com.nemo.portfolio;
+
+import com.nemo.common.dto.ApiResponse;
+import com.nemo.pmo.PmoService;
+import com.nemo.pmo.RaidItem;
+import com.nemo.pmo.RaidItemMapper;
+import com.nemo.security.AuthHelper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/portfolio")
+public class PortfolioController {
+
+    private final PmoService pmoService;
+    private final RaidItemMapper raidItemMapper;
+    private final AuthHelper authHelper;
+
+    public PortfolioController(PmoService pmoService, RaidItemMapper raidItemMapper, AuthHelper authHelper) {
+        this.pmoService = pmoService;
+        this.raidItemMapper = raidItemMapper;
+        this.authHelper = authHelper;
+    }
+
+    @GetMapping("/overview")
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXECUTIVE', 'MANAGER', 'HR')")
+    public ResponseEntity<ApiResponse<PmoService.PortfolioSummary>> getOverview(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN", "EXECUTIVE") ? null : authHelper.getCurrentCompanyId(currentUser);
+        return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioSummary(companyId)));
+    }
+
+    @GetMapping("/projects")
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXECUTIVE', 'MANAGER', 'HR')")
+    public ResponseEntity<ApiResponse<List<PmoService.CompanyPortfolioSummary>>> getProjects(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN", "EXECUTIVE") ? null : authHelper.getCurrentCompanyId(currentUser);
+        return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioByCompany(companyId)));
+    }
+
+    @GetMapping("/evm")
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXECUTIVE', 'MANAGER', 'HR')")
+    public ResponseEntity<ApiResponse<List<PmoService.ProgramEvmMetrics>>> getEvmRollup(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN", "EXECUTIVE") ? null : authHelper.getCurrentCompanyId(currentUser);
+        return ResponseEntity.ok(ApiResponse.of(pmoService.getProgramEvmRollup(companyId)));
+    }
+
+    @GetMapping("/timeline")
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXECUTIVE', 'MANAGER', 'HR')")
+    public ResponseEntity<ApiResponse<List<PmoService.ProjectTimelineEntry>>> getTimeline(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN", "EXECUTIVE") ? null : authHelper.getCurrentCompanyId(currentUser);
+        return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioTimeline(companyId)));
+    }
+
+    @GetMapping("/raid")
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXECUTIVE', 'MANAGER', 'HR')")
+    public ResponseEntity<ApiResponse<List<com.nemo.pmo.RaidItemDto>>> getRaidItems(
+            @RequestParam(required = false) RaidItem.RaidType type,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN", "EXECUTIVE") ? null : authHelper.getCurrentCompanyId(currentUser);
+        List<RaidItem> items = pmoService.getPortfolioRaidItems(type, companyId);
+        return ResponseEntity.ok(ApiResponse.of(raidItemMapper.toDtoList(items)));
+    }
+}

--- a/backend/src/main/java/com/nemo/reports/ReportController.java
+++ b/backend/src/main/java/com/nemo/reports/ReportController.java
@@ -1,0 +1,39 @@
+package com.nemo.reports;
+
+import com.nemo.common.dto.ApiResponse;
+import com.nemo.pmo.PmoService;
+import com.nemo.security.AuthHelper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/reports")
+public class ReportController {
+
+    private final PmoService pmoService;
+    private final AuthHelper authHelper;
+
+    public ReportController(PmoService pmoService, AuthHelper authHelper) {
+        this.pmoService = pmoService;
+        this.authHelper = authHelper;
+    }
+
+    @GetMapping("/evm")
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXECUTIVE', 'MANAGER', 'HR')")
+    public ResponseEntity<ApiResponse<PmoService.PortfolioSummary>> getEvmReport(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN", "EXECUTIVE") ? null : authHelper.getCurrentCompanyId(currentUser);
+        return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioSummary(companyId)));
+    }
+
+    @GetMapping("/budget")
+    @PreAuthorize("hasAnyRole('ADMIN', 'EXECUTIVE', 'MANAGER', 'HR')")
+    public ResponseEntity<ApiResponse<PmoService.PortfolioSummary>> getBudgetReport(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.hasAnyRole(currentUser, "ADMIN", "EXECUTIVE") ? null : authHelper.getCurrentCompanyId(currentUser);
+        return ResponseEntity.ok(ApiResponse.of(pmoService.getPortfolioSummary(companyId)));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PortfolioController` at `/api/portfolio/*` with: `/overview`, `/projects`, `/evm`, `/timeline`, `/raid`
- Add `ReportController` at `/api/reports/*` with: `/evm`, `/budget`
- Both controllers delegate to existing `PmoService` with EXECUTIVE seeing cross-company data (same as `/api/pmo/*` endpoints)
- Fixes the tester's 500 errors when hitting `/api/portfolio/overview`, `/api/reports/evm`, etc.

## Test plan
- [ ] `GET /api/portfolio/overview` as avery (EXECUTIVE) returns portfolio summary across all companies
- [ ] `GET /api/portfolio/projects` as avery returns per-company project breakdown
- [ ] `GET /api/portfolio/evm` as avery returns program EVM rollup
- [ ] `GET /api/reports/evm` as avery returns portfolio EVM summary
- [ ] `GET /api/reports/budget` as avery returns budget summary
- [ ] All above endpoints return 403 for CONTRIBUTOR/EXTERNAL roles

Refs #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)