### PR TITLE
fix(#171): add sprint burndown endpoint

### DIFF
--- a/backend/src/main/java/com/nemo/sprint/SprintBurndownDto.java
+++ b/backend/src/main/java/com/nemo/sprint/SprintBurndownDto.java
@@ -1,0 +1,19 @@
+package com.nemo.sprint;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record SprintBurndownDto(
+        Long sprintId,
+        String sprintName,
+        LocalDate startDate,
+        LocalDate endDate,
+        int totalStoryPoints,
+        List<DataPoint> data
+) {
+    public record DataPoint(
+            String date,
+            double idealRemaining,
+            double actualRemaining
+    ) {}
+}

--- a/backend/src/main/java/com/nemo/sprint/SprintController.java
+++ b/backend/src/main/java/com/nemo/sprint/SprintController.java
@@ -17,6 +17,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -113,5 +114,50 @@ public class SprintController {
                         completedStoryPointsBySprint.getOrDefault(s.getId(), 0L).intValue()))
                 .toList();
         return ResponseEntity.ok(ApiResponse.of(result));
+    }
+
+    @GetMapping("/{sprintId}/burndown")
+    public ResponseEntity<ApiResponse<SprintBurndownDto>> burndown(
+            @PathVariable Long projectId, @PathVariable Long sprintId,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, projectId);
+        Sprint sprint = sprintService.getById(sprintId);
+
+        // Get all tasks in this sprint
+        Page<Task> tasks = taskRepository.findByProjectId(projectId, PageRequest.of(0, 500));
+        List<Task> sprintTasks = tasks.getContent().stream()
+                .filter(t -> t.getSprint() != null && t.getSprint().getId().equals(sprintId))
+                .toList();
+
+        int totalSP = sprintTasks.stream()
+                .mapToInt(t -> t.getStoryPoints() != null ? t.getStoryPoints() : 0)
+                .sum();
+        int completedSP = sprintTasks.stream()
+                .filter(t -> t.getStatus() != null && t.getStatus().getCategory() != null
+                        && (t.getStatus().getCategory() == TaskStatus.Category.DONE
+                        || t.getStatus().getCategory() == TaskStatus.Category.CLOSED))
+                .mapToInt(t -> t.getStoryPoints() != null ? t.getStoryPoints() : 0)
+                .sum();
+
+        LocalDate start = sprint.getStartDate();
+        LocalDate end = sprint.getEndDate();
+        if (start == null || end == null) {
+            return ResponseEntity.ok(ApiResponse.of(new SprintBurndownDto(sprintId, sprint.getName(), null, null, totalSP, List.of())));
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalDate lastDay = today.isBefore(end) ? today : end;
+        long totalDays = java.time.temporal.ChronoUnit.DAYS.between(start, end) + 1;
+        double dailyBurn = totalDays > 0 ? (double) totalSP / totalDays : 0;
+
+        List<SprintBurndownDto.DataPoint> data = new java.util.ArrayList<>();
+        for (LocalDate day = start; !day.isAfter(lastDay); day = day.plusDays(1)) {
+            long daysElapsed = java.time.temporal.ChronoUnit.DAYS.between(start, day) + 1;
+            double ideal = Math.max(0, totalSP - (dailyBurn * daysElapsed));
+            data.add(new SprintBurndownDto.DataPoint(day.toString(), Math.round(ideal * 100) / 100.0, totalSP - completedSP));
+        }
+
+        return ResponseEntity.ok(ApiResponse.of(new SprintBurndownDto(
+                sprintId, sprint.getName(), start, end, totalSP, data)));
     }
 }


### PR DESCRIPTION
## Summary
- Add `GET /api/projects/{projectId}/sprints/{sprintId}/burndown` endpoint
- Returns `SprintBurndownDto` with sprint info (id, name, dates, total story points) and daily data points
- Each data point has `date`, `idealRemaining` (linear decrease from total SP to 0), and `actualRemaining` (total SP minus completed SP)
- Data points span from sprint start to today (or sprint end if already past)

## Test plan
- [ ] Call `GET /api/projects/{projectId}/sprints/{sprintId}/burndown` — should return 200 with burndown data
- [ ] Verify ideal line starts at totalSP and decreases linearly to 0 at sprint end
- [ ] Verify actual line shows remaining SP based on completed tasks
- [ ] Verify endpoint returns empty data list if sprint has null dates

Refs #171