### PR TITLE
fix(#174): add per-project EVM endpoint at /api/projects/{id}/evm

### DIFF
--- a/backend/src/main/java/com/nemo/project/ProjectController.java
+++ b/backend/src/main/java/com/nemo/project/ProjectController.java
@@ -5,6 +5,7 @@ import com.nemo.common.dto.PaginatedResponse;
 import com.nemo.common.dto.PaginatedResponse.PaginationInfo;
 import com.nemo.common.exception.ForbiddenException;
 import com.nemo.config.TaskStatus;
+import com.nemo.pmo.PmoService;
 import com.nemo.security.AuthHelper;
 import com.nemo.task.TaskRepository;
 import com.nemo.user.User;
@@ -33,13 +34,15 @@ public class ProjectController {
     private final AuthHelper authHelper;
     private final UserRepository userRepository;
     private final TaskRepository taskRepository;
+    private final PmoService pmoService;
 
-    public ProjectController(ProjectService projectService, ProjectMapper projectMapper, AuthHelper authHelper, UserRepository userRepository, TaskRepository taskRepository) {
+    public ProjectController(ProjectService projectService, ProjectMapper projectMapper, AuthHelper authHelper, UserRepository userRepository, TaskRepository taskRepository, PmoService pmoService) {
         this.projectService = projectService;
         this.projectMapper = projectMapper;
         this.authHelper = authHelper;
         this.userRepository = userRepository;
         this.taskRepository = taskRepository;
+        this.pmoService = pmoService;
     }
 
     @GetMapping
@@ -106,6 +109,13 @@ public class ProjectController {
                 favoriteIds.contains(dto.id()),
                 dto.createdAt(), dto.updatedAt());
         return ResponseEntity.ok(ApiResponse.of(enriched));
+    }
+
+    @GetMapping("/{id}/evm")
+    public ResponseEntity<ApiResponse<PmoService.EvmMetrics>> getEvm(
+            @PathVariable Long id, @AuthenticationPrincipal UserDetails currentUser) {
+        authHelper.requireProjectReadAccess(currentUser, id);
+        return ResponseEntity.ok(ApiResponse.of(pmoService.computeEvm(id)));
     }
 
     @PostMapping


### PR DESCRIPTION
## Summary
- Add `GET /api/projects/{id}/evm` endpoint to `ProjectController`
- Delegates to existing `PmoService.computeEvm()` — same calculation logic as `/api/pmo/evm/{projectId}`
- Protected by project read access check (accessible to all roles with project access)

## Test plan
- [ ] `GET /api/projects/{id}/evm` returns 200 with EVM metrics (PV, EV, AC, CPI, SPI, CV, SV)
- [ ] Works for MANAGER and EXECUTIVE roles
- [ ] Returns sensible defaults (0 values) for projects with no time logs
- [ ] Returns 403 for users without project access

Refs #174