### PR TITLE
fix(#219): rename Pending payments 'Delay' column to 'Due in'

### DIFF
--- a/frontend/src/pages/FinancePage.tsx
+++ b/frontend/src/pages/FinancePage.tsx
@@ -111,7 +111,7 @@ export default function FinancePage() {
         ) : payments && paymentView === 'pending' && payments.pending.length > 0 ? (
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">{['Project','Title','Amount','Due Date','Delay'].map(h => <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">{h}</th>)}</thead>
+              <thead className="bg-gray-50">{['Project','Title','Amount','Due Date','Due in'].map(h => <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">{h}</th>)}</thead>
               <tbody className="divide-y divide-gray-100">
                 {payments.pending.map(p => {
                   const delay = p.dueDate ? Math.ceil((new Date(p.dueDate).getTime() - Date.now()) / 86400000) : null;


### PR DESCRIPTION
## Summary
- Rename the Pending payments table column header from "Delay" to "Due in"
- The existing calculation (days-until-due) is useful information — the label was misleading, not the values

## Test plan
- [ ] Navigate to Finance page → Pending tab
- [ ] Column header shows "Due in" instead of "Delay"
- [ ] Values still display correctly: "7d" (due in 7 days), "3d late" (overdue), "Due" (due today)

Refs #219