### PR TITLE
fix(#191): global users see all projects in project listing

### DIFF
--- a/backend/src/main/java/com/nemo/project/ProjectController.java
+++ b/backend/src/main/java/com/nemo/project/ProjectController.java
@@ -72,6 +72,9 @@ public class ProjectController {
             }
         } else if (isAdmin) {
             result = projectService.search(search, programId, managerId, null, page, size, sort);
+        } else if (authHelper.isGlobalUser(currentUser)) {
+            // Global user (no company) — see all projects across all companies
+            result = projectService.search(search, programId, managerId, null, page, size, sort);
         } else if (isManagerOrExecutive || isHr) {
             result = projectService.search(search, programId, managerId, companyId, page, size, sort);
         } else {


### PR DESCRIPTION
## Summary
- FINANCE role's `GET /api/projects` returned empty for global users (company=null)
- Added a global-user check so users without a company see all projects across all companies
- Role-agnostic — applies to FINANCE or any future global role without role-specific branches

## Test plan
- [ ] `GET /api/projects` as `alex` (FINANCE) returns all projects (not empty)
- [ ] `GET /api/projects` as `jordan` (MANAGER) still shows only their company's projects (no regression)
- [ ] `GET /api/projects` as `basma` (EXTERNAL) still shows only assigned project (no regression)

Refs #191