### PR TITLE
fix(#217): add GET /api/tasks/my endpoint for cross-project user tasks

### DIFF
--- a/backend/src/main/java/com/nemo/task/MyTasksController.java
+++ b/backend/src/main/java/com/nemo/task/MyTasksController.java
@@ -1,0 +1,35 @@
+package com.nemo.task;
+
+import com.nemo.common.dto.ApiResponse;
+import com.nemo.security.AuthHelper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tasks")
+public class MyTasksController {
+
+    private final TaskService taskService;
+    private final TaskMapper taskMapper;
+    private final AuthHelper authHelper;
+
+    public MyTasksController(TaskService taskService, TaskMapper taskMapper, AuthHelper authHelper) {
+        this.taskService = taskService;
+        this.taskMapper = taskMapper;
+        this.authHelper = authHelper;
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<List<TaskDto>>> getMyTasks(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long userId = authHelper.getCurrentUserId(currentUser);
+        List<Task> tasks = taskService.getMyTasks(userId);
+        return ResponseEntity.ok(ApiResponse.of(taskMapper.toDtoList(tasks)));
+    }
+}

--- a/backend/src/main/java/com/nemo/task/TaskRepository.java
+++ b/backend/src/main/java/com/nemo/task/TaskRepository.java
@@ -34,6 +34,18 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
            "LEFT JOIN FETCH t.sprint " +
            "LEFT JOIN FETCH t.phase " +
            "LEFT JOIN FETCH t.labels " +
+           "WHERE t.assignee.id = :userId")
+    List<Task> findByAssigneeId(@Param("userId") Long userId);
+
+    @Query("SELECT t FROM Task t " +
+           "LEFT JOIN FETCH t.status " +
+           "LEFT JOIN FETCH t.type " +
+           "LEFT JOIN FETCH t.project " +
+           "LEFT JOIN FETCH t.assignee " +
+           "LEFT JOIN FETCH t.reporter " +
+           "LEFT JOIN FETCH t.sprint " +
+           "LEFT JOIN FETCH t.phase " +
+           "LEFT JOIN FETCH t.labels " +
            "WHERE t.project.id = :projectId AND " +
            "(:search IS NULL OR LOWER(t.title) LIKE LOWER(CONCAT('%', :search, '%'))) AND " +
            "(:statusId IS NULL OR t.status.id = :statusId) AND " +

--- a/backend/src/main/java/com/nemo/task/TaskService.java
+++ b/backend/src/main/java/com/nemo/task/TaskService.java
@@ -67,6 +67,11 @@ public class TaskService {
     }
 
     @Transactional(readOnly = true)
+    public List<Task> getMyTasks(Long userId) {
+        return taskRepository.findByAssigneeId(userId);
+    }
+
+    @Transactional(readOnly = true)
     public Task getById(Long id) {
         return taskRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Task", id));

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -1,6 +1,10 @@
 import { apiGet, apiPost, apiPut, apiDelete, apiGetPaginated } from './client';
 import type { TaskDto, CreateTaskRequest, UpdateTaskRequest, CommentDto, CreateCommentRequest, UpdateCommentRequest } from '@/types';
 
+export async function getMyTasks(): Promise<TaskDto[]> {
+  return apiGet<TaskDto[]>('/tasks/my');
+}
+
 export async function listProjectTasks(
   projectId: number,
   params?: Record<string, string | number>,

--- a/frontend/src/hooks/useMyTasks.ts
+++ b/frontend/src/hooks/useMyTasks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { ProjectDto, TaskDto } from '@/types';
 import { listProjects } from '@/api/projects';
-import { listProjectTasks } from '@/api/tasks';
+import { getMyTasks } from '@/api/tasks';
 import { useAuthStore } from '@/stores/authStore';
 
 export function useMyTasks() {
@@ -18,17 +18,11 @@ export function useMyTasks() {
     async function fetch() {
       try {
         setIsLoading(true);
-        const projs = await listProjects();
+        const [projs, allTasks] = await Promise.all([
+          listProjects(),
+          getMyTasks(),
+        ]);
         if (cancelled) return;
-
-        const allTasks: TaskDto[] = [];
-        await Promise.all(
-          projs.map(async (p) => {
-            const tasks = await listProjectTasks(p.id, { assigneeId: user!.id });
-            allTasks.push(...tasks);
-          }),
-        );
-
         if (!cancelled) {
           setProjects(projs);
           setMyTasks(allTasks);


### PR DESCRIPTION
## Summary
- CONTRIBUTOR users couldn't see all their assigned tasks in the My Time page dropdown
- Root cause: the hook iterated over company-scoped projects, missing cross-company task assignments
- Fixed with dedicated backend endpoint that queries tasks by assigneeId directly (no company scope)

## Changes
- New `GET /api/tasks/my` endpoint returning all tasks assigned to current user
- New `MyTasksController`, repository query, and service method
- Simplified `useMyTasks` hook to call the new endpoint

## Test plan
- [ ] `GET /api/tasks/my` as `taylor` (CONTRIBUTOR) returns all assigned tasks across all projects
- [ ] My Time page task dropdown shows all open tasks assigned to the user (not just company-scoped)
- [ ] No regression for other roles (EXTERNAL, MANAGER) on My Time page

Refs #217