### PR TITLE
fix(#189): add sprint start/complete endpoints with business logic

### DIFF
--- a/backend/src/main/java/com/nemo/sprint/SprintController.java
+++ b/backend/src/main/java/com/nemo/sprint/SprintController.java
@@ -85,6 +85,22 @@ public class SprintController {
         return ResponseEntity.ok(ApiResponse.of(sprintMapper.toDto(updated)));
     }
 
+    @PostMapping("/{sprintId}/start")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    public ResponseEntity<ApiResponse<SprintDto>> start(
+            @PathVariable Long projectId, @PathVariable Long sprintId) {
+        Sprint started = sprintService.start(sprintId);
+        return ResponseEntity.ok(ApiResponse.of(sprintMapper.toDto(started)));
+    }
+
+    @PostMapping("/{sprintId}/complete")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    public ResponseEntity<ApiResponse<SprintDto>> complete(
+            @PathVariable Long projectId, @PathVariable Long sprintId) {
+        Sprint completed = sprintService.complete(sprintId);
+        return ResponseEntity.ok(ApiResponse.of(sprintMapper.toDto(completed)));
+    }
+
     @GetMapping("/velocity")
     public ResponseEntity<ApiResponse<List<SprintVelocityDto>>> velocity(
             @PathVariable Long projectId,

--- a/backend/src/main/java/com/nemo/sprint/SprintService.java
+++ b/backend/src/main/java/com/nemo/sprint/SprintService.java
@@ -1,6 +1,9 @@
 package com.nemo.sprint;
 
 import com.nemo.common.exception.EntityNotFoundException;
+import com.nemo.common.exception.ForbiddenException;
+import com.nemo.config.TaskStatus;
+import com.nemo.task.Task;
 import com.nemo.task.TaskRepository;
 import com.nemo.project.Project;
 import com.nemo.project.ProjectRepository;
@@ -14,10 +17,13 @@ public class SprintService {
 
     private final SprintRepository sprintRepository;
     private final ProjectRepository projectRepository;
+    private final TaskRepository taskRepository;
 
-    public SprintService(SprintRepository sprintRepository, ProjectRepository projectRepository) {
+    public SprintService(SprintRepository sprintRepository, ProjectRepository projectRepository,
+                         TaskRepository taskRepository) {
         this.sprintRepository = sprintRepository;
         this.projectRepository = projectRepository;
+        this.taskRepository = taskRepository;
     }
 
     @Transactional(readOnly = true)
@@ -62,6 +68,44 @@ public class SprintService {
     public Sprint updateStatus(Long id, SprintDto.StatusUpdateRequest request) {
         Sprint sprint = getById(id);
         sprint.setStatus(Sprint.SprintStatus.valueOf(request.status()));
+        return sprintRepository.save(sprint);
+    }
+
+    @Transactional
+    public Sprint start(Long sprintId) {
+        Sprint sprint = getById(sprintId);
+        if (sprint.getStatus() != Sprint.SprintStatus.PLANNING) {
+            throw new ForbiddenException("Only PLANNING sprints can be started. Current status: " + sprint.getStatus());
+        }
+        List<Sprint> activeSprints = sprintRepository.findByProjectIdAndStatus(
+                sprint.getProject().getId(), Sprint.SprintStatus.ACTIVE);
+        if (!activeSprints.isEmpty()) {
+            throw new ForbiddenException("Project already has an active sprint (Sprint '" +
+                    activeSprints.get(0).getName() + "'). Complete it first.");
+        }
+        sprint.setStatus(Sprint.SprintStatus.ACTIVE);
+        return sprintRepository.save(sprint);
+    }
+
+    @Transactional
+    public Sprint complete(Long sprintId) {
+        Sprint sprint = getById(sprintId);
+        if (sprint.getStatus() != Sprint.SprintStatus.ACTIVE) {
+            throw new ForbiddenException("Only ACTIVE sprints can be completed. Current status: " + sprint.getStatus());
+        }
+        sprint.setStatus(Sprint.SprintStatus.CLOSED);
+
+        // Move incomplete tasks out of this sprint (set sprint = null → backlog)
+        List<Task> sprintTasks = taskRepository.findBySprintId(sprintId);
+        for (Task task : sprintTasks) {
+            if (task.getStatus() != null
+                    && task.getStatus().getCategory() != TaskStatus.Category.DONE
+                    && task.getStatus().getCategory() != TaskStatus.Category.CLOSED) {
+                task.setSprint(null);
+                taskRepository.save(task);
+            }
+        }
+
         return sprintRepository.save(sprint);
     }
 }

--- a/backend/src/main/java/com/nemo/task/TaskRepository.java
+++ b/backend/src/main/java/com/nemo/task/TaskRepository.java
@@ -56,6 +56,8 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
            "WHERE t.project.id = :projectId AND t.sprint.id IS NULL")
     Page<Task> findByProjectIdAndSprintIdIsNull(Long projectId, Pageable pageable);
 
+    List<Task> findBySprintId(Long sprintId);
+
     @Query("SELECT t.sprint.id, COUNT(t) FROM Task t WHERE t.sprint.id IN :sprintIds GROUP BY t.sprint.id")
     List<Object[]> countBySprintIds(@Param("sprintIds") List<Long> sprintIds);
 

--- a/frontend/src/api/sprints.ts
+++ b/frontend/src/api/sprints.ts
@@ -20,3 +20,11 @@ export async function updateSprint(projectId: number, sprintId: number, request:
 export async function updateSprintStatus(projectId: number, sprintId: number, status: string): Promise<SprintDto> {
   return apiPut<SprintDto>(`/projects/${projectId}/sprints/${sprintId}/status`, { status });
 }
+
+export async function startSprint(projectId: number, sprintId: number): Promise<SprintDto> {
+  return apiPost<SprintDto>(`/projects/${projectId}/sprints/${sprintId}/start`);
+}
+
+export async function completeSprint(projectId: number, sprintId: number): Promise<SprintDto> {
+  return apiPost<SprintDto>(`/projects/${projectId}/sprints/${sprintId}/complete`);
+}

--- a/frontend/src/pages/project-detail/SprintsTab.tsx
+++ b/frontend/src/pages/project-detail/SprintsTab.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useMemo } from 'react';
-import { listSprints } from '@/api/sprints';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { listSprints, startSprint, completeSprint } from '@/api/sprints';
 import { listProjectTasks } from '@/api/tasks';
 import type { SprintDto, TaskDto } from '@/types';
 import { deadlineBadge, deadlineLabel } from '@/utils/format';
@@ -13,7 +13,7 @@ interface SprintsTabProps {
 const statusColors: Record<string, string> = {
   ACTIVE: 'bg-green-100 text-green-800',
   PLANNING: 'bg-blue-100 text-blue-800',
-  COMPLETED: 'bg-gray-100 text-gray-800',
+  CLOSED: 'bg-gray-100 text-gray-800',
 };
 
 export default function SprintsTab({ projectId, canEdit }: SprintsTabProps) {
@@ -21,15 +21,30 @@ export default function SprintsTab({ projectId, canEdit }: SprintsTabProps) {
   const [tasks, setTasks] = useState<TaskDto[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
+  const fetchData = useCallback(() => {
     Promise.all([listSprints(projectId), listProjectTasks(projectId)])
       .then(([sprintData, taskData]) => {
         setSprints(sprintData);
         setTasks(taskData);
       })
-      .catch(() => {})
-      .finally(() => setLoading(false));
+      .catch(() => {});
   }, [projectId]);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchData().finally(() => setLoading(false));
+  }, [fetchData]);
+
+  const handleStart = async (sprintId: number) => {
+    await startSprint(projectId, sprintId);
+    fetchData();
+  };
+
+  const handleComplete = async (sprintId: number) => {
+    if (!confirm('Complete this sprint? Incomplete tasks will be moved to the backlog.')) return;
+    await completeSprint(projectId, sprintId);
+    fetchData();
+  };
 
   const tasksBySprint = useMemo(() => {
     const map: Record<number | string, TaskDto[]> = {};
@@ -69,6 +84,20 @@ export default function SprintsTab({ projectId, canEdit }: SprintsTabProps) {
                   <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${deadlineBadge(sprint.endDate!)}`}>
                     {deadlineLabel(sprint.endDate!)}
                   </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {canEdit && sprint.status === 'PLANNING' && (
+                  <button onClick={() => handleStart(sprint.id)}
+                    className="text-xs font-medium text-green-700 hover:text-green-900 bg-green-50 hover:bg-green-100 px-2.5 py-1 rounded-md border border-green-200">
+                    Start Sprint
+                  </button>
+                )}
+                {canEdit && sprint.status === 'ACTIVE' && (
+                  <button onClick={() => handleComplete(sprint.id)}
+                    className="text-xs font-medium text-amber-700 hover:text-amber-900 bg-amber-50 hover:bg-amber-100 px-2.5 py-1 rounded-md border border-amber-200">
+                    Complete Sprint
+                  </button>
                 )}
               </div>
               {sprint.goal && <p className="text-sm text-gray-500 max-w-md truncate">{sprint.goal}</p>}


### PR DESCRIPTION
## Summary
- Add `POST /api/projects/{id}/sprints/{sprintId}/start` (PLANNING → ACTIVE) with one-active-sprint enforcement
- Add `POST /api/projects/{id}/sprints/{sprintId}/complete` (ACTIVE → CLOSED) with automatic move of incomplete tasks to backlog
- Add Start Sprint / Complete Sprint buttons in SprintsTab
- Fix status label: CLOSED (not COMPLETED) matches SprintStatus enum

## Test plan
- [ ] `POST /api/projects/{id}/sprints/{id}/complete` sets sprint status to CLOSED and returns 200
- [ ] `POST /api/projects/{id}/sprints/{id}/start` sets PLANNING sprint to ACTIVE
- [ ] Starting a second active sprint returns 409
- [ ] Incomplete tasks from a completed sprint appear in the backlog (no sprintId)

Refs #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)