### PR TITLE
fix(#172): add ISSUE to RaidType enum and update UI

### DIFF
--- a/backend/src/main/java/com/nemo/config/DataSeeder.java
+++ b/backend/src/main/java/com/nemo/config/DataSeeder.java
@@ -719,6 +719,11 @@ public class DataSeeder implements CommandLineRunner {
                 "Assuming existing hospital systems expose HL7/FHIR APIs",
                 RaidItem.RaidStatus.OPEN, null, null, null, null, null);
 
+        createRaidItem(eHealthPortal, RaidItem.RaidType.ISSUE, "Sandbox environment downtime",
+                "Staging server crashes daily causing blocked testing cycles",
+                RaidItem.RaidStatus.OPEN, null, null, "Escalated to infra team, pending root cause analysis",
+                dev1, today.plusWeeks(1));
+
         createRaidItem(mobilePay, RaidItem.RaidType.RISK, "Payment gateway integration complexity",
                 "Multiple payment providers with different APIs and compliance rules",
                 RaidItem.RaidStatus.OPEN, 3, 4, "Start with single provider, add others incrementally",
@@ -737,6 +742,11 @@ public class DataSeeder implements CommandLineRunner {
         createRaidItem(dataWarehouse, RaidItem.RaidType.DEPENDENCY, "Source system API availability",
                 "Data extraction depends on uptime and API access of 5 source systems",
                 RaidItem.RaidStatus.OPEN, null, null, null, majid, today.plusMonths(2));
+
+        createRaidItem(dataWarehouse, RaidItem.RaidType.ISSUE, "ETL pipeline failures",
+                "Nightly ETL jobs failing intermittently causing stale dashboards",
+                RaidItem.RaidStatus.MITIGATING, null, null, "Added retry logic and alerting on job failures",
+                dev2, today.plusWeeks(2));
 
         createRaidItem(footballTeam, RaidItem.RaidType.RISK, "Data privacy regulations",
                 "Player health data subject to GDPR and local privacy laws",
@@ -924,6 +934,11 @@ public class DataSeeder implements CommandLineRunner {
         createRaidItem(mobileApp, RaidItem.RaidType.TASK, "Memory leak on Android",
                 "Android builds showing increasing memory usage over time",
                 RaidItem.RaidStatus.MITIGATING, null, null, null, dev3, today.plusWeeks(3));
+
+        createRaidItem(mobileApp, RaidItem.RaidType.ISSUE, "Push notification delays",
+                "iOS push notifications arriving 5-10 minutes late in production",
+                RaidItem.RaidStatus.OPEN, null, null, "Investigating APNs connection pooling",
+                dev3, today.plusWeeks(1));
 
         createRaidItem(apiGateway, RaidItem.RaidType.RISK, "Scalability bottleneck",
                 "Current architecture may not handle 10x traffic growth",

--- a/backend/src/main/java/com/nemo/pmo/RaidItem.java
+++ b/backend/src/main/java/com/nemo/pmo/RaidItem.java
@@ -13,7 +13,7 @@ import java.time.LocalDate;
 @Table(name = "raid_item")
 public class RaidItem {
 
-    public enum RaidType { RISK, ASSUMPTION, TASK, DEPENDENCY }
+    public enum RaidType { RISK, ASSUMPTION, ISSUE, TASK, DEPENDENCY }
     public enum RaidStatus { OPEN, MITIGATING, RESOLVED, CLOSED }
 
     @Id

--- a/frontend/src/pages/project-detail/RaidTab.tsx
+++ b/frontend/src/pages/project-detail/RaidTab.tsx
@@ -73,7 +73,7 @@ export default function RaidTab({ projectId, canEdit }: { projectId: number; can
     <div className="space-y-4">
       <div className="flex items-center justify-between flex-wrap gap-y-2">
         <div className="flex gap-2">
-          {['ALL', 'RISK', 'ASSUMPTION', 'TASK', 'DEPENDENCY'].map(f => (
+          {['ALL', 'RISK', 'ISSUE', 'ASSUMPTION', 'TASK', 'DEPENDENCY'].map(f => (
             <button key={f} onClick={() => setFilter(f)}
               className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
                 filter === f ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
@@ -94,7 +94,7 @@ export default function RaidTab({ projectId, canEdit }: { projectId: number; can
             <div>
               <label className="block text-xs font-medium text-gray-500 mb-1">Type</label>
               <select value={form.type} onChange={e => setForm(f => ({ ...f, type: e.target.value as RaidItemDto['type'] }))} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm">
-                <option value="RISK">Risk</option><option value="ASSUMPTION">Assumption</option><option value="TASK">Task</option><option value="DEPENDENCY">Dependency</option>
+                <option value="RISK">Risk</option><option value="ISSUE">Issue</option><option value="ASSUMPTION">Assumption</option><option value="TASK">Task</option><option value="DEPENDENCY">Dependency</option>
               </select>
             </div>
             <div className="sm:col-span-2">

--- a/frontend/src/types/pmo.ts
+++ b/frontend/src/types/pmo.ts
@@ -2,7 +2,7 @@ export interface RaidItemDto {
   id: number;
   projectId: number;
   projectName: string;
-  type: 'RISK' | 'ASSUMPTION' | 'TASK' | 'DEPENDENCY';
+  type: 'RISK' | 'ASSUMPTION' | 'ISSUE' | 'TASK' | 'DEPENDENCY';
   title: string;
   description: string | null;
   status: 'OPEN' | 'MITIGATING' | 'RESOLVED' | 'CLOSED';
@@ -19,7 +19,7 @@ export interface RaidItemDto {
 }
 
 export interface CreateRaidItemRequest {
-  type: 'RISK' | 'ASSUMPTION' | 'TASK' | 'DEPENDENCY';
+  type: 'RISK' | 'ASSUMPTION' | 'ISSUE' | 'TASK' | 'DEPENDENCY';
   title: string;
   description?: string;
   status?: 'OPEN' | 'MITIGATING' | 'RESOLVED' | 'CLOSED';
@@ -32,7 +32,7 @@ export interface CreateRaidItemRequest {
 }
 
 export interface UpdateRaidItemRequest {
-  type?: 'RISK' | 'ASSUMPTION' | 'TASK' | 'DEPENDENCY';
+  type?: 'RISK' | 'ASSUMPTION' | 'ISSUE' | 'TASK' | 'DEPENDENCY';
   title?: string;
   description?: string | null;
   status?: 'OPEN' | 'MITIGATING' | 'RESOLVED' | 'CLOSED';

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -87,6 +87,7 @@ export function stageLabel(stage: string | null): string {
 export function raidTypeColor(type: string): string {
   switch (type) {
     case 'RISK': return 'bg-red-50 text-red-700 border-red-200';
+    case 'ISSUE': return 'bg-rose-50 text-rose-700 border-rose-200';
     case 'ASSUMPTION': return 'bg-blue-50 text-blue-700 border-blue-200';
     case 'TASK': return 'bg-orange-50 text-orange-700 border-orange-200';
     case 'DEPENDENCY': return 'bg-purple-50 text-purple-700 border-purple-200';


### PR DESCRIPTION
## Summary
- Add `ISSUE` to `RaidItem.RaidType` enum (backend) — the "I" in RAID was missing
- Update frontend TypeScript types to include `ISSUE` in the RAID type union
- Add `ISSUE` to RAID tab filter buttons and form select dropdown
- Add `ISSUE` color mapping in format utils (rose)

## Test plan
- [ ] `POST /api/projects/{id}/raid` with `"type": "ISSUE"` returns 201 Created
- [ ] `GET /api/projects/{id}/raid?type=ISSUE` returns only ISSUE-type items
- [ ] RAID tab in UI shows "Issues" filter button and "Issue" option in the form select

Refs #172