### PR TITLE
feat(#222): bank accounts CRUD with company scoping

### DIFF
--- a/backend/src/main/java/com/nemo/bankaccount/BankAccount.java
+++ b/backend/src/main/java/com/nemo/bankaccount/BankAccount.java
@@ -1,0 +1,72 @@
+package com.nemo.bankaccount;
+
+import com.nemo.company.Company;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Entity
+@Table(name = "bank_account")
+public class BankAccount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "iban", nullable = false, length = 34)
+    private String iban;
+
+    @Column(nullable = false, length = 3)
+    private String currency;
+
+    @Column(name = "current_balance", precision = 15, scale = 2)
+    private BigDecimal currentBalance = BigDecimal.ZERO;
+
+    @Column(nullable = false)
+    private boolean active = true;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    public BankAccount() {}
+
+    public BankAccount(Company company, String name, String iban, String currency, BigDecimal currentBalance) {
+        this.company = company;
+        this.name = name;
+        this.iban = iban;
+        this.currency = currency;
+        this.currentBalance = currentBalance;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Company getCompany() { return company; }
+    public void setCompany(Company company) { this.company = company; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getIban() { return iban; }
+    public void setIban(String iban) { this.iban = iban; }
+    public String getCurrency() { return currency; }
+    public void setCurrency(String currency) { this.currency = currency; }
+    public BigDecimal getCurrentBalance() { return currentBalance; }
+    public void setCurrentBalance(BigDecimal currentBalance) { this.currentBalance = currentBalance; }
+    public boolean isActive() { return active; }
+    public void setActive(boolean active) { this.active = active; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getUpdatedAt() { return updatedAt; }
+}

--- a/backend/src/main/java/com/nemo/bankaccount/BankAccountController.java
+++ b/backend/src/main/java/com/nemo/bankaccount/BankAccountController.java
@@ -1,0 +1,102 @@
+package com.nemo.bankaccount;
+
+import com.nemo.common.dto.ApiResponse;
+import com.nemo.common.dto.PaginatedResponse;
+import com.nemo.common.dto.PaginatedResponse.PaginationInfo;
+import com.nemo.config.OrganizationConfig;
+import com.nemo.config.OrganizationConfigRepository;
+import com.nemo.security.AuthHelper;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/bank-accounts")
+public class BankAccountController {
+
+    private final BankAccountService bankAccountService;
+    private final BankAccountMapper bankAccountMapper;
+    private final AuthHelper authHelper;
+    private final OrganizationConfigRepository configRepository;
+
+    public BankAccountController(BankAccountService bankAccountService,
+                                  BankAccountMapper bankAccountMapper,
+                                  AuthHelper authHelper,
+                                  OrganizationConfigRepository configRepository) {
+        this.bankAccountService = bankAccountService;
+        this.bankAccountMapper = bankAccountMapper;
+        this.authHelper = authHelper;
+        this.configRepository = configRepository;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('FINANCE', 'EXECUTIVE')")
+    public ResponseEntity<PaginatedResponse<BankAccountDto>> list(
+            @RequestParam(required = false) String search,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "name,asc") String sort,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.getCurrentCompanyId(currentUser);
+        Page<BankAccount> result = bankAccountService.search(search, companyId, page, size, sort);
+        List<BankAccountDto> dtos = bankAccountMapper.toDtoList(result.getContent());
+        return ResponseEntity.ok(PaginatedResponse.of(dtos,
+                new PaginationInfo(page, size, result.getTotalElements(), result.getTotalPages())));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('FINANCE', 'EXECUTIVE')")
+    public ResponseEntity<ApiResponse<BankAccountDto>> get(@PathVariable Long id) {
+        BankAccount account = bankAccountService.getById(id);
+        return ResponseEntity.ok(ApiResponse.of(bankAccountMapper.toDto(account)));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<BankAccountDto>> create(
+            @Valid @RequestBody BankAccountDto.CreateRequest request,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.getCurrentCompanyId(currentUser);
+        BankAccountDto.CreateRequest resolvedRequest = request;
+        if (request.currency() == null || request.currency().isBlank()) {
+            String defaultCurrency = resolveCurrency(companyId);
+            resolvedRequest = new BankAccountDto.CreateRequest(
+                    request.name(), request.iban(), defaultCurrency, request.openingBalance());
+        }
+        BankAccount created = bankAccountService.create(resolvedRequest, companyId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(bankAccountMapper.toDto(created)));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<BankAccountDto>> update(
+            @PathVariable Long id,
+            @RequestBody BankAccountDto.UpdateRequest request) {
+        BankAccount updated = bankAccountService.update(id, request);
+        return ResponseEntity.ok(ApiResponse.of(bankAccountMapper.toDto(updated)));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<Void> deactivate(@PathVariable Long id) {
+        bankAccountService.deactivate(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    private String resolveCurrency(Long companyId) {
+        if (companyId != null) {
+            String currency = configRepository.findByCompanyId(companyId)
+                    .map(OrganizationConfig::getCurrency).orElse(null);
+            if (currency != null) return currency;
+        }
+        return configRepository.findByCompanyIdIsNull()
+                .map(OrganizationConfig::getCurrency).orElse("USD");
+    }
+}

--- a/backend/src/main/java/com/nemo/bankaccount/BankAccountDto.java
+++ b/backend/src/main/java/com/nemo/bankaccount/BankAccountDto.java
@@ -1,0 +1,33 @@
+package com.nemo.bankaccount;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+
+public record BankAccountDto(
+        Long id,
+        Long companyId,
+        String companyName,
+        String name,
+        String iban,
+        String currency,
+        BigDecimal currentBalance,
+        boolean active,
+        String createdAt,
+        String updatedAt
+) {
+    public record CreateRequest(
+            @NotBlank String name,
+            @NotBlank @Size(min = 5, max = 34) String iban,
+            @NotBlank @Size(min = 3, max = 3) String currency,
+            @NotNull BigDecimal openingBalance
+    ) {}
+
+    public record UpdateRequest(
+            String name,
+            String iban,
+            String currency
+    ) {}
+}

--- a/backend/src/main/java/com/nemo/bankaccount/BankAccountMapper.java
+++ b/backend/src/main/java/com/nemo/bankaccount/BankAccountMapper.java
@@ -1,0 +1,18 @@
+package com.nemo.bankaccount;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface BankAccountMapper {
+
+    @Mapping(target = "companyId", source = "company.id")
+    @Mapping(target = "companyName", source = "company.name")
+    @Mapping(target = "createdAt", source = "createdAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    @Mapping(target = "updatedAt", source = "updatedAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    BankAccountDto toDto(BankAccount bankAccount);
+
+    List<BankAccountDto> toDtoList(List<BankAccount> bankAccounts);
+}

--- a/backend/src/main/java/com/nemo/bankaccount/BankAccountRepository.java
+++ b/backend/src/main/java/com/nemo/bankaccount/BankAccountRepository.java
@@ -1,0 +1,20 @@
+package com.nemo.bankaccount;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface BankAccountRepository extends JpaRepository<BankAccount, Long> {
+
+    List<BankAccount> findByCompanyIdAndActiveTrue(Long companyId);
+
+    @Query("SELECT b FROM BankAccount b WHERE b.active = true AND " +
+            "(:companyId IS NULL OR b.company.id = :companyId) AND " +
+            "(:search IS NULL OR LOWER(b.name) LIKE LOWER(CONCAT('%', :search, '%')) " +
+            "OR LOWER(b.iban) LIKE LOWER(CONCAT('%', :search, '%')))")
+    Page<BankAccount> search(@Param("search") String search, @Param("companyId") Long companyId, Pageable pageable);
+}

--- a/backend/src/main/java/com/nemo/bankaccount/BankAccountService.java
+++ b/backend/src/main/java/com/nemo/bankaccount/BankAccountService.java
@@ -1,0 +1,73 @@
+package com.nemo.bankaccount;
+
+import com.nemo.common.exception.EntityNotFoundException;
+import com.nemo.company.Company;
+import com.nemo.company.CompanyRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Service
+public class BankAccountService {
+
+    private final BankAccountRepository bankAccountRepository;
+    private final CompanyRepository companyRepository;
+
+    public BankAccountService(BankAccountRepository bankAccountRepository,
+                               CompanyRepository companyRepository) {
+        this.bankAccountRepository = bankAccountRepository;
+        this.companyRepository = companyRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<BankAccount> search(String search, Long companyId, int page, int size, String sort) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sort));
+        return bankAccountRepository.search(search, companyId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public List<BankAccount> listByCompany(Long companyId) {
+        return bankAccountRepository.findByCompanyIdAndActiveTrue(companyId);
+    }
+
+    @Transactional(readOnly = true)
+    public BankAccount getById(Long id) {
+        return bankAccountRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("BankAccount", id));
+    }
+
+    @Transactional
+    public BankAccount create(BankAccountDto.CreateRequest request, Long companyId) {
+        Company company = companyRepository.findById(companyId)
+                .orElseThrow(() -> new EntityNotFoundException("Company", companyId));
+        BankAccount account = new BankAccount();
+        account.setCompany(company);
+        account.setName(request.name());
+        account.setIban(request.iban());
+        account.setCurrency(request.currency());
+        account.setCurrentBalance(request.openingBalance() != null ? request.openingBalance() : BigDecimal.ZERO);
+        return bankAccountRepository.save(account);
+    }
+
+    @Transactional
+    public BankAccount update(Long id, BankAccountDto.UpdateRequest request) {
+        BankAccount account = getById(id);
+        if (request.name() != null) account.setName(request.name());
+        if (request.iban() != null) account.setIban(request.iban());
+        if (request.currency() != null) account.setCurrency(request.currency());
+        return bankAccountRepository.save(account);
+    }
+
+    @Transactional
+    public void deactivate(Long id) {
+        BankAccount account = getById(id);
+        account.setActive(false);
+        bankAccountRepository.save(account);
+    }
+}

--- a/backend/src/main/java/com/nemo/config/DataSeeder.java
+++ b/backend/src/main/java/com/nemo/config/DataSeeder.java
@@ -8,6 +8,8 @@ import com.nemo.company.Company;
 import com.nemo.company.CompanyRepository;
 import com.nemo.asset.Asset;
 import com.nemo.asset.AssetRepository;
+import com.nemo.bankaccount.BankAccount;
+import com.nemo.bankaccount.BankAccountRepository;
 import com.nemo.documentation.WikiPage;
 import com.nemo.documentation.WikiPageRepository;
 import com.nemo.task.Task;
@@ -118,6 +120,7 @@ public class DataSeeder implements CommandLineRunner {
     private final ProjectExpenseRepository projectExpenseRepository;
     private final PreSaleRepository preSaleRepository;
     private final ProjectPaymentRepository projectPaymentRepository;
+    private final BankAccountRepository bankAccountRepository;
 
     public DataSeeder(UserRepository userRepository,
                       PasswordEncoder passwordEncoder,
@@ -148,7 +151,8 @@ public class DataSeeder implements CommandLineRunner {
                       LeaveRequestRepository leaveRequestRepository,
                       ProjectExpenseRepository projectExpenseRepository,
                       PreSaleRepository preSaleRepository,
-                      ProjectPaymentRepository projectPaymentRepository) {
+                      ProjectPaymentRepository projectPaymentRepository,
+                      BankAccountRepository bankAccountRepository) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.companyRepository = companyRepository;
@@ -179,6 +183,7 @@ public class DataSeeder implements CommandLineRunner {
         this.projectExpenseRepository = projectExpenseRepository;
         this.preSaleRepository = preSaleRepository;
         this.projectPaymentRepository = projectPaymentRepository;
+        this.bankAccountRepository = bankAccountRepository;
     }
 
     // --- Seeding profile records ---
@@ -1007,6 +1012,15 @@ public class DataSeeder implements CommandLineRunner {
         createExpense(footballTeam, ExpenseCategory.TRAVEL, new BigDecimal("10000"), "Away match logistics", today.minusMonths(2), youssef);
         createExpense(footballTeam, ExpenseCategory.INFRASTRUCTURE, new BigDecimal("15000"), "Server hosting and CDN", today.minusMonths(1), youssef);
         createExpense(footballTeam, ExpenseCategory.EXPERTISE, new BigDecimal("25000"), "Sports analytics consultancy", today.minusMonths(6), youssef);
+
+        // Bank accounts
+        if (bankAccountRepository.count() == 0) {
+            bankAccountRepository.save(new BankAccount(company1, "Main Operating Account", "MA12345678901234567890123456", "MAD", new BigDecimal("500000")));
+            bankAccountRepository.save(new BankAccount(company1, "Savings Account", "MA98765432109876543210987654", "MAD", new BigDecimal("2000000")));
+            bankAccountRepository.save(new BankAccount(company2, "EUR Operating Account", "FR1420041010050500013M02606", "EUR", new BigDecimal("150000")));
+            bankAccountRepository.save(new BankAccount(company3, "Corporate Account", "NL91ABNA0417164300", "EUR", new BigDecimal("320000")));
+            bankAccountRepository.save(new BankAccount(company4, "Primary Account", "DE89370400440532013000", "EUR", new BigDecimal("80000")));
+        }
 
         // Project payments
         createPayment(fse, "Project Kickoff Invoice", new BigDecimal("100000"), today.minusMonths(17), today.minusMonths(15), ProjectPayment.PaymentStatus.RECEIVED, alex);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import PreSalesPage from '@/pages/PreSalesPage';
 import PreSaleDetailPage from '@/pages/PreSaleDetailPage';
 import UserDetailPage from '@/pages/UserDetailPage';
 import FinancePage from '@/pages/FinancePage';
+import BankAccountsPage from '@/pages/BankAccountsPage';
 
 export default function App() {
   const checkSession = useAuthStore((s) => s.checkSession);
@@ -89,6 +90,7 @@ export default function App() {
           <Route path="/presales/:id" element={<RoleGuard roles={['ADMIN', 'MANAGER', 'EXECUTIVE', 'HR', 'FINANCE']}><PreSaleDetailPage /></RoleGuard>} />
           <Route path="/admin" element={<AdminGuard><AdminPage /></AdminGuard>} />
           <Route path="/finance" element={<RoleGuard roles={['FINANCE']}><FinancePage /></RoleGuard>} />
+          <Route path="/finance/bank-accounts" element={<RoleGuard roles={['FINANCE', 'EXECUTIVE']}><BankAccountsPage /></RoleGuard>} />
           <Route path="/profile" element={<ProfilePage />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/api/bankAccounts.ts
+++ b/frontend/src/api/bankAccounts.ts
@@ -1,0 +1,22 @@
+import { apiGet, apiGetPaginated, apiPost, apiPut, apiDelete } from './client';
+import type { PaginatedResponse, BankAccountDto, CreateBankAccountRequest, UpdateBankAccountRequest } from '@/types';
+
+export async function listBankAccounts(params?: Record<string, string | number>): Promise<PaginatedResponse<BankAccountDto>> {
+  return apiGetPaginated<BankAccountDto>('/bank-accounts', params);
+}
+
+export async function getBankAccount(id: number): Promise<BankAccountDto> {
+  return apiGet<BankAccountDto>(`/bank-accounts/${id}`);
+}
+
+export async function createBankAccount(request: CreateBankAccountRequest): Promise<BankAccountDto> {
+  return apiPost<BankAccountDto>('/bank-accounts', request);
+}
+
+export async function updateBankAccount(id: number, request: UpdateBankAccountRequest): Promise<BankAccountDto> {
+  return apiPut<BankAccountDto>(`/bank-accounts/${id}`, request);
+}
+
+export async function deactivateBankAccount(id: number): Promise<void> {
+  await apiDelete(`/bank-accounts/${id}`);
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -83,6 +83,9 @@ export default function Sidebar() {
         ...(role === 'FINANCE'
           ? [{ to: '/finance', label: 'Finance', icon: FinanceIcon }]
           : []),
+        ...(role === 'FINANCE' || role === 'EXECUTIVE'
+          ? [{ to: '/finance/bank-accounts', label: 'Bank Accounts', icon: BankAccountsIcon }]
+          : []),
       ],
     }] : []),
   ].filter((s) => s.items.length > 0);
@@ -284,6 +287,14 @@ function FinanceIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.103-.879-1.103-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  );
+}
+
+function BankAccountsIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 6h18M3 6v12a2.25 2.25 0 002.25 2.25h13.5A2.25 2.25 0 0021 18V6M3 6l9-3 9 3M9 12h.01M15 12h.01M9 16h.01M15 16h.01" />
     </svg>
   );
 }

--- a/frontend/src/pages/BankAccountsPage.tsx
+++ b/frontend/src/pages/BankAccountsPage.tsx
@@ -1,0 +1,192 @@
+import { useState, useEffect } from 'react';
+import type { BankAccountDto } from '@/types';
+import { listBankAccounts, createBankAccount, updateBankAccount, deactivateBankAccount } from '@/api/bankAccounts';
+import { useAuth } from '@/hooks/useAuth';
+import { formatCurrency, formatDate } from '@/utils/format';
+import Spinner from '@/components/common/Spinner';
+import Modal from '@/components/common/Modal';
+
+const CURRENCIES = ['MAD', 'EUR', 'USD', 'GBP', 'SAR', 'AED'];
+
+export default function BankAccountsPage() {
+  const { user } = useAuth();
+  const canEdit = user?.role === 'FINANCE';
+
+  const [accounts, setAccounts] = useState<BankAccountDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+
+  const [showModal, setShowModal] = useState(false);
+  const [editingAccount, setEditingAccount] = useState<BankAccountDto | null>(null);
+  const [name, setName] = useState('');
+  const [iban, setIban] = useState('');
+  const [currency, setCurrency] = useState('MAD');
+  const [openingBalance, setOpeningBalance] = useState('0');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAccounts = async () => {
+    setLoading(true);
+    try {
+      const res = await listBankAccounts({ search: search || undefined, page, size: 20 });
+      setAccounts(res.data);
+      setTotalPages(res.pagination.totalPages);
+    } catch { /* ignore */ }
+    finally { setLoading(false); }
+  };
+
+  useEffect(() => { fetchAccounts(); }, [page]);
+
+  const handleSearch = () => { setPage(0); fetchAccounts(); };
+
+  const openCreate = () => {
+    setEditingAccount(null);
+    setName(''); setIban(''); setCurrency('MAD'); setOpeningBalance('0');
+    setShowModal(true);
+  };
+
+  const openEdit = (a: BankAccountDto) => {
+    setEditingAccount(a);
+    setName(a.name); setIban(a.iban); setCurrency(a.currency);
+    setShowModal(true);
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !iban.trim()) return;
+    setSaving(true); setError(null);
+    try {
+      if (editingAccount) {
+        const updated = await updateBankAccount(editingAccount.id, {
+          name: name.trim(),
+          iban: iban.trim(),
+          currency,
+        });
+        setAccounts(prev => prev.map(a => a.id === updated.id ? updated : a));
+      } else {
+        const created = await createBankAccount({
+          name: name.trim(),
+          iban: iban.trim(),
+          currency,
+          openingBalance: Number(openingBalance) || 0,
+        });
+        setAccounts(prev => [created, ...prev]);
+      }
+      setShowModal(false);
+    } catch { setError('Failed to save bank account.'); }
+    finally { setSaving(false); }
+  };
+
+  const handleDeactivate = async (a: BankAccountDto) => {
+    if (!confirm(`Deactivate "${a.name}"?`)) return;
+    await deactivateBankAccount(a.id);
+    setAccounts(prev => prev.filter(x => x.id !== a.id));
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-gray-900">Bank Accounts</h2>
+        {canEdit && (
+          <button onClick={openCreate} className="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700">New Account</button>
+        )}
+      </div>
+
+      <div className="flex gap-3">
+        <input value={search} onChange={e => setSearch(e.target.value)} onKeyDown={e => e.key === 'Enter' && handleSearch()} placeholder="Search bank accounts..." className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+        <button onClick={handleSearch} className="bg-gray-100 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-200">Search</button>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center h-64"><Spinner className="h-8 w-8 text-primary-600" /></div>
+      ) : accounts.length === 0 ? (
+        <div className="bg-white rounded-xl border border-gray-200 p-8 text-center text-gray-500">No bank accounts found.</div>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead><tr className="border-b border-gray-200 bg-gray-50">
+              <th className="text-left px-4 py-3 font-medium text-gray-500">Name</th>
+              <th className="text-left px-4 py-3 font-medium text-gray-500">IBAN</th>
+              <th className="text-left px-4 py-3 font-medium text-gray-500">Currency</th>
+              <th className="text-right px-4 py-3 font-medium text-gray-500">Balance</th>
+              <th className="text-left px-4 py-3 font-medium text-gray-500">Company</th>
+              <th className="text-left px-4 py-3 font-medium text-gray-500">Created</th>
+              <th className="px-4 py-3"></th>
+            </tr></thead>
+            <tbody className="divide-y divide-gray-100">
+              {accounts.map(a => (
+                <tr key={a.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 font-medium text-gray-900">{a.name}</td>
+                  <td className="px-4 py-3 text-gray-600 font-mono text-xs">{a.iban}</td>
+                  <td className="px-4 py-3"><span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">{a.currency}</span></td>
+                  <td className="px-4 py-3 text-right font-medium">{formatCurrency(a.currentBalance)}</td>
+                  <td className="px-4 py-3">{a.companyName ? <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">{a.companyName}</span> : '—'}</td>
+                  <td className="px-4 py-3 text-gray-500">{formatDate(a.createdAt)}</td>
+                  <td className="px-4 py-3 text-right">
+                    {canEdit && (
+                      <div className="flex items-center gap-2 justify-end">
+                        <button onClick={() => openEdit(a)} className="text-primary-600 hover:text-primary-800 text-sm font-medium">Edit</button>
+                        <button onClick={() => handleDeactivate(a)} className="text-red-600 hover:text-red-800 text-sm font-medium">Deactivate</button>
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <button onClick={() => setPage(p => Math.max(0, p - 1))} disabled={page === 0} className="px-3 py-1 rounded border text-sm disabled:opacity-50">Previous</button>
+          <span className="text-sm text-gray-500">Page {page + 1} of {totalPages}</span>
+          <button onClick={() => setPage(p => p + 1)} disabled={page >= totalPages - 1} className="px-3 py-1 rounded border text-sm disabled:opacity-50">Next</button>
+        </div>
+      )}
+
+      {showModal && (
+        <Modal title={editingAccount ? 'Edit Bank Account' : 'New Bank Account'} onClose={() => setShowModal(false)}>
+          <form onSubmit={handleSave} className="space-y-4">
+            {error && <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-3 py-2">{error}</div>}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Name *</label>
+              <input value={name} onChange={e => setName(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" required />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">IBAN *</label>
+              <input value={iban} onChange={e => setIban(e.target.value)} placeholder="e.g. MA12345678901234567890123456" className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 font-mono" required />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Currency *</label>
+              <select value={currency} onChange={e => setCurrency(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
+                {CURRENCIES.map(c => <option key={c} value={c}>{c}</option>)}
+              </select>
+            </div>
+            {!editingAccount && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Opening Balance</label>
+                <input type="number" step="0.01" value={openingBalance} onChange={e => setOpeningBalance(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+              </div>
+            )}
+            {editingAccount && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Balance</label>
+                <div className="px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-500 bg-gray-50">{formatCurrency(editingAccount.currentBalance)} {editingAccount.currency}</div>
+                <p className="text-xs text-gray-400 mt-1">Balance is read-only and updated via statement imports.</p>
+              </div>
+            )}
+            <div className="flex justify-end gap-3 pt-2">
+              <button type="button" onClick={() => setShowModal(false)} className="px-4 py-2 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-100">Cancel</button>
+              <button type="submit" disabled={saving || !name.trim() || !iban.trim()} className="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50 flex items-center gap-2">
+                {saving && <Spinner className="h-4 w-4" />}{editingAccount ? 'Update' : 'Create'}
+              </button>
+            </div>
+          </form>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types/bankAccount.ts
+++ b/frontend/src/types/bankAccount.ts
@@ -1,0 +1,25 @@
+export interface BankAccountDto {
+  id: number;
+  companyId: number;
+  companyName: string | null;
+  name: string;
+  iban: string;
+  currency: string;
+  currentBalance: number;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateBankAccountRequest {
+  name: string;
+  iban: string;
+  currency: string;
+  openingBalance: number;
+}
+
+export interface UpdateBankAccountRequest {
+  name?: string;
+  iban?: string;
+  currency?: string;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -17,3 +17,4 @@ export type { LocationDto, AssetDto, AssetType, AssetStatus, CreateLocationReque
 export type { ClientDto, ClientContactDto, CreateClientRequest, UpdateClientRequest, CreateClientContactRequest, UpdateClientContactRequest } from './client';
 export type { PreSaleDto, PreSaleStage, CreatePreSaleRequest, UpdatePreSaleRequest, ConvertPreSaleRequest, CostSummaryDto, UserCostEntry } from './presale';
 export type { ProjectExpenseDto, CreateProjectExpenseRequest, UpdateProjectExpenseRequest } from './expense';
+export type { BankAccountDto, CreateBankAccountRequest, UpdateBankAccountRequest } from './bankAccount';


### PR DESCRIPTION
## Summary
- Add BankAccount entity with full CRUD (create, list, get, update, deactivate)
- FINANCE role: full access (create, edit, deactivate) | EXECUTIVE: read-only | ADMIN: no access
- Company-scoped: users see only their company's bank accounts, global users see all
- Currency defaults from OrganizationConfig hierarchy (company config → global config → USD)
- Soft delete via deactivate (active=false), list only shows active accounts
- Frontend: BankAccountsPage with search, pagination, create/edit modal, currency dropdown
- 5 seed bank accounts across 4 companies

## Test plan
- [ ] Login as FINANCE user → sidebar shows "Bank Accounts", navigate to /finance/bank-accounts
- [ ] Create bank account → modal opens, fill name/IBAN/currency/opening balance
- [ ] Edit bank account → name/IBAN/currency editable, balance is read-only
- [ ] Deactivate bank account → confirmation dialog, account disappears from list
- [ ] Login as EXECUTIVE → can view bank accounts, no create/edit/deactivate buttons
- [ ] Login as ADMIN → no "Bank Accounts" in sidebar, /finance/bank-accounts returns 403
- [ ] Search and pagination work correctly

Refs #222