### PR TITLE
feat(#195): add GET /api/finance/payments endpoint with year-scoped views

### DIFF
--- a/backend/src/main/java/com/nemo/finance/FinanceController.java
+++ b/backend/src/main/java/com/nemo/finance/FinanceController.java
@@ -54,4 +54,14 @@ public class FinanceController {
         FinanceDashboardDto.DashboardResponse dashboard = financeService.getDashboard(companyId);
         return ResponseEntity.ok(ApiResponse.of(dashboard));
     }
+
+    @GetMapping("/payments")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<FinanceDashboardDto.YearPaymentsResponse>> getPayments(
+            @RequestParam(required = false) Integer year) {
+        if (year == null) {
+            year = java.time.LocalDate.now().getYear();
+        }
+        return ResponseEntity.ok(ApiResponse.of(financeService.getYearPayments(year)));
+    }
 }

--- a/backend/src/main/java/com/nemo/finance/FinanceDashboardDto.java
+++ b/backend/src/main/java/com/nemo/finance/FinanceDashboardDto.java
@@ -42,4 +42,28 @@ public class FinanceDashboardDto {
             List<ProjectFinance> byProject,
             List<OverduePayment> overduePayments
     ) {}
+
+    public record PaymentDto(
+            Long id,
+            Long projectId,
+            String projectName,
+            String title,
+            java.math.BigDecimal amount,
+            String currency,
+            String dueDate,
+            String receivedDate,
+            String status,
+            String invoiceRef,
+            Long createdById,
+            String createdByName,
+            String createdAt,
+            String updatedAt,
+            Long delayDays
+    ) {}
+
+    public record YearPaymentsResponse(
+            int year,
+            List<PaymentDto> pending,
+            List<PaymentDto> received
+    ) {}
 }

--- a/backend/src/main/java/com/nemo/finance/FinanceDashboardDto.java
+++ b/backend/src/main/java/com/nemo/finance/FinanceDashboardDto.java
@@ -64,6 +64,7 @@ public class FinanceDashboardDto {
     public record YearPaymentsResponse(
             int year,
             List<PaymentDto> pending,
-            List<PaymentDto> received
+            List<PaymentDto> received,
+            List<PaymentDto> overdue
     ) {}
 }

--- a/backend/src/main/java/com/nemo/finance/FinanceService.java
+++ b/backend/src/main/java/com/nemo/finance/FinanceService.java
@@ -43,17 +43,49 @@ public class FinanceService {
     public FinanceDashboardDto.YearPaymentsResponse getYearPayments(int year) {
         LocalDate start = LocalDate.of(year, 1, 1);
         LocalDate end = LocalDate.of(year, 12, 31);
+        LocalDate today = LocalDate.now();
 
-        List<ProjectPayment> pendingPayments = paymentRepository.findByDueDateBetweenOrderByDueDateAsc(start, end).stream()
+        List<ProjectPayment> dueInYear = paymentRepository.findByDueDateBetweenOrderByDueDateAsc(start, end).stream()
                 .filter(p -> p.getStatus() != ProjectPayment.PaymentStatus.RECEIVED)
                 .toList();
 
-        List<ProjectPayment> receivedPayments = paymentRepository.findByReceivedDateBetweenOrderByReceivedDateAsc(start, end);
+        // Split overdue (past due) vs pending (due today/future or no due date)
+        List<ProjectPayment> overdueList = dueInYear.stream()
+                .filter(p -> p.getDueDate() != null && p.getDueDate().isBefore(today))
+                .toList();
+        List<ProjectPayment> pendingList = dueInYear.stream()
+                .filter(p -> p.getDueDate() == null || !p.getDueDate().isBefore(today))
+                .toList();
+
+        List<ProjectPayment> receivedList = paymentRepository.findByReceivedDateBetweenOrderByReceivedDateAsc(start, end);
 
         return new FinanceDashboardDto.YearPaymentsResponse(
                 year,
-                pendingPayments.stream().map(this::toPaymentDto).toList(),
-                receivedPayments.stream().map(this::toPaymentDto).toList()
+                pendingList.stream().map(this::toPaymentDto).toList(),
+                receivedList.stream().map(this::toPaymentDto).toList(),
+                overdueList.stream().map(p -> toOverduePaymentDto(p, today)).toList()
+        );
+    }
+
+    private FinanceDashboardDto.PaymentDto toOverduePaymentDto(ProjectPayment p, LocalDate today) {
+        Long delayDays = p.getDueDate() != null ? ChronoUnit.DAYS.between(p.getDueDate(), today) : 0;
+
+        return new FinanceDashboardDto.PaymentDto(
+                p.getId(),
+                p.getProject().getId(),
+                p.getProject().getName(),
+                p.getTitle(),
+                p.getAmount(),
+                p.getCurrency(),
+                p.getDueDate() != null ? p.getDueDate().toString() : null,
+                null,
+                p.getStatus().name(),
+                p.getInvoiceRef(),
+                p.getCreatedBy() != null ? p.getCreatedBy().getId() : null,
+                p.getCreatedBy() != null ? p.getCreatedBy().getFirstName() + " " + p.getCreatedBy().getLastName() : null,
+                p.getCreatedAt() != null ? p.getCreatedAt().toString() : null,
+                p.getUpdatedAt() != null ? p.getUpdatedAt().toString() : null,
+                delayDays
         );
     }
 

--- a/backend/src/main/java/com/nemo/finance/FinanceService.java
+++ b/backend/src/main/java/com/nemo/finance/FinanceService.java
@@ -40,6 +40,49 @@ public class FinanceService {
     }
 
     @Transactional(readOnly = true)
+    public FinanceDashboardDto.YearPaymentsResponse getYearPayments(int year) {
+        LocalDate start = LocalDate.of(year, 1, 1);
+        LocalDate end = LocalDate.of(year, 12, 31);
+
+        List<ProjectPayment> pendingPayments = paymentRepository.findByDueDateBetweenOrderByDueDateAsc(start, end).stream()
+                .filter(p -> p.getStatus() != ProjectPayment.PaymentStatus.RECEIVED)
+                .toList();
+
+        List<ProjectPayment> receivedPayments = paymentRepository.findByReceivedDateBetweenOrderByReceivedDateAsc(start, end);
+
+        return new FinanceDashboardDto.YearPaymentsResponse(
+                year,
+                pendingPayments.stream().map(this::toPaymentDto).toList(),
+                receivedPayments.stream().map(this::toPaymentDto).toList()
+        );
+    }
+
+    private FinanceDashboardDto.PaymentDto toPaymentDto(ProjectPayment p) {
+        Long delayDays = null;
+        if (p.getReceivedDate() != null && p.getDueDate() != null) {
+            delayDays = ChronoUnit.DAYS.between(p.getDueDate(), p.getReceivedDate());
+        }
+
+        return new FinanceDashboardDto.PaymentDto(
+                p.getId(),
+                p.getProject().getId(),
+                p.getProject().getName(),
+                p.getTitle(),
+                p.getAmount(),
+                p.getCurrency(),
+                p.getDueDate() != null ? p.getDueDate().toString() : null,
+                p.getReceivedDate() != null ? p.getReceivedDate().toString() : null,
+                p.getStatus().name(),
+                p.getInvoiceRef(),
+                p.getCreatedBy() != null ? p.getCreatedBy().getId() : null,
+                p.getCreatedBy() != null ? p.getCreatedBy().getFirstName() + " " + p.getCreatedBy().getLastName() : null,
+                p.getCreatedAt() != null ? p.getCreatedAt().toString() : null,
+                p.getUpdatedAt() != null ? p.getUpdatedAt().toString() : null,
+                delayDays
+        );
+    }
+
+    @Transactional(readOnly = true)
     public FinanceDashboardDto.DashboardResponse getDashboard(Long companyId) {
         List<Project> projects = projectRepository.findAllByCompanyIdOrNull(companyId);
 

--- a/backend/src/main/java/com/nemo/payment/ProjectPaymentRepository.java
+++ b/backend/src/main/java/com/nemo/payment/ProjectPaymentRepository.java
@@ -21,6 +21,9 @@ public interface ProjectPaymentRepository extends JpaRepository<ProjectPayment, 
     @Query("SELECT p FROM ProjectPayment p JOIN FETCH p.project WHERE p.status = :status AND p.dueDate < :date ORDER BY p.dueDate ASC")
     List<ProjectPayment> findOverduePayments(@Param("status") ProjectPayment.PaymentStatus status, @Param("date") LocalDate date);
 
+    @Query("SELECT p FROM ProjectPayment p JOIN FETCH p.project WHERE p.status = :status AND p.dueDate BETWEEN :start AND :end ORDER BY p.dueDate ASC")
+    List<ProjectPayment> findOverdueByDateBetween(@Param("status") ProjectPayment.PaymentStatus status, @Param("start") LocalDate start, @Param("end") LocalDate end);
+
     @Query("SELECT p FROM ProjectPayment p JOIN FETCH p.project WHERE p.dueDate BETWEEN :start AND :end ORDER BY p.dueDate ASC")
     List<ProjectPayment> findByDueDateBetweenOrderByDueDateAsc(@Param("start") LocalDate start, @Param("end") LocalDate end);
 

--- a/backend/src/main/java/com/nemo/payment/ProjectPaymentRepository.java
+++ b/backend/src/main/java/com/nemo/payment/ProjectPaymentRepository.java
@@ -20,4 +20,10 @@ public interface ProjectPaymentRepository extends JpaRepository<ProjectPayment, 
 
     @Query("SELECT p FROM ProjectPayment p JOIN FETCH p.project WHERE p.status = :status AND p.dueDate < :date ORDER BY p.dueDate ASC")
     List<ProjectPayment> findOverduePayments(@Param("status") ProjectPayment.PaymentStatus status, @Param("date") LocalDate date);
+
+    @Query("SELECT p FROM ProjectPayment p JOIN FETCH p.project WHERE p.dueDate BETWEEN :start AND :end ORDER BY p.dueDate ASC")
+    List<ProjectPayment> findByDueDateBetweenOrderByDueDateAsc(@Param("start") LocalDate start, @Param("end") LocalDate end);
+
+    @Query("SELECT p FROM ProjectPayment p JOIN FETCH p.project WHERE p.receivedDate BETWEEN :start AND :end ORDER BY p.receivedDate ASC")
+    List<ProjectPayment> findByReceivedDateBetweenOrderByReceivedDateAsc(@Param("start") LocalDate start, @Param("end") LocalDate end);
 }

--- a/frontend/src/api/finance.ts
+++ b/frontend/src/api/finance.ts
@@ -38,6 +38,35 @@ export interface DashboardResponse {
   overduePayments: OverduePayment[];
 }
 
+export interface PaymentDto {
+  id: number;
+  projectId: number;
+  projectName: string;
+  title: string;
+  amount: number;
+  currency: string | null;
+  dueDate: string | null;
+  receivedDate: string | null;
+  status: string;
+  invoiceRef: string | null;
+  createdById: number | null;
+  createdByName: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  delayDays: number | null;
+}
+
+export interface YearPaymentsResponse {
+  year: number;
+  pending: PaymentDto[];
+  received: PaymentDto[];
+}
+
 export function getFinanceDashboard(): Promise<DashboardResponse> {
   return apiGet('/finance/dashboard');
+}
+
+export function getFinancePayments(year?: number): Promise<YearPaymentsResponse> {
+  const params = year ? `?year=${year}` : '';
+  return apiGet('/finance/payments' + params);
 }

--- a/frontend/src/api/finance.ts
+++ b/frontend/src/api/finance.ts
@@ -60,6 +60,7 @@ export interface YearPaymentsResponse {
   year: number;
   pending: PaymentDto[];
   received: PaymentDto[];
+  overdue: PaymentDto[];
 }
 
 export function getFinanceDashboard(): Promise<DashboardResponse> {

--- a/frontend/src/pages/FinancePage.tsx
+++ b/frontend/src/pages/FinancePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
-import { getFinanceDashboard } from '@/api/finance';
+import { getFinanceDashboard, getFinancePayments } from '@/api/finance';
 import { approveExpense, rejectExpense } from '@/api/expenses';
-import type { DashboardResponse, ProjectFinance, OverduePayment } from '@/api/finance';
+import type { DashboardResponse, ProjectFinance, OverduePayment, YearPaymentsResponse } from '@/api/finance';
 import { apiGet } from '@/api/client';
 import type { ProjectExpenseDto } from '@/types';
 import { formatCurrency, formatDate } from '@/utils/format';
@@ -28,6 +28,10 @@ export default function FinancePage() {
   const [sortAsc, setSortAsc] = useState(true);
   const [rejectId, setRejectId] = useState<{ projectId: number; expenseId: number } | null>(null);
   const [rejectReason, setRejectReason] = useState('');
+  const [payments, setPayments] = useState<YearPaymentsResponse | null>(null);
+  const [paymentYear, setPaymentYear] = useState(new Date().getFullYear());
+  const [paymentView, setPaymentView] = useState<'pending' | 'received'>('pending');
+  const [loadingPayments, setLoadingPayments] = useState(false);
 
   const fetchDashboard = useCallback(async () => {
     setLoading(true);
@@ -43,6 +47,14 @@ export default function FinancePage() {
   }, []);
 
   useEffect(() => { fetchDashboard(); }, [fetchDashboard]);
+
+  useEffect(() => {
+    setLoadingPayments(true);
+    getFinancePayments(paymentYear)
+      .then(setPayments)
+      .catch(() => setPayments(null))
+      .finally(() => setLoadingPayments(false));
+  }, [paymentYear]);
 
   const handleSort = (key: keyof ProjectFinance) => {
     if (sortKey === key) setSortAsc(!sortAsc);
@@ -176,6 +188,95 @@ export default function FinancePage() {
           </table>
         </div>
       )}
+
+      {/* Payments Panel */}
+      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between flex-wrap gap-3">
+          <div className="flex items-center gap-3">
+            <h2 className="text-lg font-semibold text-gray-900">Payments</h2>
+            <div className="flex items-center gap-1 text-sm">
+              <button onClick={() => setPaymentYear(paymentYear - 1)}
+                className="px-2 py-1 rounded hover:bg-gray-100 text-gray-600 font-medium">&larr;</button>
+              <span className="px-3 py-1 bg-gray-100 rounded font-medium text-gray-800">{paymentYear}</span>
+              <button onClick={() => setPaymentYear(paymentYear + 1)}
+                className="px-2 py-1 rounded hover:bg-gray-100 text-gray-600 font-medium">&rarr;</button>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button onClick={() => setPaymentView('pending')}
+              className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${paymentView === 'pending' ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>
+              Pending ({payments?.pending.length ?? 0})
+            </button>
+            <button onClick={() => setPaymentView('received')}
+              className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${paymentView === 'received' ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>
+              Received ({payments?.received.length ?? 0})
+            </button>
+          </div>
+        </div>
+        {loadingPayments ? (
+          <div className="flex items-center justify-center h-32"><Spinner className="h-6 w-6 text-primary-600" /></div>
+        ) : payments && paymentView === 'pending' && payments.pending.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Project</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Title</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Amount</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Due Date</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {payments.pending.map((p) => (
+                  <tr key={p.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 text-sm font-medium text-gray-900">{p.projectName}</td>
+                    <td className="px-4 py-3 text-sm text-gray-700">{p.title}</td>
+                    <td className="px-4 py-3 text-sm font-medium text-right">{formatCurrency(p.amount)}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{p.dueDate ? formatDate(p.dueDate) : '—'}</td>
+                    <td className="px-4 py-3">
+                      <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">{p.status}</span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : payments && paymentView === 'received' && payments.received.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Project</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Title</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Amount</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Received</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Delay</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {payments.received.map((p) => (
+                  <tr key={p.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 text-sm font-medium text-gray-900">{p.projectName}</td>
+                    <td className="px-4 py-3 text-sm text-gray-700">{p.title}</td>
+                    <td className="px-4 py-3 text-sm font-medium text-right">{formatCurrency(p.amount)}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{p.receivedDate ? formatDate(p.receivedDate) : '—'}</td>
+                    <td className="px-4 py-3 text-sm text-right">
+                      {p.delayDays !== null ? (
+                        <span className={`font-medium ${p.delayDays > 0 ? 'text-red-600' : 'text-green-600'}`}>
+                          {p.delayDays > 0 ? `${p.delayDays}d late` : 'On time'}
+                        </span>
+                      ) : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="px-4 py-8 text-center text-sm text-gray-400">No payments found for {paymentYear}</div>
+        )}
+      </div>
 
       {/* Pending Expense Approvals */}
       {pendingExpenses.length > 0 && (

--- a/frontend/src/pages/FinancePage.tsx
+++ b/frontend/src/pages/FinancePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getFinanceDashboard, getFinancePayments } from '@/api/finance';
 import { approveExpense, rejectExpense } from '@/api/expenses';
-import type { DashboardResponse, ProjectFinance, OverduePayment, YearPaymentsResponse } from '@/api/finance';
+import type { DashboardResponse, ProjectFinance, YearPaymentsResponse } from '@/api/finance';
 import { apiGet } from '@/api/client';
 import type { ProjectExpenseDto } from '@/types';
 import { formatCurrency, formatDate } from '@/utils/format';
@@ -30,7 +30,7 @@ export default function FinancePage() {
   const [rejectReason, setRejectReason] = useState('');
   const [payments, setPayments] = useState<YearPaymentsResponse | null>(null);
   const [paymentYear, setPaymentYear] = useState(new Date().getFullYear());
-  const [paymentView, setPaymentView] = useState<'pending' | 'received'>('pending');
+  const [paymentView, setPaymentView] = useState<'pending' | 'received' | 'overdue'>('pending');
   const [loadingPayments, setLoadingPayments] = useState(false);
 
   const fetchDashboard = useCallback(async () => {
@@ -77,7 +77,7 @@ export default function FinancePage() {
   if (loading) return <div className="flex items-center justify-center h-64"><Spinner className="h-8 w-8 text-primary-600" /></div>;
   if (!dashboard) return <div className="p-6 text-gray-500">Unable to load dashboard data.</div>;
 
-  const { summary, byProject, overduePayments } = dashboard;
+  const { summary, byProject } = dashboard;
   const projectNameById = new Map(byProject.map(p => [p.projectId, p.projectName]));
   const sorted = [...byProject].sort((a, b) => {
     const av = a[sortKey];
@@ -158,37 +158,6 @@ export default function FinancePage() {
         </div>
       </div>
 
-      {/* Overdue Payments Panel */}
-      {overduePayments.length > 0 && (
-        <div className="bg-white rounded-xl border border-red-200 overflow-hidden">
-          <div className="px-4 py-3 border-b border-red-200 bg-red-50">
-            <h2 className="text-lg font-semibold text-red-800">Overdue Payments ({overduePayments.length})</h2>
-          </div>
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-red-50">
-              <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-red-600 uppercase">Project</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-red-600 uppercase">Title</th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-red-600 uppercase">Amount</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-red-600 uppercase">Due Date</th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-red-600 uppercase">Days Overdue</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {overduePayments.map((p: OverduePayment) => (
-                <tr key={p.paymentId} className="hover:bg-red-50">
-                  <td className="px-4 py-3 text-sm font-medium text-gray-900">{p.projectName}</td>
-                  <td className="px-4 py-3 text-sm text-gray-700">{p.title}</td>
-                  <td className="px-4 py-3 text-sm font-medium text-red-700 text-right">{formatCurrency(p.amount)}</td>
-                  <td className="px-4 py-3 text-sm text-gray-500">{p.dueDate ? formatDate(p.dueDate) : '—'}</td>
-                  <td className="px-4 py-3 text-sm font-bold text-red-600 text-right">{p.daysOverdue}d</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-
       {/* Payments Panel */}
       <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
         <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between flex-wrap gap-3">
@@ -210,6 +179,10 @@ export default function FinancePage() {
             <button onClick={() => setPaymentView('received')}
               className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${paymentView === 'received' ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>
               Received ({payments?.received.length ?? 0})
+            </button>
+            <button onClick={() => setPaymentView('overdue')}
+              className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${paymentView === 'overdue' ? 'bg-red-600 text-white' : 'bg-red-50 text-red-700 hover:bg-red-100'}`}>
+              Overdue ({payments?.overdue.length ?? 0})
             </button>
           </div>
         </div>
@@ -237,6 +210,31 @@ export default function FinancePage() {
                     <td className="px-4 py-3">
                       <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">{p.status}</span>
                     </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : payments && paymentView === 'overdue' && payments.overdue.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-red-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-red-600 uppercase">Project</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-red-600 uppercase">Title</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-red-600 uppercase">Amount</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-red-600 uppercase">Due Date</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-red-600 uppercase">Days Overdue</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {payments.overdue.map((p) => (
+                  <tr key={p.id} className="hover:bg-red-50">
+                    <td className="px-4 py-3 text-sm font-medium text-gray-900">{p.projectName}</td>
+                    <td className="px-4 py-3 text-sm text-gray-700">{p.title}</td>
+                    <td className="px-4 py-3 text-sm font-medium text-red-700 text-right">{formatCurrency(p.amount)}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{p.dueDate ? formatDate(p.dueDate) : '—'}</td>
+                    <td className="px-4 py-3 text-sm font-bold text-red-600 text-right">{p.delayDays}d</td>
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
## Summary
- Added cross-company payments endpoint at `GET /api/finance/payments?year=2026` for FINANCE role
- Year-scoped sets (prev/next year navigation) instead of arbitrary pagination
- Three views in a unified Payments panel: Pending (by dueDate), Overdue (red, days-overdue count), Received (by receivedDate, with delay calculation)
- Merged standalone Overdue Payments section into the new panel
- Full-stack: backend query + controller + frontend panel with toggle

## Test plan
- [ ] `GET /api/finance/payments` as `alex` (FINANCE) returns 200 with pending + received + overdue lists
- [ ] `GET /api/finance/payments?year=2025` returns data for the specified year
- [ ] `GET /api/finance/payments` as `jordan` (MANAGER) returns 403
- [ ] Pending payments exclude past-due items (they are in Overdue)
- [ ] Overdue view shows days-overdue count per payment
- [ ] Received payments show delay (days late) where applicable
- [ ] Frontend year nav buttons switch between years
- [ ] Frontend Pending/Received/Overdue toggle switches between the three views
- [ ] No duplicate Overdue Payments section below dashboard

Refs #195