### PR TITLE
fix(#205): add FINANCE to program EVM endpoint

### DIFF
--- a/backend/src/main/java/com/nemo/program/ProgramController.java
+++ b/backend/src/main/java/com/nemo/program/ProgramController.java
@@ -75,7 +75,7 @@ public class ProgramController {
     }
 
     @GetMapping("/{id}/evm")
-    @PreAuthorize("hasAnyRole('MANAGER', 'EXECUTIVE')")
+    @PreAuthorize("hasAnyRole('MANAGER', 'EXECUTIVE', 'FINANCE')")
     public ResponseEntity<ApiResponse<PmoService.ProgramEvmMetrics>> getEvm(@PathVariable Long id) {
         return ResponseEntity.ok(ApiResponse.of(pmoService.computeProgramEvm(id)));
     }


### PR DESCRIPTION
## Summary
- FINANCE role got 403 on `GET /api/programs/{id}/evm`
- Added FINANCE to `@PreAuthorize` alongside MANAGER and EXECUTIVE
- Frontend already supports FINANCE — Programs sidebar, route guards, and EVM display on ProgramDetailPage all work without changes

## Test plan
- [ ] `GET /api/programs/1/evm` as `alex` (FINANCE) returns 200 with EVM data
- [ ] `GET /api/programs/1/evm` as `jordan` (MANAGER) still works (no regression)
- [ ] FINANCE user can see EVM metrics on Program detail page

Refs #205