### PR TITLE
fix(#204): remove EXECUTIVE from project payments and expenses GET access

### DIFF
--- a/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
+++ b/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
@@ -28,7 +28,7 @@ public class ProjectExpenseController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('MANAGER', 'EXECUTIVE', 'FINANCE')")
+    @PreAuthorize("hasAnyRole('MANAGER', 'FINANCE')")
     public ResponseEntity<ApiResponse<List<ProjectExpenseDto>>> list(
             @PathVariable Long projectId,
             @AuthenticationPrincipal UserDetails currentUser) {

--- a/backend/src/main/java/com/nemo/payment/ProjectPaymentController.java
+++ b/backend/src/main/java/com/nemo/payment/ProjectPaymentController.java
@@ -25,7 +25,7 @@ public class ProjectPaymentController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('MANAGER', 'EXECUTIVE', 'FINANCE')")
+    @PreAuthorize("hasAnyRole('MANAGER', 'FINANCE')")
     public ResponseEntity<ApiResponse<List<ProjectPaymentDto.Response>>> list(
             @PathVariable Long projectId,
             @AuthenticationPrincipal UserDetails currentUser) {


### PR DESCRIPTION
## Summary
- EXECUTIVE was incorrectly added to payment and expense read endpoints in #197
- Removed EXECUTIVE from both `@PreAuthorize` annotations
- Now: MANAGER and FINANCE only

## Test plan
- [ ] `GET /api/projects/1/payments` as `avery` (EXECUTIVE) returns 403
- [ ] `GET /api/projects/1/expenses` as `avery` returns 403
- [ ] `GET /api/projects/1/payments` as `jordan` (MANAGER) returns 200
- [ ] `GET /api/projects/1/expenses` as `alex` (FINANCE) returns 200

Refs #204