### PR TITLE
feat(#199): reorganize finance — charts on dashboard, tables on /finance page

### DIFF
--- a/backend/src/main/java/com/nemo/config/DataSeeder.java
+++ b/backend/src/main/java/com/nemo/config/DataSeeder.java
@@ -670,37 +670,51 @@ public class DataSeeder implements CommandLineRunner {
 
         Phase mobilePlan = createPhase("Planning", "Design and architecture phase", mobileApp, 0,
                 today.minusMonths(6), today.minusMonths(4).plusDays(14));
+        mobilePlan.setPlannedAmount(new BigDecimal("50000"));
+        phaseRepository.save(mobilePlan);
         createDeliverable("UX Wireframes", "Mobile app screen designs and user flows", mobilePlan, DeliverableState.VALIDATED, today.minusMonths(5));
         createDeliverable("Architecture Document", "Technical architecture and API contracts", mobilePlan, DeliverableState.VALIDATED, today.minusMonths(4).plusDays(14));
 
         Phase mobileExec = createPhase("Execution", "Mobile app development", mobileApp, 1,
                 today.minusMonths(4).plusDays(15), today.plusMonths(2));
+        mobileExec.setPlannedAmount(new BigDecimal("180000"));
+        phaseRepository.save(mobileExec);
         createDeliverable("Alpha Build", "Core functionality with placeholder data", mobileExec, DeliverableState.DELIVERED, today.minusMonths(2));
         createDeliverable("Beta Build", "Feature-complete build for testing", mobileExec, DeliverableState.DRAFT, today.plusMonths(1));
         createDeliverable("App Store Submission", "Final build with App Store assets", mobileExec, DeliverableState.DRAFT, today.plusMonths(2));
 
         Phase apiPlan = createPhase("Planning", "API gateway design", apiGateway, 0,
                 today.minusMonths(5), today.minusMonths(3));
+        apiPlan.setPlannedAmount(new BigDecimal("30000"));
+        phaseRepository.save(apiPlan);
         createDeliverable("API Specification", "OpenAPI spec for gateway endpoints", apiPlan, DeliverableState.VALIDATED, today.minusMonths(4).plusDays(15));
         createDeliverable("Security Audit Plan", "Security review checklist and tooling setup", apiPlan, DeliverableState.DRAFT, today.minusMonths(3));
 
         Phase apiExec = createPhase("Execution", "Gateway implementation", apiGateway, 1,
                 today.minusMonths(3).plusDays(1), today.plusMonths(4));
+        apiExec.setPlannedAmount(new BigDecimal("100000"));
+        phaseRepository.save(apiExec);
         createDeliverable("Rate Limiter Module", "Configurable rate limiting per service", apiExec, DeliverableState.DRAFT, today.plusMonths(1));
         createDeliverable("Service Registry", "Dynamic service discovery and health checks", apiExec, DeliverableState.DRAFT, today.plusMonths(4));
 
         Phase erpInit = createPhase("Initiation", "Stakeholder alignment and scope", erpProject, 0,
                 today.minusMonths(8), today.minusMonths(6));
+        erpInit.setPlannedAmount(new BigDecimal("60000"));
+        phaseRepository.save(erpInit);
         createDeliverable("Business Case", "ROI analysis and project justification", erpInit, DeliverableState.VALIDATED, today.minusMonths(7).plusDays(1));
         createDeliverable("Stakeholder Map", "Key stakeholders and communication plan", erpInit, DeliverableState.VALIDATED, today.minusMonths(6).plusDays(14));
 
         Phase erpExec = createPhase("Execution", "ERP module development", erpProject, 1,
                 today.minusMonths(6).plusDays(1), today.plusMonths(2));
+        erpExec.setPlannedAmount(new BigDecimal("250000"));
+        phaseRepository.save(erpExec);
         createDeliverable("Patient Management Module", "Core patient record system", erpExec, DeliverableState.DELIVERED, today.minusMonths(1));
         createDeliverable("Billing Module", "Insurance and payment processing", erpExec, DeliverableState.DRAFT, today.plusMonths(2));
 
         Phase ftmExec = createPhase("Execution", "Core platform features", footballTeam, 0,
                 today.minusMonths(5), today.plusMonths(1));
+        ftmExec.setPlannedAmount(new BigDecimal("150000"));
+        phaseRepository.save(ftmExec);
         createDeliverable("Player Database", "Player profiles, stats, and history", ftmExec, DeliverableState.DELIVERED, today.minusMonths(3).plusDays(15));
         createDeliverable("Match Engine", "Match scheduling and result tracking", ftmExec, DeliverableState.DRAFT, today.plusMonths(1));
 

--- a/backend/src/main/java/com/nemo/expense/ProjectExpenseRepository.java
+++ b/backend/src/main/java/com/nemo/expense/ProjectExpenseRepository.java
@@ -26,4 +26,10 @@ public interface ProjectExpenseRepository extends JpaRepository<ProjectExpense, 
     BigDecimal sumByProjectIdAndApprovalStatus(@Param("projectId") Long projectId, @Param("status") ProjectExpense.ApprovalStatus status);
 
     long countByProjectIdAndApprovalStatus(Long projectId, ProjectExpense.ApprovalStatus approvalStatus);
+
+    @Query("SELECT e FROM ProjectExpense e JOIN FETCH e.project WHERE e.expenseDate BETWEEN :start AND :end ORDER BY e.expenseDate DESC")
+    List<ProjectExpense> findByExpenseDateBetween(@Param("start") LocalDate start, @Param("end") LocalDate end);
+
+    @Query("SELECT e FROM ProjectExpense e JOIN FETCH e.project WHERE e.expenseDate BETWEEN :start AND :end AND e.approvalStatus = :status ORDER BY e.expenseDate DESC")
+    List<ProjectExpense> findByExpenseDateBetweenAndStatus(@Param("start") LocalDate start, @Param("end") LocalDate end, @Param("status") ProjectExpense.ApprovalStatus status);
 }

--- a/backend/src/main/java/com/nemo/finance/FinanceController.java
+++ b/backend/src/main/java/com/nemo/finance/FinanceController.java
@@ -84,10 +84,8 @@ public class FinanceController {
         response.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
 
         try (PrintWriter writer = response.getWriter()) {
-            // Header
             writer.println("Project,Budget,Expenses,Labor,Payments Received,Collection %,CPI,SPI,Pending Expenses");
 
-            // Rows
             for (FinanceDashboardDto.ProjectFinance pf : data.byProject()) {
                 writer.println(
                         csvEscape(pf.projectName()) + ","
@@ -102,7 +100,6 @@ public class FinanceController {
                 );
             }
 
-            // Summary row
             writer.println();
             FinanceDashboardDto.DashboardSummary s = data.summary();
             writer.println("TOTAL,"
@@ -116,6 +113,23 @@ public class FinanceController {
                     + s.pendingExpenseApprovals()
             );
         }
+    }
+
+    @GetMapping("/expenses-by-year")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<FinanceDashboardDto.YearExpensesResponse>> getYearExpenses(
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) String status) {
+        if (year == null) year = LocalDate.now().getYear();
+        return ResponseEntity.ok(ApiResponse.of(financeService.getYearExpenses(year, status)));
+    }
+
+    @GetMapping("/chart-data")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<FinanceDashboardDto.MonthlyFinanceData>> getChartData(
+            @RequestParam(required = false) Integer year) {
+        if (year == null) year = LocalDate.now().getYear();
+        return ResponseEntity.ok(ApiResponse.of(financeService.getMonthlyChartData(year)));
     }
 
     private String csvEscape(String value) {

--- a/backend/src/main/java/com/nemo/finance/FinanceDashboardDto.java
+++ b/backend/src/main/java/com/nemo/finance/FinanceDashboardDto.java
@@ -67,4 +67,32 @@ public class FinanceDashboardDto {
             List<PaymentDto> received,
             List<PaymentDto> overdue
     ) {}
+
+    public record ExpenseDto(
+            Long id,
+            Long projectId,
+            String projectName,
+            String category,
+            String amount,
+            String description,
+            String expenseDate,
+            Long createdById,
+            String createdByName,
+            String approvalStatus,
+            String rejectionReason,
+            String createdAt
+    ) {}
+
+    public record YearExpensesResponse(
+            int year,
+            String statusFilter,
+            List<ExpenseDto> expenses
+    ) {}
+
+    public record MonthlyFinanceData(
+            int year,
+            List<BigDecimal> paymentsReceived,  // 12 months
+            List<BigDecimal> paymentsPending,
+            List<BigDecimal> expenses
+    ) {}
 }

--- a/backend/src/main/java/com/nemo/finance/FinanceService.java
+++ b/backend/src/main/java/com/nemo/finance/FinanceService.java
@@ -67,6 +67,68 @@ public class FinanceService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public FinanceDashboardDto.YearExpensesResponse getYearExpenses(int year, String statusFilter) {
+        LocalDate start = LocalDate.of(year, 1, 1);
+        LocalDate end = LocalDate.of(year, 12, 31);
+
+        List<ProjectExpense> expenses;
+        if (statusFilter != null && !statusFilter.isEmpty() && !statusFilter.equals("ALL")) {
+            ProjectExpense.ApprovalStatus status = ProjectExpense.ApprovalStatus.valueOf(statusFilter);
+            expenses = expenseRepository.findByExpenseDateBetweenAndStatus(start, end, status);
+        } else {
+            expenses = expenseRepository.findByExpenseDateBetween(start, end);
+        }
+
+        return new FinanceDashboardDto.YearExpensesResponse(
+                year, statusFilter != null ? statusFilter : "ALL",
+                expenses.stream().map(this::toExpenseDto).toList()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public FinanceDashboardDto.MonthlyFinanceData getMonthlyChartData(int year) {
+        List<BigDecimal> paymentsReceived = new ArrayList<>();
+        List<BigDecimal> paymentsPending = new ArrayList<>();
+        List<BigDecimal> expenses = new ArrayList<>();
+
+        for (int month = 1; month <= 12; month++) {
+            LocalDate monthStart = LocalDate.of(year, month, 1);
+            LocalDate monthEnd = monthStart.withDayOfMonth(monthStart.lengthOfMonth());
+
+            BigDecimal received = paymentRepository.findByReceivedDateBetweenOrderByReceivedDateAsc(monthStart, monthEnd).stream()
+                    .map(ProjectPayment::getAmount)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+            paymentsReceived.add(received);
+
+            BigDecimal pending = paymentRepository.findByDueDateBetweenOrderByDueDateAsc(monthStart, monthEnd).stream()
+                    .filter(p -> p.getStatus() != ProjectPayment.PaymentStatus.RECEIVED)
+                    .map(ProjectPayment::getAmount)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+            paymentsPending.add(pending);
+
+            BigDecimal monthExpenses = expenseRepository.findByExpenseDateBetween(monthStart, monthEnd).stream()
+                    .map(ProjectExpense::getAmount)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+            expenses.add(monthExpenses);
+        }
+
+        return new FinanceDashboardDto.MonthlyFinanceData(year, paymentsReceived, paymentsPending, expenses);
+    }
+
+    private FinanceDashboardDto.ExpenseDto toExpenseDto(ProjectExpense e) {
+        return new FinanceDashboardDto.ExpenseDto(
+                e.getId(), e.getProject().getId(), e.getProject().getName(),
+                e.getCategory().name(), e.getAmount().toString(), e.getDescription(),
+                e.getExpenseDate() != null ? e.getExpenseDate().toString() : null,
+                e.getCreatedBy() != null ? e.getCreatedBy().getId() : null,
+                e.getCreatedBy() != null ? e.getCreatedBy().getFirstName() + " " + e.getCreatedBy().getLastName() : null,
+                e.getApprovalStatus() != null ? e.getApprovalStatus().name() : null,
+                e.getRejectionReason(),
+                e.getCreatedAt() != null ? e.getCreatedAt().toString() : null
+        );
+    }
+
     private FinanceDashboardDto.PaymentDto toOverduePaymentDto(ProjectPayment p, LocalDate today) {
         Long delayDays = p.getDueDate() != null ? ChronoUnit.DAYS.between(p.getDueDate(), today) : 0;
 

--- a/backend/src/main/java/com/nemo/phase/ClientPaymentController.java
+++ b/backend/src/main/java/com/nemo/phase/ClientPaymentController.java
@@ -38,7 +38,7 @@ public class ClientPaymentController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    @PreAuthorize("hasRole('FINANCE')")
     public ResponseEntity<ApiResponse<ClientPaymentDto>> create(
             @PathVariable Long projectId,
             @PathVariable Long phaseId,
@@ -50,7 +50,7 @@ public class ClientPaymentController {
     }
 
     @PutMapping("/{paymentId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    @PreAuthorize("hasRole('FINANCE')")
     public ResponseEntity<ApiResponse<ClientPaymentDto>> update(
             @PathVariable Long projectId,
             @PathVariable Long phaseId,
@@ -63,7 +63,7 @@ public class ClientPaymentController {
     }
 
     @DeleteMapping("/{paymentId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    @PreAuthorize("hasRole('FINANCE')")
     public ResponseEntity<Void> delete(
             @PathVariable Long projectId,
             @PathVariable Long phaseId,

--- a/backend/src/main/java/com/nemo/phase/PhaseDto.java
+++ b/backend/src/main/java/com/nemo/phase/PhaseDto.java
@@ -25,7 +25,7 @@ public record PhaseDto(
             String description,
             LocalDate startDate,
             LocalDate endDate,
-            String plannedAmount,
+            @NotBlank String plannedAmount,
             String status
     ) {}
 
@@ -35,7 +35,7 @@ public record PhaseDto(
             LocalDate startDate,
             LocalDate endDate,
             Integer position,
-            String plannedAmount,
+            @NotBlank String plannedAmount,
             String status
     ) {}
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,12 @@ import PreSaleDetailPage from '@/pages/PreSaleDetailPage';
 import UserDetailPage from '@/pages/UserDetailPage';
 import FinancePage from '@/pages/FinancePage';
 
+function FinanceOrDashboard() {
+  const role = useAuthStore((s) => s.user?.role);
+  if (role === 'FINANCE') return <FinancePage />;
+  return <DashboardPage />;
+}
+
 export default function App() {
   const checkSession = useAuthStore((s) => s.checkSession);
   const isLoading = useAuthStore((s) => s.isLoading);
@@ -68,7 +74,7 @@ export default function App() {
             </AuthGuard>
           }
         >
-          <Route path="/" element={<DashboardPage />} />
+          <Route path="/" element={<FinanceOrDashboard />} />
           <Route path="/programs" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'FINANCE']}><ProgramsPage /></RoleGuard>} />
           <Route path="/programs/:id" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'FINANCE']}><ProgramDetailPage /></RoleGuard>} />
           <Route path="/projects" element={<ProjectsPage />} />
@@ -81,14 +87,13 @@ export default function App() {
           <Route path="/people/:id" element={<RoleGuard roles={['HR', 'EXECUTIVE']}><UserDetailPage /></RoleGuard>} />
           <Route path="/holidays" element={<RoleGuard roles={['HR', 'ADMIN']}><HolidaysPage /></RoleGuard>} />
           <Route path="/leave" element={<LeavePage />} />
-          <Route path="/reports" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'FINANCE']}><TimeReportsPage /></RoleGuard>} />
+          <Route path="/reports" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR']}><TimeReportsPage /></RoleGuard>} />
           <Route path="/assets" element={<RoleGuard roles={['ADMIN', 'HR']}><AssetsPage /></RoleGuard>} />
           <Route path="/clients" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'FINANCE']}><ClientsPage /></RoleGuard>} />
           <Route path="/clients/:id" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'FINANCE']}><ClientDetailPage /></RoleGuard>} />
           <Route path="/presales" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'FINANCE']}><PreSalesPage /></RoleGuard>} />
           <Route path="/presales/:id" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'FINANCE']}><PreSaleDetailPage /></RoleGuard>} />
           <Route path="/admin" element={<AdminGuard><AdminPage /></AdminGuard>} />
-          <Route path="/finance" element={<RoleGuard roles={['FINANCE']}><FinancePage /></RoleGuard>} />
           <Route path="/profile" element={<ProfilePage />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,12 +30,6 @@ import PreSaleDetailPage from '@/pages/PreSaleDetailPage';
 import UserDetailPage from '@/pages/UserDetailPage';
 import FinancePage from '@/pages/FinancePage';
 
-function FinanceOrDashboard() {
-  const role = useAuthStore((s) => s.user?.role);
-  if (role === 'FINANCE') return <FinancePage />;
-  return <DashboardPage />;
-}
-
 export default function App() {
   const checkSession = useAuthStore((s) => s.checkSession);
   const isLoading = useAuthStore((s) => s.isLoading);
@@ -74,7 +68,7 @@ export default function App() {
             </AuthGuard>
           }
         >
-          <Route path="/" element={<FinanceOrDashboard />} />
+          <Route path="/" element={<DashboardPage />} />
           <Route path="/programs" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'FINANCE']}><ProgramsPage /></RoleGuard>} />
           <Route path="/programs/:id" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'FINANCE']}><ProgramDetailPage /></RoleGuard>} />
           <Route path="/projects" element={<ProjectsPage />} />
@@ -94,6 +88,7 @@ export default function App() {
           <Route path="/presales" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'FINANCE']}><PreSalesPage /></RoleGuard>} />
           <Route path="/presales/:id" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'FINANCE']}><PreSaleDetailPage /></RoleGuard>} />
           <Route path="/admin" element={<AdminGuard><AdminPage /></AdminGuard>} />
+          <Route path="/finance" element={<RoleGuard roles={['FINANCE']}><FinancePage /></RoleGuard>} />
           <Route path="/profile" element={<ProfilePage />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/api/finance.ts
+++ b/frontend/src/api/finance.ts
@@ -63,6 +63,34 @@ export interface YearPaymentsResponse {
   overdue: PaymentDto[];
 }
 
+export interface ExpenseDto {
+  id: number;
+  projectId: number;
+  projectName: string;
+  category: string;
+  amount: string;
+  description: string | null;
+  expenseDate: string | null;
+  createdById: number | null;
+  createdByName: string | null;
+  approvalStatus: string | null;
+  rejectionReason: string | null;
+  createdAt: string | null;
+}
+
+export interface YearExpensesResponse {
+  year: number;
+  statusFilter: string;
+  expenses: ExpenseDto[];
+}
+
+export interface MonthlyFinanceData {
+  year: number;
+  paymentsReceived: number[];
+  paymentsPending: number[];
+  expenses: number[];
+}
+
 export function getFinanceDashboard(): Promise<DashboardResponse> {
   return apiGet('/finance/dashboard');
 }
@@ -70,4 +98,16 @@ export function getFinanceDashboard(): Promise<DashboardResponse> {
 export function getFinancePayments(year?: number): Promise<YearPaymentsResponse> {
   const params = year ? `?year=${year}` : '';
   return apiGet('/finance/payments' + params);
+}
+
+export function getFinanceExpenses(year?: number, status?: string): Promise<YearExpensesResponse> {
+  const params = new URLSearchParams();
+  if (year) params.set('year', String(year));
+  if (status) params.set('status', status);
+  return apiGet('/finance/expenses-by-year?' + params.toString());
+}
+
+export function getFinanceChartData(year?: number): Promise<MonthlyFinanceData> {
+  const params = year ? `?year=${year}` : '';
+  return apiGet('/finance/chart-data' + params);
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -80,6 +80,9 @@ export default function Sidebar() {
         ...(role === 'ADMIN' || role === 'MANAGER' || role === 'EXECUTIVE' || role === 'HR'
           ? [{ to: '/reports', label: 'Reports', icon: ReportsIcon }]
           : []),
+        ...(role === 'FINANCE'
+          ? [{ to: '/finance', label: 'Finance', icon: FinanceIcon }]
+          : []),
       ],
     }] : []),
   ].filter((s) => s.items.length > 0);
@@ -273,6 +276,14 @@ function PresalesIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.875c0-.621.91-1.092 1.607-.792l3.403 1.495a3.75 3.75 0 002.58 0l3.403-1.495c.697-.3 1.607.171 1.607.792v8.25c0 .621-.91 1.092-1.607.792l-3.403-1.495a3.75 3.75 0 00-2.58 0L5.357 13.868c-.697.3-1.607-.171-1.607-.792V4.875zM15.75 3.75v12M18.75 3.75v12" />
+    </svg>
+  );
+}
+
+function FinanceIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.103-.879-1.103-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
   );
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -77,11 +77,8 @@ export default function Sidebar() {
     ...(!isExternal ? [{
       header: 'Insights' as string | undefined,
       items: [
-        ...(role === 'ADMIN' || role === 'MANAGER' || role === 'EXECUTIVE' || role === 'HR' || role === 'FINANCE'
+        ...(role === 'ADMIN' || role === 'MANAGER' || role === 'EXECUTIVE' || role === 'HR'
           ? [{ to: '/reports', label: 'Reports', icon: ReportsIcon }]
-          : []),
-        ...(role === 'FINANCE'
-          ? [{ to: '/finance', label: 'Finance', icon: FinanceIcon }]
           : []),
       ],
     }] : []),
@@ -276,14 +273,6 @@ function PresalesIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.875c0-.621.91-1.092 1.607-.792l3.403 1.495a3.75 3.75 0 002.58 0l3.403-1.495c.697-.3 1.607.171 1.607.792v8.25c0 .621-.91 1.092-1.607.792l-3.403-1.495a3.75 3.75 0 00-2.58 0L5.357 13.868c-.697.3-1.607-.171-1.607-.792V4.875zM15.75 3.75v12M18.75 3.75v12" />
-    </svg>
-  );
-}
-
-function FinanceIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.103-.879-1.103-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
   );
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,6 +5,7 @@ import ManagerDashboard from '@/pages/dashboard/ManagerDashboard';
 import ExecutiveDashboard from '@/pages/dashboard/ExecutiveDashboard';
 import ContributorDashboard from '@/pages/dashboard/ContributorDashboard';
 import HrDashboard from '@/pages/dashboard/HrDashboard';
+import FinanceDashboard from '@/pages/dashboard/FinanceDashboard';
 
 class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
   state: { error: Error | null } = { error: null };
@@ -40,6 +41,8 @@ export default function DashboardPage() {
       return <ErrorBoundary><ExecutiveDashboard /></ErrorBoundary>;
     case 'HR':
       return <ErrorBoundary><HrDashboard /></ErrorBoundary>;
+    case 'FINANCE':
+      return <ErrorBoundary><FinanceDashboard /></ErrorBoundary>;
     default:
       return <ErrorBoundary><ContributorDashboard /></ErrorBoundary>;
   }

--- a/frontend/src/pages/FinancePage.tsx
+++ b/frontend/src/pages/FinancePage.tsx
@@ -206,21 +206,28 @@ export default function FinancePage() {
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Title</th>
                   <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Amount</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Due Date</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Delay</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
-                {payments.pending.map((p) => (
+                {payments.pending.map((p) => {
+                  const delay = p.dueDate ? Math.ceil((new Date(p.dueDate).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)) : null;
+                  const color = delay !== null ? (delay <= 0 ? 'text-red-600 font-bold' : delay <= 3 ? 'text-orange-600' : 'text-gray-600') : '';
+                  return (
                   <tr key={p.id} className="hover:bg-gray-50">
                     <td className="px-4 py-3 text-sm font-medium text-gray-900">{p.projectName}</td>
                     <td className="px-4 py-3 text-sm text-gray-700">{p.title}</td>
                     <td className="px-4 py-3 text-sm font-medium text-right">{formatCurrency(p.amount)}</td>
                     <td className="px-4 py-3 text-sm text-gray-500">{p.dueDate ? formatDate(p.dueDate) : '—'}</td>
-                    <td className="px-4 py-3">
-                      <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">{p.status}</span>
+                    <td className="px-4 py-3 text-sm text-right">
+                      {delay !== null ? (
+                        <span className={`font-medium ${color}`}>
+                          {delay < 0 ? `${Math.abs(delay)}d late` : delay === 0 ? 'Due' : `${delay}d`}
+                        </span>
+                      ) : '—'}
                     </td>
                   </tr>
-                ))}
+                )})}
               </tbody>
             </table>
           </div>

--- a/frontend/src/pages/FinancePage.tsx
+++ b/frontend/src/pages/FinancePage.tsx
@@ -90,7 +90,16 @@ export default function FinancePage() {
 
   return (
     <div className="p-6 space-y-6">
-      <h1 className="text-2xl font-bold text-gray-900">Finance Dashboard</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Finance Dashboard</h1>
+        <a href="/api/finance/export?format=csv"
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors">
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          Export CSV
+        </a>
+      </div>
 
       {/* KPI Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">

--- a/frontend/src/pages/FinancePage.tsx
+++ b/frontend/src/pages/FinancePage.tsx
@@ -212,7 +212,7 @@ export default function FinancePage() {
               <tbody className="divide-y divide-gray-100">
                 {payments.pending.map((p) => {
                   const delay = p.dueDate ? Math.ceil((new Date(p.dueDate).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)) : null;
-                  const color = delay !== null ? (delay <= 0 ? 'text-red-600 font-bold' : delay <= 3 ? 'text-orange-600' : 'text-gray-600') : '';
+                  const color = delay !== null ? (delay <= 0 ? 'text-red-600 font-bold' : delay <= 3 ? 'text-orange-600' : 'text-gray-800') : '';
                   return (
                   <tr key={p.id} className="hover:bg-gray-50">
                     <td className="px-4 py-3 text-sm font-medium text-gray-900">{p.projectName}</td>

--- a/frontend/src/pages/FinancePage.tsx
+++ b/frontend/src/pages/FinancePage.tsx
@@ -1,9 +1,7 @@
-import { useState, useEffect, useCallback } from 'react';
-import { getFinanceDashboard, getFinancePayments } from '@/api/finance';
+import { useState, useEffect } from 'react';
+import { getFinancePayments, getFinanceExpenses } from '@/api/finance';
 import { approveExpense, rejectExpense } from '@/api/expenses';
-import type { DashboardResponse, ProjectFinance, YearPaymentsResponse } from '@/api/finance';
-import { apiGet } from '@/api/client';
-import type { ProjectExpenseDto } from '@/types';
+import type { YearPaymentsResponse, YearExpensesResponse, ExpenseDto } from '@/api/finance';
 import { formatCurrency, formatDate } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
 import Modal from '@/components/common/Modal';
@@ -20,33 +18,21 @@ const approvalLabel: Record<string, string> = {
   REJECTED: 'Rejected',
 };
 
+const STATUS_TABS = ['ALL', 'PENDING_REVIEW', 'APPROVED', 'REJECTED'] as const;
+
 export default function FinancePage() {
-  const [dashboard, setDashboard] = useState<DashboardResponse | null>(null);
-  const [pendingExpenses, setPendingExpenses] = useState<ProjectExpenseDto[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [sortKey, setSortKey] = useState<keyof ProjectFinance>('projectName');
-  const [sortAsc, setSortAsc] = useState(true);
-  const [rejectId, setRejectId] = useState<{ projectId: number; expenseId: number } | null>(null);
-  const [rejectReason, setRejectReason] = useState('');
   const [payments, setPayments] = useState<YearPaymentsResponse | null>(null);
   const [paymentYear, setPaymentYear] = useState(new Date().getFullYear());
   const [paymentView, setPaymentView] = useState<'pending' | 'received' | 'overdue'>('pending');
   const [loadingPayments, setLoadingPayments] = useState(false);
 
-  const fetchDashboard = useCallback(async () => {
-    setLoading(true);
-    try {
-      const [dash, expenses] = await Promise.all([
-        getFinanceDashboard(),
-        apiGet<ProjectExpenseDto[]>('/finance/expenses?approvalStatus=PENDING_REVIEW').catch(() => []),
-      ]);
-      setDashboard(dash);
-      setPendingExpenses(expenses);
-    } catch { /* ignore */ }
-    finally { setLoading(false); }
-  }, []);
+  const [expenses, setExpenses] = useState<YearExpensesResponse | null>(null);
+  const [expenseYear, setExpenseYear] = useState(new Date().getFullYear());
+  const [expenseStatus, setExpenseStatus] = useState<string>('ALL');
+  const [loadingExpenses, setLoadingExpenses] = useState(false);
 
-  useEffect(() => { fetchDashboard(); }, [fetchDashboard]);
+  const [rejectId, setRejectId] = useState<{ projectId: number; expenseId: number } | null>(null);
+  const [rejectReason, setRejectReason] = useState('');
 
   useEffect(() => {
     setLoadingPayments(true);
@@ -56,14 +42,18 @@ export default function FinancePage() {
       .finally(() => setLoadingPayments(false));
   }, [paymentYear]);
 
-  const handleSort = (key: keyof ProjectFinance) => {
-    if (sortKey === key) setSortAsc(!sortAsc);
-    else { setSortKey(key); setSortAsc(true); }
-  };
+  useEffect(() => {
+    setLoadingExpenses(true);
+    getFinanceExpenses(expenseYear, expenseStatus === 'ALL' ? undefined : expenseStatus)
+      .then(setExpenses)
+      .catch(() => setExpenses(null))
+      .finally(() => setLoadingExpenses(false));
+  }, [expenseYear, expenseStatus]);
 
   const handleApprove = async (projectId: number, expenseId: number) => {
     await approveExpense(projectId, expenseId);
-    fetchDashboard();
+    const res = await getFinanceExpenses(expenseYear, expenseStatus === 'ALL' ? undefined : expenseStatus);
+    setExpenses(res);
   };
 
   const handleReject = async () => {
@@ -71,27 +61,14 @@ export default function FinancePage() {
     await rejectExpense(rejectId.projectId, rejectId.expenseId, rejectReason);
     setRejectId(null);
     setRejectReason('');
-    fetchDashboard();
+    const res = await getFinanceExpenses(expenseYear, expenseStatus === 'ALL' ? undefined : expenseStatus);
+    setExpenses(res);
   };
-
-  if (loading) return <div className="flex items-center justify-center h-64"><Spinner className="h-8 w-8 text-primary-600" /></div>;
-  if (!dashboard) return <div className="p-6 text-gray-500">Unable to load dashboard data.</div>;
-
-  const { summary, byProject } = dashboard;
-  const projectNameById = new Map(byProject.map(p => [p.projectId, p.projectName]));
-  const sorted = [...byProject].sort((a, b) => {
-    const av = a[sortKey];
-    const bv = b[sortKey];
-    const cmp = typeof av === 'string' ? av.localeCompare(bv as string) : (av as number) - (bv as number);
-    return sortAsc ? cmp : -cmp;
-  });
-
-  const sortIcon = (key: keyof ProjectFinance) => sortKey === key ? (sortAsc ? ' ↑' : ' ↓') : '';
 
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">Finance Dashboard</h1>
+        <h1 className="text-2xl font-bold text-gray-900">Finance</h1>
         <a href="/api/finance/export?format=csv"
           className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors">
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -99,72 +76,6 @@ export default function FinancePage() {
           </svg>
           Export CSV
         </a>
-      </div>
-
-      {/* KPI Cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
-        {[
-          { label: 'Total Budget', value: formatCurrency(summary.totalBudget), color: 'bg-blue-50 text-blue-700' },
-          { label: 'Total Expenses', value: formatCurrency(summary.totalExpenses), color: 'bg-red-50 text-red-700' },
-          { label: 'Payments Received', value: formatCurrency(summary.totalPaymentsReceived), color: 'bg-green-50 text-green-700' },
-          { label: 'Payments Pending', value: formatCurrency(summary.totalPaymentsPending), color: 'bg-yellow-50 text-yellow-700' },
-          { label: 'Collection Rate', value: `${summary.collectionRate}%`, color: 'bg-purple-50 text-purple-700' },
-        ].map((kpi) => (
-          <div key={kpi.label} className={`rounded-xl border border-gray-200 p-4 ${kpi.color}`}>
-            <p className="text-xs font-medium uppercase tracking-wide opacity-75">{kpi.label}</p>
-            <p className="text-2xl font-bold mt-1">{kpi.value}</p>
-          </div>
-        ))}
-      </div>
-
-      {/* Project Financial Table */}
-      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
-        <div className="px-4 py-3 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">Project Financials</h2>
-        </div>
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                {([
-                  ['projectName', 'Project'],
-                  ['budget', 'Budget'],
-                  ['expenses', 'Expenses'],
-                  ['laborCost', 'Labor'],
-                  ['paymentsReceived', 'Received'],
-                  ['collectionProgress', 'Collection %'],
-                  ['cpi', 'CPI'],
-                  ['spi', 'SPI'],
-                  ['pendingExpenses', 'Pending'],
-                ] as [keyof ProjectFinance, string][]).map(([key, label]) => (
-                  <th key={key} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase cursor-pointer hover:text-gray-700"
-                    onClick={() => handleSort(key)}>
-                    {label}{sortIcon(key)}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {sorted.map((p) => (
-                <tr key={p.projectId} className="hover:bg-gray-50">
-                  <td className="px-4 py-3 text-sm font-medium text-gray-900">{p.projectName}</td>
-                  <td className="px-4 py-3 text-sm text-gray-700">{formatCurrency(p.budget)}</td>
-                  <td className="px-4 py-3 text-sm text-gray-700">{formatCurrency(p.expenses)}</td>
-                  <td className="px-4 py-3 text-sm text-gray-700">{formatCurrency(p.laborCost)}</td>
-                  <td className="px-4 py-3 text-sm text-gray-700">{formatCurrency(p.paymentsReceived)}</td>
-                  <td className="px-4 py-3 text-sm text-gray-700">{p.collectionProgress}%</td>
-                  <td className="px-4 py-3 text-sm text-gray-700">{p.cpi !== null ? p.cpi : '—'}</td>
-                  <td className="px-4 py-3 text-sm text-gray-700">{p.spi !== null ? p.spi : '—'}</td>
-                  <td className="px-4 py-3 text-sm">
-                    {p.pendingExpenses > 0
-                      ? <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">{p.pendingExpenses}</span>
-                      : <span className="text-gray-400">0</span>}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
       </div>
 
       {/* Payments Panel */}
@@ -200,90 +111,49 @@ export default function FinancePage() {
         ) : payments && paymentView === 'pending' && payments.pending.length > 0 ? (
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Project</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Title</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Amount</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Due Date</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Delay</th>
-                </tr>
-              </thead>
+              <thead className="bg-gray-50">{['Project','Title','Amount','Due Date','Delay'].map(h => <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">{h}</th>)}</thead>
               <tbody className="divide-y divide-gray-100">
-                {payments.pending.map((p) => {
-                  const delay = p.dueDate ? Math.ceil((new Date(p.dueDate).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)) : null;
+                {payments.pending.map(p => {
+                  const delay = p.dueDate ? Math.ceil((new Date(p.dueDate).getTime() - Date.now()) / 86400000) : null;
                   const color = delay !== null ? (delay <= 0 ? 'text-red-600 font-bold' : delay <= 3 ? 'text-orange-600' : 'text-gray-800') : '';
-                  return (
-                  <tr key={p.id} className="hover:bg-gray-50">
+                  return <tr key={p.id} className="hover:bg-gray-50">
                     <td className="px-4 py-3 text-sm font-medium text-gray-900">{p.projectName}</td>
                     <td className="px-4 py-3 text-sm text-gray-700">{p.title}</td>
                     <td className="px-4 py-3 text-sm font-medium text-right">{formatCurrency(p.amount)}</td>
                     <td className="px-4 py-3 text-sm text-gray-500">{p.dueDate ? formatDate(p.dueDate) : '—'}</td>
-                    <td className="px-4 py-3 text-sm text-right">
-                      {delay !== null ? (
-                        <span className={`font-medium ${color}`}>
-                          {delay < 0 ? `${Math.abs(delay)}d late` : delay === 0 ? 'Due' : `${delay}d`}
-                        </span>
-                      ) : '—'}
-                    </td>
-                  </tr>
-                )})}
+                    <td className="px-4 py-3 text-sm text-right">{delay !== null ? <span className={`font-medium ${color}`}>{delay < 0 ? `${Math.abs(delay)}d late` : delay === 0 ? 'Due' : `${delay}d`}</span> : '—'}</td>
+                  </tr>;
+                })}
               </tbody>
             </table>
           </div>
         ) : payments && paymentView === 'overdue' && payments.overdue.length > 0 ? (
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-red-50">
-                <tr>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-red-600 uppercase">Project</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-red-600 uppercase">Title</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium text-red-600 uppercase">Amount</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-red-600 uppercase">Due Date</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium text-red-600 uppercase">Days Overdue</th>
-                </tr>
-              </thead>
+              <thead className="bg-red-50">{['Project','Title','Amount','Due Date','Days Overdue'].map(h => <th key={h} className="px-4 py-3 text-left text-xs font-medium text-red-600 uppercase">{h}</th>)}</thead>
               <tbody className="divide-y divide-gray-100">
-                {payments.overdue.map((p) => (
-                  <tr key={p.id} className="hover:bg-red-50">
-                    <td className="px-4 py-3 text-sm font-medium text-gray-900">{p.projectName}</td>
-                    <td className="px-4 py-3 text-sm text-gray-700">{p.title}</td>
-                    <td className="px-4 py-3 text-sm font-medium text-red-700 text-right">{formatCurrency(p.amount)}</td>
-                    <td className="px-4 py-3 text-sm text-gray-500">{p.dueDate ? formatDate(p.dueDate) : '—'}</td>
-                    <td className="px-4 py-3 text-sm font-bold text-red-600 text-right">{p.delayDays}d</td>
-                  </tr>
-                ))}
+                {payments.overdue.map(p => <tr key={p.id} className="hover:bg-red-50">
+                  <td className="px-4 py-3 text-sm font-medium text-gray-900">{p.projectName}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{p.title}</td>
+                  <td className="px-4 py-3 text-sm font-medium text-red-700 text-right">{formatCurrency(p.amount)}</td>
+                  <td className="px-4 py-3 text-sm text-gray-500">{p.dueDate ? formatDate(p.dueDate) : '—'}</td>
+                  <td className="px-4 py-3 text-sm font-bold text-red-600 text-right">{p.delayDays}d</td>
+                </tr>)}
               </tbody>
             </table>
           </div>
         ) : payments && paymentView === 'received' && payments.received.length > 0 ? (
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Project</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Title</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Amount</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Received</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Delay</th>
-                </tr>
-              </thead>
+              <thead className="bg-gray-50">{['Project','Title','Amount','Received','Delay'].map(h => <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">{h}</th>)}</thead>
               <tbody className="divide-y divide-gray-100">
-                {payments.received.map((p) => (
-                  <tr key={p.id} className="hover:bg-gray-50">
-                    <td className="px-4 py-3 text-sm font-medium text-gray-900">{p.projectName}</td>
-                    <td className="px-4 py-3 text-sm text-gray-700">{p.title}</td>
-                    <td className="px-4 py-3 text-sm font-medium text-right">{formatCurrency(p.amount)}</td>
-                    <td className="px-4 py-3 text-sm text-gray-500">{p.receivedDate ? formatDate(p.receivedDate) : '—'}</td>
-                    <td className="px-4 py-3 text-sm text-right">
-                      {p.delayDays !== null ? (
-                        <span className={`font-medium ${p.delayDays > 0 ? 'text-red-600' : 'text-green-600'}`}>
-                          {p.delayDays > 0 ? `${p.delayDays}d late` : 'On time'}
-                        </span>
-                      ) : '—'}
-                    </td>
-                  </tr>
-                ))}
+                {payments.received.map(p => <tr key={p.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 text-sm font-medium text-gray-900">{p.projectName}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{p.title}</td>
+                  <td className="px-4 py-3 text-sm font-medium text-right">{formatCurrency(p.amount)}</td>
+                  <td className="px-4 py-3 text-sm text-gray-500">{p.receivedDate ? formatDate(p.receivedDate) : '—'}</td>
+                  <td className="px-4 py-3 text-sm text-right">{p.delayDays !== null ? <span className={`font-medium ${p.delayDays > 0 ? 'text-red-600' : 'text-green-600'}`}>{p.delayDays > 0 ? `${p.delayDays}d late` : 'On time'}</span> : '—'}</td>
+                </tr>)}
               </tbody>
             </table>
           </div>
@@ -292,49 +162,78 @@ export default function FinancePage() {
         )}
       </div>
 
-      {/* Pending Expense Approvals */}
-      {pendingExpenses.length > 0 && (
-        <div className="bg-white rounded-xl border border-yellow-200 overflow-hidden">
-          <div className="px-4 py-3 border-b border-yellow-200 bg-yellow-50">
-            <h2 className="text-lg font-semibold text-yellow-800">Pending Expense Approvals ({pendingExpenses.length})</h2>
+      {/* Expenses Panel */}
+      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between flex-wrap gap-3">
+          <div className="flex items-center gap-3">
+            <h2 className="text-lg font-semibold text-gray-900">Expenses</h2>
+            <div className="flex items-center gap-1 text-sm">
+              <button onClick={() => setExpenseYear(expenseYear - 1)}
+                className="px-2 py-1 rounded hover:bg-gray-100 text-gray-600 font-medium">&larr;</button>
+              <span className="px-3 py-1 bg-gray-100 rounded font-medium text-gray-800">{expenseYear}</span>
+              <button onClick={() => setExpenseYear(expenseYear + 1)}
+                className="px-2 py-1 rounded hover:bg-gray-100 text-gray-600 font-medium">&rarr;</button>
+            </div>
           </div>
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-yellow-50">
-              <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-yellow-700 uppercase">Project</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-yellow-700 uppercase">Category</th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-yellow-700 uppercase">Amount</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-yellow-700 uppercase">Description</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-yellow-700 uppercase">Date</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-yellow-700 uppercase">Status</th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-yellow-700 uppercase">Actions</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {pendingExpenses.map((exp) => (
-                <tr key={exp.id} className="hover:bg-yellow-50">
-                  <td className="px-4 py-3 text-sm font-medium text-gray-900">{projectNameById.get(exp.projectId) ?? `Project ${exp.projectId}`}</td>
-                  <td className="px-4 py-3 text-sm text-gray-700">{exp.category}</td>
-                  <td className="px-4 py-3 text-sm font-medium text-gray-900 text-right">{formatCurrency(Number(exp.amount))}</td>
-                  <td className="px-4 py-3 text-sm text-gray-700 max-w-xs truncate">{exp.description || '—'}</td>
-                  <td className="px-4 py-3 text-sm text-gray-500">{formatDate(exp.expenseDate)}</td>
-                  <td className="px-4 py-3">
-                    <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${approvalBadge[exp.approvalStatus] || 'bg-gray-100 text-gray-600'}`}>
-                      {approvalLabel[exp.approvalStatus] || exp.approvalStatus}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-right space-x-2">
-                    <button onClick={() => handleApprove(exp.projectId, exp.id)}
-                      className="text-green-600 hover:text-green-800 text-xs font-medium">Approve</button>
-                    <button onClick={() => { setRejectId({ projectId: exp.projectId, expenseId: exp.id }); setRejectReason(''); }}
-                      className="text-red-600 hover:text-red-800 text-xs font-medium">Reject</button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <div className="flex items-center gap-2">
+            {STATUS_TABS.map(s => (
+              <button key={s} onClick={() => setExpenseStatus(s)}
+                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${expenseStatus === s ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>
+                {s === 'ALL' ? 'All' : approvalLabel[s] || s}
+              </button>
+            ))}
+          </div>
         </div>
-      )}
+        {loadingExpenses ? (
+          <div className="flex items-center justify-center h-32"><Spinner className="h-6 w-6 text-primary-600" /></div>
+        ) : expenses && expenses.expenses.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Project</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Category</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Amount</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Description</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Date</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">By</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {expenses.expenses.map((e: ExpenseDto) => (
+                  <tr key={e.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 text-sm font-medium text-gray-900">{e.projectName}</td>
+                    <td className="px-4 py-3 text-sm text-gray-700">{e.category}</td>
+                    <td className="px-4 py-3 text-sm font-medium text-right">{formatCurrency(Number(e.amount))}</td>
+                    <td className="px-4 py-3 text-sm text-gray-700 max-w-xs truncate">{e.description || '—'}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{e.expenseDate ? formatDate(e.expenseDate) : '—'}</td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${approvalBadge[e.approvalStatus || ''] || 'bg-gray-100 text-gray-600'}`}>
+                        {approvalLabel[e.approvalStatus || ''] || e.approvalStatus || '—'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{e.createdByName || '—'}</td>
+                    <td className="px-4 py-3 text-right space-x-2">
+                      {e.approvalStatus === 'PENDING_REVIEW' && (
+                        <>
+                          <button onClick={() => handleApprove(e.projectId, e.id)}
+                            className="text-green-600 hover:text-green-800 text-xs font-medium">Approve</button>
+                          <button onClick={() => { setRejectId({ projectId: e.projectId, expenseId: e.id }); setRejectReason(''); }}
+                            className="text-red-600 hover:text-red-800 text-xs font-medium">Reject</button>
+                        </>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="px-4 py-8 text-center text-sm text-gray-400">No expenses found for {expenseYear}</div>
+        )}
+      </div>
 
       {rejectId && (
         <Modal title="Reject Expense" onClose={() => { setRejectId(null); setRejectReason(''); }}>

--- a/frontend/src/pages/dashboard/FinanceDashboard.tsx
+++ b/frontend/src/pages/dashboard/FinanceDashboard.tsx
@@ -1,30 +1,55 @@
-import { useState, useEffect } from 'react';
-import { getFinanceChartData } from '@/api/finance';
-import type { MonthlyFinanceData } from '@/api/finance';
+import { useState, useEffect, useCallback } from 'react';
+import { getFinanceDashboard, getFinanceChartData } from '@/api/finance';
+import type { DashboardResponse, ProjectFinance, MonthlyFinanceData } from '@/api/finance';
 import { formatCurrency } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
 
 const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
 
 export default function FinanceDashboard() {
-  const [data, setData] = useState<MonthlyFinanceData | null>(null);
+  const [dashboard, setDashboard] = useState<DashboardResponse | null>(null);
+  const [chartData, setChartData] = useState<MonthlyFinanceData | null>(null);
   const [year, setYear] = useState(new Date().getFullYear());
   const [loading, setLoading] = useState(true);
+  const [sortKey, setSortKey] = useState<keyof ProjectFinance>('projectName');
+  const [sortAsc, setSortAsc] = useState(true);
 
-  useEffect(() => {
+  const fetchData = useCallback(async () => {
     setLoading(true);
-    getFinanceChartData(year)
-      .then(setData)
-      .catch(() => setData(null))
-      .finally(() => setLoading(false));
+    try {
+      const [dash, chart] = await Promise.all([
+        getFinanceDashboard(),
+        getFinanceChartData(year),
+      ]);
+      setDashboard(dash);
+      setChartData(chart);
+    } catch { /* ignore */ }
+    finally { setLoading(false) }
   }, [year]);
 
-  const maxVal = data ? Math.max(
-    ...data.paymentsReceived, ...data.paymentsPending, ...data.expenses, 1
-  ) : 1;
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const handleSort = (key: keyof ProjectFinance) => {
+    if (sortKey === key) setSortAsc(!sortAsc);
+    else { setSortKey(key); setSortAsc(true); }
+  };
 
   if (loading) return <div className="flex items-center justify-center h-64"><Spinner className="h-8 w-8 text-primary-600" /></div>;
-  if (!data) return <div className="p-6 text-gray-500">Unable to load chart data.</div>;
+  if (!dashboard) return <div className="p-6 text-gray-500">Unable to load dashboard data.</div>;
+
+  const { summary, byProject } = dashboard;
+  const sorted = [...byProject].sort((a, b) => {
+    const av = a[sortKey];
+    const bv = b[sortKey];
+    const cmp = typeof av === 'string' ? av.localeCompare(bv as string) : (av as number) - (bv as number);
+    return sortAsc ? cmp : -cmp;
+  });
+
+  const sortIcon = (key: keyof ProjectFinance) => sortKey === key ? (sortAsc ? ' ↑' : ' ↓') : '';
+
+  const maxVal = chartData ? Math.max(
+    ...chartData.paymentsReceived, ...chartData.paymentsPending, ...chartData.expenses, 1
+  ) : 1;
 
   return (
     <div className="p-6 space-y-6">
@@ -39,57 +64,126 @@ export default function FinanceDashboard() {
         </div>
       </div>
 
-      {/* Payments Chart */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Payments Received vs Pending by Month</h2>
-        <div className="flex items-end gap-1 h-48">
-          {MONTHS.map((m, i) => {
-            const received = Number(data.paymentsReceived[i]) || 0;
-            const pending = Number(data.paymentsPending[i]) || 0;
-            const rH = Math.round((received / maxVal) * 100);
-            const pH = Math.round((pending / maxVal) * 100);
-            return (
-              <div key={m} className="flex-1 flex flex-col items-center gap-0.5">
-                <div className="w-full flex flex-col items-center justify-end h-44">
-                  <div title={`Received: ${formatCurrency(received)}`}
-                    className="w-full bg-green-500 rounded-t transition-all duration-300"
-                    style={{ height: `${Math.max(rH, 1)}%` }} />
-                  <div title={`Pending: ${formatCurrency(pending)}`}
-                    className="w-full bg-yellow-400 transition-all duration-300"
-                    style={{ height: `${Math.max(pH, 1)}%` }} />
+      {/* KPI Cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+        {[
+          { label: 'Total Budget', value: formatCurrency(summary.totalBudget), color: 'bg-blue-50 text-blue-700' },
+          { label: 'Total Expenses', value: formatCurrency(summary.totalExpenses), color: 'bg-red-50 text-red-700' },
+          { label: 'Payments Received', value: formatCurrency(summary.totalPaymentsReceived), color: 'bg-green-50 text-green-700' },
+          { label: 'Payments Pending', value: formatCurrency(summary.totalPaymentsPending), color: 'bg-yellow-50 text-yellow-700' },
+          { label: 'Collection Rate', value: `${summary.collectionRate}%`, color: 'bg-purple-50 text-purple-700' },
+        ].map((kpi) => (
+          <div key={kpi.label} className={`rounded-xl border border-gray-200 p-4 ${kpi.color}`}>
+            <p className="text-xs font-medium uppercase tracking-wide opacity-75">{kpi.label}</p>
+            <p className="text-2xl font-bold mt-1">{kpi.value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Charts — side by side on large screens */}
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        {/* Payments Chart */}
+        <div className="bg-white rounded-xl border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Payments Received vs Pending by Month</h2>
+          <div className="flex items-end gap-1 h-48">
+            {MONTHS.map((m, i) => {
+              const received = Number(chartData?.paymentsReceived[i]) || 0;
+              const pending = Number(chartData?.paymentsPending[i]) || 0;
+              const rH = Math.round((received / maxVal) * 100);
+              const pH = Math.round((pending / maxVal) * 100);
+              return (
+                <div key={m} className="flex-1 flex flex-col items-center gap-0.5">
+                  <div className="w-full flex flex-col items-center justify-end h-44">
+                    <div title={`Received: ${formatCurrency(received)}`}
+                      className="w-full bg-green-500 rounded-t transition-all duration-300"
+                      style={{ height: `${Math.max(rH, 1)}%` }} />
+                    <div title={`Pending: ${formatCurrency(pending)}`}
+                      className="w-full bg-yellow-400 transition-all duration-300"
+                      style={{ height: `${Math.max(pH, 1)}%` }} />
+                  </div>
+                  <span className="text-[10px] text-gray-500 mt-1">{m}</span>
                 </div>
-                <span className="text-[10px] text-gray-500 mt-1">{m}</span>
-              </div>
-            );
-          })}
+              );
+            })}
+          </div>
+          <div className="flex items-center gap-4 mt-4 text-xs text-gray-600">
+            <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-green-500" /> Received</span>
+            <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-yellow-400" /> Pending</span>
+          </div>
         </div>
-        <div className="flex items-center gap-4 mt-4 text-xs text-gray-600">
-          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-green-500" /> Received</span>
-          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-yellow-400" /> Pending</span>
+
+        {/* Expenses Chart */}
+        <div className="bg-white rounded-xl border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Expenses by Month</h2>
+          <div className="flex items-end gap-1 h-48">
+            {MONTHS.map((m, i) => {
+              const exp = Number(chartData?.expenses[i]) || 0;
+              const h = Math.round((exp / maxVal) * 100);
+              return (
+                <div key={m} className="flex-1 flex flex-col items-center">
+                  <div className="w-full flex flex-col items-center justify-end h-44">
+                    <div title={`Expenses: ${formatCurrency(exp)}`}
+                      className="w-full bg-red-400 rounded-t transition-all duration-300"
+                      style={{ height: `${Math.max(h, 1)}%` }} />
+                  </div>
+                  <span className="text-[10px] text-gray-500 mt-1">{m}</span>
+                </div>
+              );
+            })}
+          </div>
+          <div className="flex items-center gap-4 mt-4 text-xs text-gray-600">
+            <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-red-400" /> Expenses</span>
+          </div>
         </div>
       </div>
 
-      {/* Expenses Chart */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Expenses by Month</h2>
-        <div className="flex items-end gap-1 h-48">
-          {MONTHS.map((m, i) => {
-            const exp = Number(data.expenses[i]) || 0;
-            const h = Math.round((exp / maxVal) * 100);
-            return (
-              <div key={m} className="flex-1 flex flex-col items-center">
-                <div className="w-full flex flex-col items-center justify-end h-44">
-                  <div title={`Expenses: ${formatCurrency(exp)}`}
-                    className="w-full bg-red-400 rounded-t transition-all duration-300"
-                    style={{ height: `${Math.max(h, 1)}%` }} />
-                </div>
-                <span className="text-[10px] text-gray-500 mt-1">{m}</span>
-              </div>
-            );
-          })}
+      {/* Project Financial Table */}
+      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        <div className="px-4 py-3 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">Project Financials</h2>
         </div>
-        <div className="flex items-center gap-4 mt-4 text-xs text-gray-600">
-          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-red-400" /> Expenses</span>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                {([
+                  ['projectName', 'Project'],
+                  ['budget', 'Budget'],
+                  ['expenses', 'Expenses'],
+                  ['laborCost', 'Labor'],
+                  ['paymentsReceived', 'Received'],
+                  ['collectionProgress', 'Collection %'],
+                  ['cpi', 'CPI'],
+                  ['spi', 'SPI'],
+                  ['pendingExpenses', 'Pending'],
+                ] as [keyof ProjectFinance, string][]).map(([key, label]) => (
+                  <th key={key} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase cursor-pointer hover:text-gray-700"
+                    onClick={() => handleSort(key)}>
+                    {label}{sortIcon(key)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {sorted.map((p) => (
+                <tr key={p.projectId} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 text-sm font-medium text-gray-900">{p.projectName}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{formatCurrency(p.budget)}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{formatCurrency(p.expenses)}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{formatCurrency(p.laborCost)}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{formatCurrency(p.paymentsReceived)}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{p.collectionProgress}%</td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{p.cpi !== null ? p.cpi : '—'}</td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{p.spi !== null ? p.spi : '—'}</td>
+                  <td className="px-4 py-3 text-sm">
+                    {p.pendingExpenses > 0
+                      ? <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">{p.pendingExpenses}</span>
+                      : <span className="text-gray-400">0</span>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/dashboard/FinanceDashboard.tsx
+++ b/frontend/src/pages/dashboard/FinanceDashboard.tsx
@@ -1,0 +1,97 @@
+import { useState, useEffect } from 'react';
+import { getFinanceChartData } from '@/api/finance';
+import type { MonthlyFinanceData } from '@/api/finance';
+import { formatCurrency } from '@/utils/format';
+import Spinner from '@/components/common/Spinner';
+
+const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+export default function FinanceDashboard() {
+  const [data, setData] = useState<MonthlyFinanceData | null>(null);
+  const [year, setYear] = useState(new Date().getFullYear());
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    getFinanceChartData(year)
+      .then(setData)
+      .catch(() => setData(null))
+      .finally(() => setLoading(false));
+  }, [year]);
+
+  const maxVal = data ? Math.max(
+    ...data.paymentsReceived, ...data.paymentsPending, ...data.expenses, 1
+  ) : 1;
+
+  if (loading) return <div className="flex items-center justify-center h-64"><Spinner className="h-8 w-8 text-primary-600" /></div>;
+  if (!data) return <div className="p-6 text-gray-500">Unable to load chart data.</div>;
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Finance Dashboard</h1>
+        <div className="flex items-center gap-1 text-sm">
+          <button onClick={() => setYear(year - 1)}
+            className="px-2 py-1 rounded hover:bg-gray-100 text-gray-600 font-medium">&larr;</button>
+          <span className="px-3 py-1 bg-gray-100 rounded font-medium text-gray-800">{year}</span>
+          <button onClick={() => setYear(year + 1)}
+            className="px-2 py-1 rounded hover:bg-gray-100 text-gray-600 font-medium">&rarr;</button>
+        </div>
+      </div>
+
+      {/* Payments Chart */}
+      <div className="bg-white rounded-xl border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Payments Received vs Pending by Month</h2>
+        <div className="flex items-end gap-1 h-48">
+          {MONTHS.map((m, i) => {
+            const received = Number(data.paymentsReceived[i]) || 0;
+            const pending = Number(data.paymentsPending[i]) || 0;
+            const rH = Math.round((received / maxVal) * 100);
+            const pH = Math.round((pending / maxVal) * 100);
+            return (
+              <div key={m} className="flex-1 flex flex-col items-center gap-0.5">
+                <div className="w-full flex flex-col items-center justify-end h-44">
+                  <div title={`Received: ${formatCurrency(received)}`}
+                    className="w-full bg-green-500 rounded-t transition-all duration-300"
+                    style={{ height: `${Math.max(rH, 1)}%` }} />
+                  <div title={`Pending: ${formatCurrency(pending)}`}
+                    className="w-full bg-yellow-400 transition-all duration-300"
+                    style={{ height: `${Math.max(pH, 1)}%` }} />
+                </div>
+                <span className="text-[10px] text-gray-500 mt-1">{m}</span>
+              </div>
+            );
+          })}
+        </div>
+        <div className="flex items-center gap-4 mt-4 text-xs text-gray-600">
+          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-green-500" /> Received</span>
+          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-yellow-400" /> Pending</span>
+        </div>
+      </div>
+
+      {/* Expenses Chart */}
+      <div className="bg-white rounded-xl border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Expenses by Month</h2>
+        <div className="flex items-end gap-1 h-48">
+          {MONTHS.map((m, i) => {
+            const exp = Number(data.expenses[i]) || 0;
+            const h = Math.round((exp / maxVal) * 100);
+            return (
+              <div key={m} className="flex-1 flex flex-col items-center">
+                <div className="w-full flex flex-col items-center justify-end h-44">
+                  <div title={`Expenses: ${formatCurrency(exp)}`}
+                    className="w-full bg-red-400 rounded-t transition-all duration-300"
+                    style={{ height: `${Math.max(h, 1)}%` }} />
+                </div>
+                <span className="text-[10px] text-gray-500 mt-1">{m}</span>
+              </div>
+            );
+          })}
+        </div>
+        <div className="flex items-center gap-4 mt-4 text-xs text-gray-600">
+          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-red-400" /> Expenses</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/project-detail/PhasesTab.tsx
+++ b/frontend/src/pages/project-detail/PhasesTab.tsx
@@ -391,7 +391,7 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
                     <div className="mb-4">
                       <div className="flex items-center justify-between mb-2">
                         <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Payments ({phasePayments.length})</span>
-                        {(canEdit || canManagePayments) && (
+                        {canManagePayments && (
                           <button onClick={() => openPaymentForm(phase.id)} className="text-xs font-medium text-primary-600 hover:text-primary-800">+ Add Payment</button>
                         )}
                       </div>
@@ -416,7 +416,7 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
                             <th className="text-right px-2 py-1 font-medium text-gray-500 text-xs">Amount</th>
                             <th className="text-left px-2 py-1 font-medium text-gray-500 text-xs">Reference</th>
                             <th className="text-left px-2 py-1 font-medium text-gray-500 text-xs">Notes</th>
-                            {(canEdit || canManagePayments) && <th className="px-2 py-1"></th>}
+                            {canManagePayments && <th className="px-2 py-1"></th>}
                           </tr></thead>
                           <tbody className="divide-y divide-gray-50">
                             {phasePayments.map(p => (
@@ -425,7 +425,7 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
                                 <td className="px-2 py-1.5 text-right font-medium text-gray-900">{formatCurrency(Number(p.amount))}</td>
                                 <td className="px-2 py-1.5 text-gray-600">{p.reference || '—'}</td>
                                 <td className="px-2 py-1.5 text-gray-500 max-w-[200px] truncate">{p.notes || '—'}</td>
-                                {(canEdit || canManagePayments) && (
+                                {canManagePayments && (
                                   <td className="px-2 py-1.5 text-right">
                                     <button onClick={() => openPaymentForm(phase.id, p)} className="text-primary-600 hover:text-primary-800 text-xs font-medium mr-2">Edit</button>
                                     <button onClick={() => handlePaymentDelete(phase.id, p.id)} className="text-red-600 hover:text-red-800 text-xs font-medium">Delete</button>

--- a/frontend/src/pages/project-detail/PhasesTab.tsx
+++ b/frontend/src/pages/project-detail/PhasesTab.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import type { PhaseDto, ClientPaymentDto, DeliverableDto } from '@/types';
 import { listPhases, createPhase, updatePhase, deletePhase, listDeliverables, createDeliverable, updateDeliverable, deleteDeliverable, uploadDeliverableAttachment, deleteDeliverableAttachment, getDeliverableAttachmentDownloadUrl, listClientPayments, createClientPayment, updateClientPayment, deleteClientPayment } from '@/api/phases';
 import axios from 'axios';
-import { formatDate, formatCurrency, deliverableStateBadge, deliverableStateLabel, deadlineBadge, deadlineLabel } from '@/utils/format';
+import { formatDate, formatCurrency, formatCurrencyUnit, deliverableStateBadge, deliverableStateLabel, deadlineBadge, deadlineLabel } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
 import Modal from '@/components/common/Modal';
 
@@ -334,7 +334,7 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
                       )}
                       {(Number(phase.totalPaid || 0) > 0 || Number(phase.spent || 0) > 0) && (
                         <span className="text-xs font-medium text-gray-500">
-                          pay/exp: {formatCurrency(Number(phase.totalPaid || 0))}/{formatCurrency(Number(phase.spent || 0))}
+                          DH pay/exp: {formatCurrencyUnit(Number(phase.totalPaid || 0))}/{formatCurrencyUnit(Number(phase.spent || 0))}
                         </span>
                       )}
                     </div>
@@ -344,7 +344,7 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
                           <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
                             <div className={`h-full rounded-full ${progress.color}`} style={{ width: `${progress.pct}%` }} />
                           </div>
-                          <span className="text-xs text-gray-500 whitespace-nowrap">{formatCurrency(Number(phase.totalPaid || 0))}</span>
+                          <span className="text-xs text-gray-500 whitespace-nowrap">{formatCurrencyUnit(Number(phase.totalPaid || 0))}</span>
                         </div>
                       )}
                       {(phase.startDate || phase.endDate) && (
@@ -379,8 +379,8 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
                           <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Budget vs Spent</span>
                         </div>
                         <div className="flex items-center gap-3 mb-2 text-xs">
-                          <span className="text-gray-500">Budget: <span className="font-medium text-gray-900">{formatCurrency(sProgress.planned)}</span></span>
-                          <span className="text-gray-500">Spent: <span className={`font-medium ${sProgress.pct >= 100 ? 'text-red-700' : sProgress.pct >= 80 ? 'text-amber-700' : 'text-gray-900'}`}>{formatCurrency(sProgress.spent)}</span></span>
+                          <span className="text-gray-500">Budget: <span className="font-medium text-gray-900">{formatCurrencyUnit(sProgress.planned)}</span></span>
+                          <span className="text-gray-500">Spent: <span className={`font-medium ${sProgress.pct >= 100 ? 'text-red-700' : sProgress.pct >= 80 ? 'text-amber-700' : 'text-gray-900'}`}>{formatCurrencyUnit(sProgress.spent)}</span></span>
                           <span className={`font-medium ${sProgress.pct >= 100 ? 'text-red-700' : sProgress.pct >= 80 ? 'text-amber-700' : 'text-gray-500'}`}>({sProgress.pct}%)</span>
                         </div>
                         <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
@@ -399,14 +399,14 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
                       </div>
                       {progress.planned > 0 && (
                         <div className="flex items-center gap-3 mb-2 text-xs">
-                          <span className="text-gray-500">Planned: <span className="font-medium text-gray-900">{formatCurrency(progress.planned)}</span></span>
-                          <span className="text-gray-500">Paid: <span className={`font-medium ${progress.pct >= 100 ? 'text-green-700' : 'text-gray-900'}`}>{formatCurrency(progress.paid)}</span></span>
+                          <span className="text-gray-500">Planned: <span className="font-medium text-gray-900">{formatCurrencyUnit(progress.planned)}</span></span>
+                          <span className="text-gray-500">Paid: <span className={`font-medium ${progress.pct >= 100 ? 'text-green-700' : 'text-gray-900'}`}>{formatCurrencyUnit(progress.paid)}</span></span>
                           <span className={`font-medium ${progress.pct >= 100 ? 'text-green-700' : 'text-gray-500'}`}>({progress.pct}%)</span>
                         </div>
                       )}
                       {progress.paid > 0 && progress.planned === 0 && (
                         <div className="flex items-center gap-3 mb-2 text-xs">
-                          <span className="text-gray-500">Paid: <span className="font-medium text-gray-900">{formatCurrency(progress.paid)}</span></span>
+                          <span className="text-gray-500">Paid: <span className="font-medium text-gray-900">{formatCurrencyUnit(progress.paid)}</span></span>
                         </div>
                       )}
                       {phasePayments.length === 0 ? (
@@ -424,7 +424,7 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
                             {phasePayments.map(p => (
                               <tr key={p.id} className="hover:bg-gray-50">
                                 <td className="px-2 py-1.5 text-gray-600">{p.paymentDate ? formatDate(p.paymentDate) : '—'}</td>
-                                <td className="px-2 py-1.5 text-right font-medium text-gray-900">{formatCurrency(Number(p.amount))}</td>
+                                <td className="px-2 py-1.5 text-right font-medium text-gray-900">{formatCurrencyUnit(Number(p.amount))}</td>
                                 <td className="px-2 py-1.5 text-gray-600">{p.reference || '—'}</td>
                                 <td className="px-2 py-1.5 text-gray-500 max-w-[200px] truncate">{p.notes || '—'}</td>
                                 {canManagePayments && (

--- a/frontend/src/pages/project-detail/PhasesTab.tsx
+++ b/frontend/src/pages/project-detail/PhasesTab.tsx
@@ -6,7 +6,7 @@ import { formatDate, formatCurrency, deliverableStateBadge, deliverableStateLabe
 import Spinner from '@/components/common/Spinner';
 import Modal from '@/components/common/Modal';
 
-export default function PhasesTab({ projectId, canEdit }: { projectId: number; canEdit: boolean }) {
+export default function PhasesTab({ projectId, canEdit, canManagePayments = false }: { projectId: number; canEdit: boolean; canManagePayments?: boolean }) {
   const [phases, setPhases] = useState<PhaseDto[]>([]);
   const [deliverables, setDeliverables] = useState<DeliverableDto[]>([]);
   const [payments, setPayments] = useState<Record<number, ClientPaymentDto[]>>({});
@@ -391,7 +391,7 @@ export default function PhasesTab({ projectId, canEdit }: { projectId: number; c
                     <div className="mb-4">
                       <div className="flex items-center justify-between mb-2">
                         <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Payments ({phasePayments.length})</span>
-                        {canEdit && (
+                        {(canEdit || canManagePayments) && (
                           <button onClick={() => openPaymentForm(phase.id)} className="text-xs font-medium text-primary-600 hover:text-primary-800">+ Add Payment</button>
                         )}
                       </div>
@@ -416,7 +416,7 @@ export default function PhasesTab({ projectId, canEdit }: { projectId: number; c
                             <th className="text-right px-2 py-1 font-medium text-gray-500 text-xs">Amount</th>
                             <th className="text-left px-2 py-1 font-medium text-gray-500 text-xs">Reference</th>
                             <th className="text-left px-2 py-1 font-medium text-gray-500 text-xs">Notes</th>
-                            {canEdit && <th className="px-2 py-1"></th>}
+                            {(canEdit || canManagePayments) && <th className="px-2 py-1"></th>}
                           </tr></thead>
                           <tbody className="divide-y divide-gray-50">
                             {phasePayments.map(p => (
@@ -425,7 +425,7 @@ export default function PhasesTab({ projectId, canEdit }: { projectId: number; c
                                 <td className="px-2 py-1.5 text-right font-medium text-gray-900">{formatCurrency(Number(p.amount))}</td>
                                 <td className="px-2 py-1.5 text-gray-600">{p.reference || '—'}</td>
                                 <td className="px-2 py-1.5 text-gray-500 max-w-[200px] truncate">{p.notes || '—'}</td>
-                                {canEdit && (
+                                {(canEdit || canManagePayments) && (
                                   <td className="px-2 py-1.5 text-right">
                                     <button onClick={() => openPaymentForm(phase.id, p)} className="text-primary-600 hover:text-primary-800 text-xs font-medium mr-2">Edit</button>
                                     <button onClick={() => handlePaymentDelete(phase.id, p.id)} className="text-red-600 hover:text-red-800 text-xs font-medium">Delete</button>

--- a/frontend/src/pages/project-detail/PhasesTab.tsx
+++ b/frontend/src/pages/project-detail/PhasesTab.tsx
@@ -332,19 +332,26 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
                       {phaseDeliverables.length > 0 && (
                         <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-gray-100 text-[10px] font-medium text-gray-600">{phaseDeliverables.length}</span>
                       )}
-                      {(Number(phase.totalPaid || 0) > 0 || Number(phase.spent || 0) > 0) && (
-                        <span className="text-xs font-medium text-gray-500">
-                          DH pay/exp: {formatCurrencyUnit(Number(phase.totalPaid || 0))}/{formatCurrencyUnit(Number(phase.spent || 0))}
-                        </span>
-                      )}
                     </div>
                     <div className="flex items-center gap-4">
-                      {(Number(phase.totalPaid || 0) > 0 || (progress.planned > 0)) && (
-                        <div className="flex items-center gap-2 min-w-[140px]">
-                          <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
-                            <div className={`h-full rounded-full ${progress.color}`} style={{ width: `${progress.pct}%` }} />
-                          </div>
-                          <span className="text-xs text-gray-500 whitespace-nowrap">{formatCurrencyUnit(Number(phase.totalPaid || 0))}</span>
+                      {(Number(phase.totalPaid || 0) > 0 || (progress.planned > 0) || Number(phase.spent || 0) > 0) && (
+                        <div className="flex flex-col gap-1 min-w-[180px]">
+                          {(Number(phase.totalPaid || 0) > 0 || progress.planned > 0) && (
+                            <div className="flex items-center gap-2">
+                              <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+                                <div className={`h-full rounded-full ${progress.color}`} style={{ width: `${progress.pct}%` }} />
+                              </div>
+                              <span className="text-[11px] text-gray-500 whitespace-nowrap w-16 text-right">{formatCurrencyUnit(Number(phase.totalPaid || 0))}</span>
+                            </div>
+                          )}
+                          {Number(phase.spent || 0) > 0 && (
+                            <div className="flex items-center gap-2">
+                              <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+                                <div className={`h-full rounded-full ${Number(progress.planned) > 0 ? sProgress.color : 'bg-red-300'}`} style={{ width: `${sProgress.planned > 0 ? sProgress.pct : 100}%` }} />
+                              </div>
+                              <span className="text-[11px] text-gray-500 whitespace-nowrap w-16 text-right">{formatCurrencyUnit(Number(phase.spent))}</span>
+                            </div>
+                          )}
                         </div>
                       )}
                       {(phase.startDate || phase.endDate) && (

--- a/frontend/src/pages/project-detail/PhasesTab.tsx
+++ b/frontend/src/pages/project-detail/PhasesTab.tsx
@@ -273,7 +273,7 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
     if (!phase.plannedAmount || Number(phase.plannedAmount) === 0) return { planned: 0, spent: Number(phase.spent || 0), pct: 0, color: 'bg-gray-300' };
     const planned = Number(phase.plannedAmount);
     const spent = Number(phase.spent || 0);
-    const pct = Math.min(100, Math.round((spent / planned) * 100));
+    const pct = Math.round((spent / planned) * 100);
     const color = pct >= 100 ? 'bg-red-500' : pct >= 80 ? 'bg-amber-500' : 'bg-blue-500';
     return { planned, spent, pct, color };
   };
@@ -347,7 +347,7 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
                           )}
                           {Number(phase.spent || 0) > 0 && (
                             <div className="flex items-center gap-2">
-                              <span className="text-[11px] text-gray-500 w-6">exp</span>
+                              <span className="text-[11px] text-gray-500 w-6">spe</span>
                               <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
                                 <div className={`h-full rounded-full ${Number(progress.planned) > 0 ? sProgress.color : 'bg-red-300'}`} style={{ width: `${sProgress.planned > 0 ? sProgress.pct : 100}%` }} />
                               </div>

--- a/frontend/src/pages/project-detail/PhasesTab.tsx
+++ b/frontend/src/pages/project-detail/PhasesTab.tsx
@@ -332,8 +332,10 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
                       {phaseDeliverables.length > 0 && (
                         <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-gray-100 text-[10px] font-medium text-gray-600">{phaseDeliverables.length}</span>
                       )}
-                      {phase.plannedAmount && Number(phase.plannedAmount) > 0 && (
-                        <span className="text-xs font-medium text-gray-500">{formatCurrency(Number(phase.plannedAmount))}</span>
+                      {(Number(phase.totalPaid || 0) > 0 || Number(phase.spent || 0) > 0) && (
+                        <span className="text-xs font-medium text-gray-500">
+                          pay/exp: {formatCurrency(Number(phase.totalPaid || 0))}/{formatCurrency(Number(phase.spent || 0))}
+                        </span>
                       )}
                     </div>
                     <div className="flex items-center gap-4">

--- a/frontend/src/pages/project-detail/PhasesTab.tsx
+++ b/frontend/src/pages/project-detail/PhasesTab.tsx
@@ -339,12 +339,12 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
                       )}
                     </div>
                     <div className="flex items-center gap-4">
-                      {(sProgress.spent > 0 || sProgress.planned > 0) && (
+                      {(Number(phase.totalPaid || 0) > 0 || (progress.planned > 0)) && (
                         <div className="flex items-center gap-2 min-w-[140px]">
                           <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
-                            <div className={`h-full rounded-full ${sProgress.color}`} style={{ width: `${sProgress.pct}%` }} />
+                            <div className={`h-full rounded-full ${progress.color}`} style={{ width: `${progress.pct}%` }} />
                           </div>
-                          <span className="text-xs text-gray-500 whitespace-nowrap">{formatCurrency(sProgress.spent)}</span>
+                          <span className="text-xs text-gray-500 whitespace-nowrap">{formatCurrency(Number(phase.totalPaid || 0))}</span>
                         </div>
                       )}
                       {(phase.startDate || phase.endDate) && (

--- a/frontend/src/pages/project-detail/PhasesTab.tsx
+++ b/frontend/src/pages/project-detail/PhasesTab.tsx
@@ -338,18 +338,20 @@ export default function PhasesTab({ projectId, canEdit, canManagePayments = fals
                         <div className="flex flex-col gap-1 min-w-[180px]">
                           {(Number(phase.totalPaid || 0) > 0 || progress.planned > 0) && (
                             <div className="flex items-center gap-2">
+                              <span className="text-[11px] text-gray-500 w-6">pay</span>
                               <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
                                 <div className={`h-full rounded-full ${progress.color}`} style={{ width: `${progress.pct}%` }} />
                               </div>
-                              <span className="text-[11px] text-gray-500 whitespace-nowrap w-16 text-right">{formatCurrencyUnit(Number(phase.totalPaid || 0))}</span>
+                              <span className="text-[11px] text-gray-500 whitespace-nowrap w-12 text-right">{formatCurrencyUnit(Number(phase.totalPaid || 0))}</span>
                             </div>
                           )}
                           {Number(phase.spent || 0) > 0 && (
                             <div className="flex items-center gap-2">
+                              <span className="text-[11px] text-gray-500 w-6">exp</span>
                               <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
                                 <div className={`h-full rounded-full ${Number(progress.planned) > 0 ? sProgress.color : 'bg-red-300'}`} style={{ width: `${sProgress.planned > 0 ? sProgress.pct : 100}%` }} />
                               </div>
-                              <span className="text-[11px] text-gray-500 whitespace-nowrap w-16 text-right">{formatCurrencyUnit(Number(phase.spent))}</span>
+                              <span className="text-[11px] text-gray-500 whitespace-nowrap w-12 text-right">{formatCurrencyUnit(Number(phase.spent))}</span>
                             </div>
                           )}
                         </div>

--- a/frontend/src/pages/project-detail/SettingsTab.tsx
+++ b/frontend/src/pages/project-detail/SettingsTab.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { ProjectDto, LabelDto } from '@/types';
+import type { ProjectDto, LabelDto, PhaseDto } from '@/types';
 import { updateProject, getLabels, createLabel, updateLabel, deleteLabel } from '@/api/projects';
+import { listPhases } from '@/api/phases';
 import { extractValidationErrors } from '@/api/client';
+import { formatCurrencyUnit } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
 
 export default function SettingsTab({ project, onUpdate, canEdit }: { project: ProjectDto; onUpdate: (p: ProjectDto) => void; canEdit: boolean }) {
@@ -14,6 +16,16 @@ export default function SettingsTab({ project, onUpdate, canEdit }: { project: P
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  // Phases budget indicator
+  const [phasesPlannedTotal, setPhasesPlannedTotal] = useState(0);
+
+  useEffect(() => {
+    listPhases(project.id).then(p => {
+      const total = p.reduce((sum: number, ph: PhaseDto) => sum + (Number(ph.plannedAmount) || 0), 0);
+      setPhasesPlannedTotal(total);
+    }).catch(() => {});
+  }, [project.id]);
 
   // Labels state
   const [labels, setLabels] = useState<LabelDto[]>([]);
@@ -120,7 +132,14 @@ export default function SettingsTab({ project, onUpdate, canEdit }: { project: P
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Total Budget</label>
-            <input type="text" value={budget} onChange={e => setBudget(e.target.value)} placeholder="e.g. 150000" className={inputClass('budget')} />
+            <div className="flex items-center gap-3">
+              <input type="text" value={budget} onChange={e => setBudget(e.target.value)} placeholder="e.g. 150000" className={`${inputClass('budget')} flex-1`} />
+              {phasesPlannedTotal > 0 && (
+                <span className={`text-xs font-medium whitespace-nowrap shrink-0 ${Number(budget) && phasesPlannedTotal > Number(budget) ? 'text-red-600 font-bold' : 'text-gray-500'}`}>
+                  Phases: {formatCurrencyUnit(phasesPlannedTotal)}
+                </span>
+              )}
+            </div>
             {fieldErrors.budget && <p className="mt-1 text-sm text-red-600">{fieldErrors.budget}</p>}
           </div>
         </div>

--- a/frontend/src/pages/project-detail/SprintsTab.tsx
+++ b/frontend/src/pages/project-detail/SprintsTab.tsx
@@ -22,7 +22,7 @@ export default function SprintsTab({ projectId, canEdit }: SprintsTabProps) {
   const [loading, setLoading] = useState(true);
 
   const fetchData = useCallback(() => {
-    Promise.all([listSprints(projectId), listProjectTasks(projectId)])
+    return Promise.all([listSprints(projectId), listProjectTasks(projectId)])
       .then(([sprintData, taskData]) => {
         setSprints(sprintData);
         setTasks(taskData);

--- a/frontend/src/pages/project-detail/index.tsx
+++ b/frontend/src/pages/project-detail/index.tsx
@@ -149,7 +149,7 @@ export default function ProjectDetailPage() {
       {activeTab === 'board' && <BoardTab projectId={project.id} projectKey={project.key} isExternal={isExternal} />}
       {activeTab === 'docs' && <DocsTab projectId={project.id} canEdit={canEdit || role === 'CONTRIBUTOR'} />}
       {activeTab === 'raid' && <RaidTab projectId={project.id} canEdit={canEdit} />}
-      {activeTab === 'phases' && <PhasesTab projectId={project.id} canEdit={canEdit} />}
+      {activeTab === 'phases' && <PhasesTab projectId={project.id} canEdit={canEdit} canManagePayments={role === 'FINANCE'} />}
       {activeTab === 'expenses' && <ExpensesTab projectId={project.id} canEdit={canEdit} />}
       {activeTab === 'settings' && <SettingsTab project={project} onUpdate={(p) => setProject(p)} canEdit={canEdit} />}
       {activeTab === 'members' && <MembersTab projectId={project.id} managerId={project.managerId} canEdit={canEdit} canSeeScores={canSeeScores} />}

--- a/frontend/src/pages/project-detail/index.tsx
+++ b/frontend/src/pages/project-detail/index.tsx
@@ -65,10 +65,8 @@ export default function ProjectDetailPage() {
     { key: 'docs', label: 'Docs' },
   ] : role === 'FINANCE' ? [
     { key: 'summary', label: 'Summary' },
-    { key: 'board', label: 'Board' },
-    { key: 'sprints', label: 'Sprints' },
+    { key: 'phases', label: 'Phases' },
     { key: 'expenses', label: 'Expenses' },
-    { key: 'docs', label: 'Docs' },
   ] : [ // EXTERNAL or fallback
     { key: 'tasks', label: 'Tasks' },
     { key: 'board', label: 'Board' },

--- a/frontend/src/pages/project-detail/index.tsx
+++ b/frontend/src/pages/project-detail/index.tsx
@@ -63,6 +63,12 @@ export default function ProjectDetailPage() {
     { key: 'planning', label: 'Planning' },
     { key: 'sprints', label: 'Sprints' },
     { key: 'docs', label: 'Docs' },
+  ] : role === 'FINANCE' ? [
+    { key: 'summary', label: 'Summary' },
+    { key: 'board', label: 'Board' },
+    { key: 'sprints', label: 'Sprints' },
+    { key: 'expenses', label: 'Expenses' },
+    { key: 'docs', label: 'Docs' },
   ] : [ // EXTERNAL or fallback
     { key: 'tasks', label: 'Tasks' },
     { key: 'board', label: 'Board' },

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -137,6 +137,11 @@ export function formatCurrency(value: number | null | undefined): string {
   return symbol + ' ' + formatted;
 }
 
+export function formatCurrencyUnit(value: number | null | undefined): string {
+  if (value == null) return '—';
+  return Math.round(value).toLocaleString('en-US').replace(/,/g, "'");
+}
+
 export function scoreLabel(score: number): string {
   switch (score) {
     case 0: return 'Marginal';


### PR DESCRIPTION
## Summary
- Restructured FINANCE role UI: charts on dashboard, detailed tables on dedicated /finance page
- Added backend endpoints for year-scoped expenses and monthly chart data

## Dashboard (charts)
- Monthly bar chart: payments received vs pending
- Monthly bar chart: expenses
- Year navigation

## Finance page (tables)
- Payments panel with Pending/Overdue/Received tabs + year nav + delay
- Expenses panel with All/Pending/Approved/Rejected filter + year nav + inline approve/reject
- Export CSV button

## Backend
- New queries: findByExpenseDateBetween (with/without status filter)
- New service methods: getYearExpenses, getMonthlyChartData
- New endpoints: /finance/expenses-by-year, /finance/chart-data

## Test plan
- [ ] FINANCE dashboard shows monthly charts with correct data
- [ ] /finance page shows payments panel with 3 tabs
- [ ] /finance page shows expenses panel with 4 status filters
- [ ] Approve/Reject actions work on pending expenses
- [ ] Year navigation works on both panels
- [ ] Export CSV downloads correctly
- [ ] FINANCE sidebar shows Dashboard → charts, Finance → tables

Refs #199