### PR TITLE
fix(#206): payment currency defaults from global config when company config missing

### DIFF
--- a/backend/src/main/java/com/nemo/payment/ProjectPaymentService.java
+++ b/backend/src/main/java/com/nemo/payment/ProjectPaymentService.java
@@ -51,11 +51,10 @@ public class ProjectPaymentService {
         payment.setAmount(request.amount());
         if (request.currency() != null) {
             payment.setCurrency(request.currency());
-        } else if (project.getCompany() != null) {
-            String projectCurrency = configRepository.findByCompanyId(project.getCompany().getId())
-                    .map(OrganizationConfig::getCurrency).orElse(null);
-            if (projectCurrency != null) {
-                payment.setCurrency(projectCurrency);
+        } else {
+            String resolvedCurrency = resolveCurrency(project);
+            if (resolvedCurrency != null) {
+                payment.setCurrency(resolvedCurrency);
             }
         }
         payment.setDueDate(request.dueDate() != null ? LocalDate.parse(request.dueDate()) : null);
@@ -96,6 +95,20 @@ public class ProjectPaymentService {
     public BigDecimal sumReceivedByProjectId(Long projectId) {
         BigDecimal sum = paymentRepository.sumAmountByProjectIdAndStatus(projectId, ProjectPayment.PaymentStatus.RECEIVED);
         return sum != null ? sum : BigDecimal.ZERO;
+    }
+
+    private String resolveCurrency(Project project) {
+        // 1. Try company-specific config
+        if (project.getCompany() != null) {
+            String currency = configRepository.findByCompanyId(project.getCompany().getId())
+                    .map(OrganizationConfig::getCurrency).orElse(null);
+            if (currency != null) {
+                return currency;
+            }
+        }
+        // 2. Fall back to global config
+        return configRepository.findByCompanyIdIsNull()
+                .map(OrganizationConfig::getCurrency).orElse(null);
     }
 
     private void computeOverdue(ProjectPayment payment) {


### PR DESCRIPTION
## Summary
- Fix `ProjectPaymentService.create()` to resolve currency through the full config hierarchy: company-specific config → global config → null
- Previous fix only queried `findByCompanyId()`, which returns empty when no company-specific `OrganizationConfig` exists — the common case since seed data only has a global config

## Test plan
- [x] Seed data payments show correct currency (already working)
- [ ] `POST /api/projects/1/payments` without explicit currency returns the project's configured currency (e.g. "USD") instead of null
- [ ] Verify the resolution hierarchy: company config takes priority, global config is the fallback

Refs #206