### PR TITLE
fix(#196): add FINANCE role to expense create and update endpoints

### DIFF
--- a/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
+++ b/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
@@ -37,7 +37,7 @@ public class ProjectExpenseController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyRole('MANAGER', 'CONTRIBUTOR')")
+    @PreAuthorize("hasAnyRole('MANAGER', 'CONTRIBUTOR', 'FINANCE')")
     public ResponseEntity<ApiResponse<ProjectExpenseDto>> create(
             @PathVariable Long projectId,
             @RequestBody ProjectExpenseDto.CreateRequest request,
@@ -49,7 +49,7 @@ public class ProjectExpenseController {
     }
 
     @PutMapping("/{expenseId}")
-    @PreAuthorize("hasAnyRole('MANAGER')")
+    @PreAuthorize("hasAnyRole('MANAGER', 'FINANCE')")
     public ResponseEntity<ApiResponse<ProjectExpenseDto>> update(
             @PathVariable Long projectId,
             @PathVariable Long expenseId,


### PR DESCRIPTION
## Summary
- FINANCE role could read and approve/reject expenses but got 403 on create/update
- Added FINANCE to @PreAuthorize on POST and PUT endpoints
- Minimal change — 2 lines

## Test plan
- [ ] `POST /api/projects/1/expenses` as `alex` (FINANCE) returns 201
- [ ] `PUT /api/projects/1/expenses/{id}` as `alex` returns 200
- [ ] `POST /api/projects/1/expenses` as `jordan` (MANAGER) still works (no regression)
- [ ] `DELETE /api/projects/1/expenses/{id}` still returns 403 for FINANCE (intentional)

Refs #196