### PR TITLE
fix(#218): add CONTRIBUTOR to timesheet endpoint authorization

### DIFF
--- a/backend/src/main/java/com/nemo/timetracking/TimesheetController.java
+++ b/backend/src/main/java/com/nemo/timetracking/TimesheetController.java
@@ -24,7 +24,7 @@ public class TimesheetController {
     }
 
     @GetMapping("/weekly")
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'CONTRIBUTOR')")
     public ResponseEntity<ApiResponse<Object>> weekly(
             @RequestParam Long userId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStart) {
@@ -44,7 +44,7 @@ public class TimesheetController {
     }
 
     @GetMapping("/daily")
-    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'CONTRIBUTOR')")
     public ResponseEntity<ApiResponse<Object>> daily(
             @RequestParam Long userId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {


### PR DESCRIPTION
## Summary
- CONTRIBUTOR users saw 0.0h on My Time page despite dashboard showing logged hours
- Root cause: timesheet endpoints returned 403 for CONTRIBUTOR (not in @PreAuthorize)
- Added CONTRIBUTOR to both weekly and daily endpoints

## Test plan
- [ ] Log in as `taylor` (CONTRIBUTOR) → My Time page shows logged hours matching dashboard
- [ ] Log in as `jordan` (MANAGER) → My Time page still works (no regression)
- [ ] `GET /api/timesheets/weekly` as CONTRIBUTOR returns 200

Refs #218