### PR TITLE
fix(#163): add /balance alias for leave balance endpoint

### DIFF
--- a/backend/src/main/java/com/nemo/leave/LeaveRequestController.java
+++ b/backend/src/main/java/com/nemo/leave/LeaveRequestController.java
@@ -169,6 +169,15 @@ public class LeaveRequestController {
 
     // --- Balance endpoints ---
 
+    @GetMapping("/balance")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<List<LeaveBalanceDto>>> getBalance(
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) Integer year,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        return getBalances(userId, year, currentUser);
+    }
+
     @GetMapping("/balances")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<List<LeaveBalanceDto>>> getBalances(


### PR DESCRIPTION
## Summary
- Add `GET /api/leave-requests/balance` (singular) as an alias that delegates to the existing `GET /api/leave-requests/balances` endpoint
- The tester hit `/balance` (singular) and got 500 "No static resource" — the endpoint only existed at `/balances` (plural)
- Both URLs now work identically

## Test plan
- [ ] `GET /api/leave-requests/balance` → 200 with balance list
- [ ] `GET /api/leave-requests/balance?userId=3` → 200 (HR can query other users)
- [ ] `GET /api/leave-requests/balances` → 200 (existing endpoint still works)
- [ ] Regular user can only see their own balances

Refs #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)