### PR TITLE
fix(#197): restrict financial endpoints to MANAGER, EXECUTIVE, FINANCE only

### DIFF
--- a/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
+++ b/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
@@ -28,7 +28,7 @@ public class ProjectExpenseController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('MANAGER', 'EXECUTIVE', 'CONTRIBUTOR', 'HR', 'FINANCE')")
+    @PreAuthorize("hasAnyRole('MANAGER', 'EXECUTIVE', 'FINANCE')")
     public ResponseEntity<ApiResponse<List<ProjectExpenseDto>>> list(
             @PathVariable Long projectId,
             @AuthenticationPrincipal UserDetails currentUser) {

--- a/backend/src/main/java/com/nemo/payment/ProjectPaymentController.java
+++ b/backend/src/main/java/com/nemo/payment/ProjectPaymentController.java
@@ -25,6 +25,7 @@ public class ProjectPaymentController {
     }
 
     @GetMapping
+    @PreAuthorize("hasAnyRole('MANAGER', 'EXECUTIVE', 'FINANCE')")
     public ResponseEntity<ApiResponse<List<ProjectPaymentDto.Response>>> list(
             @PathVariable Long projectId,
             @AuthenticationPrincipal UserDetails currentUser) {


### PR DESCRIPTION
## Summary
- CONTRIBUTOR and HR could read project expenses and payments
- Removed CONTRIBUTOR/HR from expense GET `@PreAuthorize`
- Added `@PreAuthorize` to payment GET (was completely unprotected)

## Test plan
- [ ] `GET /api/projects/1/expenses` as `taylor` (CONTRIBUTOR) returns 403
- [ ] `GET /api/projects/1/payments` as `taylor` returns 403
- [ ] `GET /api/projects/1/expenses` as `jordan` (MANAGER) returns 200
- [ ] `GET /api/projects/1/payments` as `alex` (FINANCE) returns 200
- [ ] `GET /api/projects/1/expenses` as `sam` (HR) returns 403 (regression check)

Refs #197