### PR TITLE
fix(#207): auto-approve expenses created by FINANCE role

### DIFF
--- a/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
+++ b/backend/src/main/java/com/nemo/expense/ProjectExpenseController.java
@@ -44,7 +44,8 @@ public class ProjectExpenseController {
             @AuthenticationPrincipal UserDetails currentUser) {
         authHelper.requireProjectReadAccess(currentUser, projectId);
         Long userId = authHelper.getCurrentUserId(currentUser);
-        ProjectExpense created = expenseService.create(projectId, userId, request);
+        boolean isFinance = authHelper.hasAnyRole(currentUser, "FINANCE");
+        ProjectExpense created = expenseService.create(projectId, userId, request, isFinance);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(expenseMapper.toDto(created)));
     }
 

--- a/backend/src/main/java/com/nemo/expense/ProjectExpenseService.java
+++ b/backend/src/main/java/com/nemo/expense/ProjectExpenseService.java
@@ -37,7 +37,7 @@ public class ProjectExpenseService {
     }
 
     @Transactional
-    public ProjectExpense create(Long projectId, Long userId, ProjectExpenseDto.CreateRequest request) {
+    public ProjectExpense create(Long projectId, Long userId, ProjectExpenseDto.CreateRequest request, boolean autoApprove) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new EntityNotFoundException("Project", projectId));
         User user = userRepository.findById(userId)
@@ -50,7 +50,13 @@ public class ProjectExpenseService {
         expense.setDescription(request.description());
         expense.setExpenseDate(java.time.LocalDate.parse(request.expenseDate()));
         expense.setCreatedBy(user);
-        expense.setApprovalStatus(ProjectExpense.ApprovalStatus.PENDING_REVIEW);
+        if (autoApprove) {
+            expense.setApprovalStatus(ProjectExpense.ApprovalStatus.APPROVED);
+            expense.setApprovedBy(user);
+            expense.setApprovedAt(java.time.Instant.now());
+        } else {
+            expense.setApprovalStatus(ProjectExpense.ApprovalStatus.PENDING_REVIEW);
+        }
         return expenseRepository.save(expense);
     }
 


### PR DESCRIPTION
## Summary
- FINANCE-created expenses now auto-approve instead of defaulting to PENDING_REVIEW
- Eliminates redundant step: FINANCE no longer needs to approve their own expense
- MANAGER and CONTRIBUTOR-created expenses still default to PENDING_REVIEW

## Test plan
- [ ] `POST /api/projects/1/expenses` as `alex` (FINANCE) → approvalStatus: APPROVED, approvedById set
- [ ] `POST /api/projects/1/expenses` as `jordan` (MANAGER) → approvalStatus: PENDING_REVIEW (no regression)
- [ ] FINANCE-created expenses don't appear in pending approvals count

Refs #207