### PR TITLE
fix(#164): add program milestones endpoint

### DIFF
--- a/backend/src/main/java/com/nemo/phase/DeliverableRepository.java
+++ b/backend/src/main/java/com/nemo/phase/DeliverableRepository.java
@@ -12,6 +12,9 @@ public interface DeliverableRepository extends JpaRepository<Deliverable, Long> 
 
     List<Deliverable> findByPhaseProjectId(Long projectId);
 
+    @Query("SELECT d FROM Deliverable d JOIN FETCH d.phase WHERE d.phase.project.id IN :projectIds ORDER BY d.dueDate ASC")
+    List<Deliverable> findByProjectProgramId(@Param("projectIds") List<Long> projectIds);
+
     long countByPhaseId(Long phaseId);
 
     @Query("SELECT d.phase.id, COUNT(d) FROM Deliverable d WHERE d.phase.id IN :phaseIds GROUP BY d.phase.id")

--- a/backend/src/main/java/com/nemo/program/ProgramController.java
+++ b/backend/src/main/java/com/nemo/program/ProgramController.java
@@ -3,7 +3,13 @@ package com.nemo.program;
 import com.nemo.common.dto.ApiResponse;
 import com.nemo.common.dto.PaginatedResponse;
 import com.nemo.common.dto.PaginatedResponse.PaginationInfo;
+import com.nemo.common.exception.EntityNotFoundException;
+import com.nemo.phase.Deliverable;
+import com.nemo.phase.DeliverableDto;
+import com.nemo.phase.DeliverableMapper;
+import com.nemo.phase.DeliverableRepository;
 import com.nemo.pmo.PmoService;
+import com.nemo.project.ProjectRepository;
 import com.nemo.security.AuthHelper;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
@@ -24,12 +30,18 @@ public class ProgramController {
     private final ProgramMapper programMapper;
     private final AuthHelper authHelper;
     private final PmoService pmoService;
+    private final ProjectRepository projectRepository;
+    private final DeliverableRepository deliverableRepository;
+    private final DeliverableMapper deliverableMapper;
 
-    public ProgramController(ProgramService programService, ProgramMapper programMapper, AuthHelper authHelper, PmoService pmoService) {
+    public ProgramController(ProgramService programService, ProgramMapper programMapper, AuthHelper authHelper, PmoService pmoService, ProjectRepository projectRepository, DeliverableRepository deliverableRepository, DeliverableMapper deliverableMapper) {
         this.programService = programService;
         this.programMapper = programMapper;
         this.authHelper = authHelper;
         this.pmoService = pmoService;
+        this.projectRepository = projectRepository;
+        this.deliverableRepository = deliverableRepository;
+        this.deliverableMapper = deliverableMapper;
     }
 
     @GetMapping
@@ -66,6 +78,18 @@ public class ProgramController {
     @PreAuthorize("hasAnyRole('MANAGER', 'EXECUTIVE')")
     public ResponseEntity<ApiResponse<PmoService.ProgramEvmMetrics>> getEvm(@PathVariable Long id) {
         return ResponseEntity.ok(ApiResponse.of(pmoService.computeProgramEvm(id)));
+    }
+
+    @GetMapping("/{id}/milestones")
+    public ResponseEntity<ApiResponse<List<DeliverableDto>>> getMilestones(@PathVariable Long id) {
+        programService.getById(id); // validate program exists
+        List<Long> projectIds = projectRepository.findByProgramId(id).stream()
+                .map(p -> p.getId()).toList();
+        if (projectIds.isEmpty()) {
+            return ResponseEntity.ok(ApiResponse.of(List.of()));
+        }
+        List<Deliverable> deliverables = deliverableRepository.findByProjectProgramId(projectIds);
+        return ResponseEntity.ok(ApiResponse.of(deliverableMapper.toDtoList(deliverables)));
     }
 
     @PostMapping


### PR DESCRIPTION
## Summary
- Add `GET /api/programs/{id}/milestones` that returns all deliverables across the program's projects, ordered by due date
- New `DeliverableRepository.findByProjectProgramId()` query with `JOIN FETCH d.phase` to avoid lazy loading
- Returns empty list if program has no projects
- Follows same auth pattern as program detail endpoint (any authenticated user)

## Test plan
- [ ] `GET /api/programs/1/milestones` → 200 with list of deliverables (each with phaseId, phaseName, dueDate, state)
- [ ] `GET /api/programs/999/milestones` → 404 (program not found)
- [ ] Program with no projects → returns empty array
- [ ] MANAGER sees milestones for programs in their company; EXECUTIVE/ADMIN sees all

Refs #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)