### PR TITLE
fix(#152): accept string enum values for RAID probability/impact

### DIFF
--- a/backend/src/main/java/com/nemo/pmo/RaidItemDto.java
+++ b/backend/src/main/java/com/nemo/pmo/RaidItemDto.java
@@ -1,5 +1,6 @@
 package com.nemo.pmo;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -29,8 +30,8 @@ public record RaidItemDto(
             @NotBlank String title,
             String description,
             RaidItem.RaidStatus status,
-            Integer probability,
-            Integer impact,
+            @JsonDeserialize(using = RiskScaleDeserializer.class) Integer probability,
+            @JsonDeserialize(using = RiskScaleDeserializer.class) Integer impact,
             String mitigationPlan,
             Long dependsOnProjectId,
             Long ownerId,
@@ -42,8 +43,8 @@ public record RaidItemDto(
             String title,
             String description,
             RaidItem.RaidStatus status,
-            Integer probability,
-            Integer impact,
+            @JsonDeserialize(using = RiskScaleDeserializer.class) Integer probability,
+            @JsonDeserialize(using = RiskScaleDeserializer.class) Integer impact,
             String mitigationPlan,
             Long dependsOnProjectId,
             Long ownerId,

--- a/backend/src/main/java/com/nemo/pmo/RiskScaleDeserializer.java
+++ b/backend/src/main/java/com/nemo/pmo/RiskScaleDeserializer.java
@@ -1,0 +1,50 @@
+package com.nemo.pmo;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Deserializes RAID probability/impact values that can be either integers (1-5)
+ * or string enums (VERY_LOW, LOW, MEDIUM, HIGH, CRITICAL).
+ */
+public class RiskScaleDeserializer extends JsonDeserializer<Integer> {
+
+    private static final Map<String, Integer> STRING_TO_INT = Map.of(
+            "VERY_LOW", 1,
+            "LOW", 2,
+            "MEDIUM", 3,
+            "HIGH", 4,
+            "CRITICAL", 5
+    );
+
+    @Override
+    public Integer deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        switch (p.currentToken()) {
+            case VALUE_NUMBER_INT:
+                return p.getIntValue();
+            case VALUE_STRING:
+                String text = p.getText().trim().toUpperCase();
+                if (text.isEmpty()) {
+                    return null;
+                }
+                Integer mapped = STRING_TO_INT.get(text);
+                if (mapped != null) {
+                    return mapped;
+                }
+                try {
+                    return Integer.parseInt(text);
+                } catch (NumberFormatException e) {
+                    throw new IOException("Invalid risk scale value: '" + p.getText() +
+                            "'. Expected integer (1-5) or string (VERY_LOW, LOW, MEDIUM, HIGH, CRITICAL).");
+                }
+            case VALUE_NULL:
+                return null;
+            default:
+                throw new IOException("Unexpected token for risk scale value: " + p.currentToken());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `RiskScaleDeserializer` custom Jackson deserializer that accepts both integer (1-5) and string enum values (VERY_LOW, LOW, MEDIUM, HIGH, CRITICAL) for `probability` and `impact` fields
- Annotate `probability` and `impact` fields in `RaidItemDto.CreateRequest` and `UpdateRequest` with `@JsonDeserialize(using = RiskScaleDeserializer.class)`
- String enum mapping: VERY_LOW→1, LOW→2, MEDIUM→3, HIGH→4, CRITICAL→5
- Plain integer values still work as before (backward compatible)

## Test plan
- [ ] `POST /api/projects/1/raid` with `{"probability": "MEDIUM", "impact": "HIGH"}` → 200 OK
- [ ] `POST /api/projects/1/raid` with `{"probability": 3, "impact": 4}` → 200 OK (existing behavior)
- [ ] `PUT /api/projects/1/raid/{id}` with string enums → 200 OK
- [ ] Frontend RAID form still works (sends integers)

Refs #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)