### PR TITLE
fix(#152): use labeled dropdowns for RAID probability/impact fields

### DIFF
--- a/frontend/src/pages/project-detail/RaidTab.tsx
+++ b/frontend/src/pages/project-detail/RaidTab.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { RaidItemDto } from '@/types';
 import { listRaidItems, createRaidItem, updateRaidItem, deleteRaidItem } from '@/api/pmo';
-import { riskColor, riskLabel, raidTypeColor, raidStatusBadge } from '@/utils/format';
+import { riskColor, riskLabel, raidTypeColor, raidStatusBadge, probabilityImpactLabel } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
 
 export default function RaidTab({ projectId, canEdit }: { projectId: number; canEdit: boolean }) {
@@ -109,12 +109,26 @@ export default function RaidTab({ projectId, canEdit }: { projectId: number; can
           {form.type === 'RISK' && (
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <div>
-                <label className="block text-xs font-medium text-gray-500 mb-1">Probability (1-5)</label>
-                <input type="number" min="1" max="5" value={form.probability} onChange={e => setForm(f => ({ ...f, probability: e.target.value }))} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+                <label className="block text-xs font-medium text-gray-500 mb-1">Probability</label>
+                <select value={form.probability} onChange={e => setForm(f => ({ ...f, probability: e.target.value }))} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm">
+                  <option value="">—</option>
+                  <option value="1">1 – Very Low</option>
+                  <option value="2">2 – Low</option>
+                  <option value="3">3 – Medium</option>
+                  <option value="4">4 – High</option>
+                  <option value="5">5 – Critical</option>
+                </select>
               </div>
               <div>
-                <label className="block text-xs font-medium text-gray-500 mb-1">Impact (1-5)</label>
-                <input type="number" min="1" max="5" value={form.impact} onChange={e => setForm(f => ({ ...f, impact: e.target.value }))} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" />
+                <label className="block text-xs font-medium text-gray-500 mb-1">Impact</label>
+                <select value={form.impact} onChange={e => setForm(f => ({ ...f, impact: e.target.value }))} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm">
+                  <option value="">—</option>
+                  <option value="1">1 – Very Low</option>
+                  <option value="2">2 – Low</option>
+                  <option value="3">3 – Medium</option>
+                  <option value="4">4 – High</option>
+                  <option value="5">5 – Critical</option>
+                </select>
               </div>
               <div>
                 <label className="block text-xs font-medium text-gray-500 mb-1">Mitigation Plan</label>
@@ -158,6 +172,8 @@ export default function RaidTab({ projectId, canEdit }: { projectId: number; can
                   {item.description && <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.description}</p>}
                   {item.mitigationPlan && <p className="text-sm text-blue-600 mt-1"><span className="font-medium">Mitigation:</span> {item.mitigationPlan}</p>}
                   <div className="flex items-center gap-3 mt-2 text-xs text-gray-400">
+                    {item.probability != null && <span>P: {probabilityImpactLabel(item.probability)}</span>}
+                    {item.impact != null && <span>I: {probabilityImpactLabel(item.impact)}</span>}
                     {item.ownerName && <span>Owner: {item.ownerName}</span>}
                     {item.dueDate && <span>Due: {item.dueDate}</span>}
                   </div>

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -57,6 +57,18 @@ export function riskLabel(score: number): string {
   return 'Low';
 }
 
+export function probabilityImpactLabel(value: number | null): string {
+  if (value == null) return '—';
+  switch (value) {
+    case 1: return '1 – Very Low';
+    case 2: return '2 – Low';
+    case 3: return '3 – Medium';
+    case 4: return '4 – High';
+    case 5: return '5 – Critical';
+    default: return String(value);
+  }
+}
+
 export function stageBadge(stage: string | null): string {
   switch (stage) {
     case 'INITIATION': return 'bg-blue-100 text-blue-800';


### PR DESCRIPTION
## Summary
- Replace bare number inputs for probability and impact with select dropdowns showing human-readable labels (1=Very Low, 2=Low, 3=Medium, 4=High, 5=Critical)
- Display probability and impact values with labels in RAID item cards
- Add `probabilityImpactLabel()` utility function to format 1-5 scale values

## Test plan
- [ ] Open RAID tab on a project and click "Add Item"
- [ ] Select type "Risk" — probability and impact should show dropdowns with labeled options
- [ ] Create a RAID item with probability=4, impact=5 — should succeed without 500 error
- [ ] Verify the item card shows "P: 4 – High" and "I: 5 – Critical"
- [ ] Edit existing RAID item — probability/impact dropdowns should show current values
- [ ] Create RAID item without probability/impact (type=ASSUMPTION) — should work fine

Refs #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)