### PR TITLE
feat(#223,#224): bank transactions CRUD + reconciliation with project payments

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 
+    // Apache PDFBox for PDF text extraction
+    implementation 'org.apache.pdfbox:pdfbox:3.0.4'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/backend/src/main/java/com/nemo/bankaccount/BankAccountController.java
+++ b/backend/src/main/java/com/nemo/bankaccount/BankAccountController.java
@@ -63,12 +63,15 @@ public class BankAccountController {
     public ResponseEntity<ApiResponse<BankAccountDto>> create(
             @Valid @RequestBody BankAccountDto.CreateRequest request,
             @AuthenticationPrincipal UserDetails currentUser) {
-        Long companyId = authHelper.getCurrentCompanyId(currentUser);
+        Long companyId = request.companyId();
+        if (companyId == null) {
+            companyId = authHelper.getCurrentCompanyId(currentUser);
+        }
         BankAccountDto.CreateRequest resolvedRequest = request;
         if (request.currency() == null || request.currency().isBlank()) {
             String defaultCurrency = resolveCurrency(companyId);
             resolvedRequest = new BankAccountDto.CreateRequest(
-                    request.name(), request.iban(), defaultCurrency, request.openingBalance());
+                    request.companyId(), request.name(), request.iban(), defaultCurrency, request.openingBalance());
         }
         BankAccount created = bankAccountService.create(resolvedRequest, companyId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(bankAccountMapper.toDto(created)));

--- a/backend/src/main/java/com/nemo/bankaccount/BankAccountDto.java
+++ b/backend/src/main/java/com/nemo/bankaccount/BankAccountDto.java
@@ -19,6 +19,7 @@ public record BankAccountDto(
         String updatedAt
 ) {
     public record CreateRequest(
+            Long companyId,
             @NotBlank String name,
             @NotBlank @Size(min = 5, max = 34) String iban,
             @NotBlank @Size(min = 3, max = 3) String currency,

--- a/backend/src/main/java/com/nemo/bankstatement/BankStatement.java
+++ b/backend/src/main/java/com/nemo/bankstatement/BankStatement.java
@@ -1,0 +1,90 @@
+package com.nemo.bankstatement;
+
+import com.nemo.bankaccount.BankAccount;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "bank_statement")
+public class BankStatement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bank_account_id", nullable = false)
+    private BankAccount bankAccount;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(name = "period_start")
+    private LocalDate periodStart;
+
+    @Column(name = "period_end")
+    private LocalDate periodEnd;
+
+    @Column(name = "total_debits", precision = 15, scale = 2)
+    private BigDecimal totalDebits;
+
+    @Column(name = "total_credits", precision = 15, scale = 2)
+    private BigDecimal totalCredits;
+
+    @Column(name = "opening_balance", precision = 15, scale = 2)
+    private BigDecimal openingBalance;
+
+    @Column(name = "closing_balance", precision = 15, scale = 2)
+    private BigDecimal closingBalance;
+
+    @Column(name = "computed_debits", precision = 15, scale = 2)
+    private BigDecimal computedDebits;
+
+    @Column(name = "computed_credits", precision = 15, scale = 2)
+    private BigDecimal computedCredits;
+
+    @Column(nullable = false)
+    private boolean matched = false;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    public BankStatement() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public BankAccount getBankAccount() { return bankAccount; }
+    public void setBankAccount(BankAccount bankAccount) { this.bankAccount = bankAccount; }
+    public String getFileName() { return fileName; }
+    public void setFileName(String fileName) { this.fileName = fileName; }
+    public LocalDate getPeriodStart() { return periodStart; }
+    public void setPeriodStart(LocalDate periodStart) { this.periodStart = periodStart; }
+    public LocalDate getPeriodEnd() { return periodEnd; }
+    public void setPeriodEnd(LocalDate periodEnd) { this.periodEnd = periodEnd; }
+    public BigDecimal getTotalDebits() { return totalDebits; }
+    public void setTotalDebits(BigDecimal totalDebits) { this.totalDebits = totalDebits; }
+    public BigDecimal getTotalCredits() { return totalCredits; }
+    public void setTotalCredits(BigDecimal totalCredits) { this.totalCredits = totalCredits; }
+    public BigDecimal getOpeningBalance() { return openingBalance; }
+    public void setOpeningBalance(BigDecimal openingBalance) { this.openingBalance = openingBalance; }
+    public BigDecimal getClosingBalance() { return closingBalance; }
+    public void setClosingBalance(BigDecimal closingBalance) { this.closingBalance = closingBalance; }
+    public BigDecimal getComputedDebits() { return computedDebits; }
+    public void setComputedDebits(BigDecimal computedDebits) { this.computedDebits = computedDebits; }
+    public BigDecimal getComputedCredits() { return computedCredits; }
+    public void setComputedCredits(BigDecimal computedCredits) { this.computedCredits = computedCredits; }
+    public boolean isMatched() { return matched; }
+    public void setMatched(boolean matched) { this.matched = matched; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getUpdatedAt() { return updatedAt; }
+}

--- a/backend/src/main/java/com/nemo/bankstatement/BankStatementController.java
+++ b/backend/src/main/java/com/nemo/bankstatement/BankStatementController.java
@@ -1,0 +1,57 @@
+package com.nemo.bankstatement;
+
+import com.nemo.bankaccount.BankAccountService;
+import com.nemo.common.dto.ApiResponse;
+import com.nemo.common.dto.PaginatedResponse;
+import com.nemo.common.dto.PaginatedResponse.PaginationInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/bank-accounts/{bankAccountId}/statements")
+public class BankStatementController {
+
+    private final StatementImportService importService;
+    private final BankStatementRepository bankStatementRepository;
+    private final BankStatementMapper bankStatementMapper;
+    private final BankAccountService bankAccountService;
+
+    public BankStatementController(StatementImportService importService,
+                                    BankStatementRepository bankStatementRepository,
+                                    BankStatementMapper bankStatementMapper,
+                                    BankAccountService bankAccountService) {
+        this.importService = importService;
+        this.bankStatementRepository = bankStatementRepository;
+        this.bankStatementMapper = bankStatementMapper;
+        this.bankAccountService = bankAccountService;
+    }
+
+    @PostMapping("/import")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<BankStatementDto.ImportResult>> importStatement(
+            @PathVariable Long bankAccountId,
+            @RequestParam("file") MultipartFile file) {
+        BankStatementDto.ImportResult result = importService.importPdf(bankAccountId, file);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(result));
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('FINANCE', 'EXECUTIVE')")
+    public ResponseEntity<PaginatedResponse<BankStatementDto>> list(
+            @PathVariable Long bankAccountId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        bankAccountService.getById(bankAccountId); // validate parent exists
+        Page<BankStatement> result = bankStatementRepository.findByBankAccountIdOrderByCreatedAtDesc(bankAccountId,
+                org.springframework.data.domain.PageRequest.of(page, size));
+        List<BankStatementDto> dtos = bankStatementMapper.toDtoList(result.getContent());
+        return ResponseEntity.ok(PaginatedResponse.of(dtos,
+                new PaginationInfo(page, size, result.getTotalElements(), result.getTotalPages())));
+    }
+}

--- a/backend/src/main/java/com/nemo/bankstatement/BankStatementDto.java
+++ b/backend/src/main/java/com/nemo/bankstatement/BankStatementDto.java
@@ -1,0 +1,28 @@
+package com.nemo.bankstatement;
+
+import java.math.BigDecimal;
+
+public record BankStatementDto(
+        Long id,
+        Long bankAccountId,
+        String fileName,
+        String periodStart,
+        String periodEnd,
+        BigDecimal totalDebits,
+        BigDecimal totalCredits,
+        BigDecimal openingBalance,
+        BigDecimal closingBalance,
+        BigDecimal computedDebits,
+        BigDecimal computedCredits,
+        boolean matched,
+        int transactionCount,
+        String createdAt,
+        String updatedAt
+) {
+    public record ImportResult(
+            Long statementId,
+            int importedCount,
+            boolean matched,
+            String warning
+    ) {}
+}

--- a/backend/src/main/java/com/nemo/bankstatement/BankStatementMapper.java
+++ b/backend/src/main/java/com/nemo/bankstatement/BankStatementMapper.java
@@ -1,0 +1,18 @@
+package com.nemo.bankstatement;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface BankStatementMapper {
+
+    @Mapping(target = "bankAccountId", source = "bankAccount.id")
+    @Mapping(target = "transactionCount", expression = "java(0)")
+    @Mapping(target = "createdAt", source = "createdAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    @Mapping(target = "updatedAt", source = "updatedAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    BankStatementDto toDto(BankStatement bankStatement);
+
+    List<BankStatementDto> toDtoList(List<BankStatement> bankStatements);
+}

--- a/backend/src/main/java/com/nemo/bankstatement/BankStatementRepository.java
+++ b/backend/src/main/java/com/nemo/bankstatement/BankStatementRepository.java
@@ -1,0 +1,10 @@
+package com.nemo.bankstatement;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BankStatementRepository extends JpaRepository<BankStatement, Long> {
+
+    Page<BankStatement> findByBankAccountIdOrderByCreatedAtDesc(Long bankAccountId, Pageable pageable);
+}

--- a/backend/src/main/java/com/nemo/bankstatement/StatementImportService.java
+++ b/backend/src/main/java/com/nemo/bankstatement/StatementImportService.java
@@ -9,7 +9,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.text.PDFTextStripper;
+import org.apache.pdfbox.rendering.ImageType;
+import org.apache.pdfbox.rendering.PDFRenderer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,9 +20,13 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -30,6 +35,7 @@ public class StatementImportService {
 
     private static final Logger log = LoggerFactory.getLogger(StatementImportService.class);
     private static final BigDecimal MATCH_TOLERANCE = new BigDecimal("0.02");
+    private static final float RENDER_DPI = 150f;
 
     private final BankAccountRepository bankAccountRepository;
     private final BankStatementRepository bankStatementRepository;
@@ -45,8 +51,8 @@ public class StatementImportService {
                                    BankTransactionRepository bankTransactionRepository,
                                    ObjectMapper objectMapper,
                                    @Value("${nemo.openai.api-key:}") String apiKey,
-                                   @Value("${nemo.openai.base-url:https://ollama.com/v1}") String baseUrl,
-                                   @Value("${nemo.openai.model:qwen3.5}") String model) {
+                                   @Value("${nemo.openai.base-url:https://api.fireworks.ai/inference/v1}") String baseUrl,
+                                   @Value("${nemo.openai.model:accounts/fireworks/models/kimi-k2p6}") String model) {
         this.bankAccountRepository = bankAccountRepository;
         this.bankStatementRepository = bankStatementRepository;
         this.bankTransactionRepository = bankTransactionRepository;
@@ -72,38 +78,53 @@ public class StatementImportService {
         }
 
         try {
-            // 1. Extract text from PDF using PDFBox
-            String pdfText;
+            // 1. Render PDF pages as images
+            List<Map<String, Object>> pageImages = new ArrayList<>();
             try (PDDocument document = Loader.loadPDF(file.getBytes())) {
-                PDFTextStripper stripper = new PDFTextStripper();
-                pdfText = stripper.getText(document);
+                PDFRenderer renderer = new PDFRenderer(document);
+                for (int page = 0; page < document.getNumberOfPages(); page++) {
+                    BufferedImage image = renderer.renderImageWithDPI(page, RENDER_DPI, ImageType.RGB);
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    ImageIO.write(image, "png", baos);
+                    String base64Page = Base64.getEncoder().encodeToString(baos.toByteArray());
+                    pageImages.add(Map.of(
+                            "type", "image_url",
+                            "image_url", Map.of("url", "data:image/png;base64," + base64Page)
+                    ));
+                }
             }
 
-            if (pdfText == null || pdfText.isBlank()) {
-                throw new RuntimeException("Could not extract any text from the PDF. The file may be a scanned image.");
+            if (pageImages.isEmpty()) {
+                throw new RuntimeException("Could not render any pages from the PDF.");
             }
 
-            // 2. Build OpenAI-compatible request with extracted text
-            String systemPrompt = "You are a bank statement parser. Extract all transactions from the bank statement text. " +
+            // 2. Build multimodal OpenAI-compatible request
+            String systemPrompt = "You are a bank statement parser. Extract all transactions from the bank statement image(s). " +
                     "Return a JSON object with the exact schema specified. " +
                     "Amounts should be positive for credits (money in) and negative for debits (money out). " +
                     "Be thorough — extract every transaction. " +
+                    "Do NOT include the opening/closing balance rows or 'SOLDE' rows as transactions — only include actual transactions (credits and debits). " +
+                    "The openingBalance and closingBalance fields should contain the statement's opening and closing balance numbers. " +
                     "The statement period, totals, and balances should match what is shown in the document. " +
                     "IMPORTANT: Return ONLY valid JSON, no markdown fences, no explanation.";
 
-            String userPrompt = "Extract all transactions from this bank statement text. Return JSON with: " +
+            String userPrompt = "Extract all transactions from this bank statement. Return JSON with: " +
                     "\"statementPeriod\" (\"startDate\" as YYYY-MM-DD, \"endDate\" as YYYY-MM-DD), " +
                     "\"totalDebits\" (absolute sum of all negative amounts as positive number), " +
                     "\"totalCredits\" (sum of all positive amounts), " +
                     "\"openingBalance\", \"closingBalance\", " +
-                    "and \"operations\" array (each with \"date\" as YYYY-MM-DD, \"description\", \"amount\" where positive=credit/negative=debit, \"reference\" or null).\n\n" +
-                    "Bank statement text:\n" + pdfText;
+                    "and \"operations\" array (each with \"date\" as YYYY-MM-DD, \"description\", \"amount\" where positive=credit/negative=debit, \"reference\" or null).";
+
+            // Build content array: text prompt first, then page images
+            List<Map<String, Object>> content = new ArrayList<>();
+            content.add(Map.of("type", "text", "text", userPrompt));
+            content.addAll(pageImages);
 
             Map<String, Object> request = Map.of(
                     "model", model,
                     "messages", List.of(
                             Map.of("role", "system", "content", systemPrompt),
-                            Map.of("role", "user", "content", userPrompt)
+                            Map.of("role", "user", "content", content)
                     ),
                     "max_tokens", 16384,
                     "response_format", Map.of("type", "json_object")
@@ -121,32 +142,32 @@ public class StatementImportService {
             // 4. Parse response
             JsonNode responseJson = objectMapper.readTree(response.getBody());
             JsonNode messageNode = responseJson.path("choices").get(0).path("message");
-            String content = messageNode.path("content").asText();
+            String content1 = messageNode.path("content").asText();
 
             // If content is empty, check for reasoning field (some models like qwen3.5 put the answer there)
-            if (content == null || content.isBlank()) {
+            if (content1 == null || content1.isBlank()) {
                 String reasoning = messageNode.path("reasoning").asText(null);
                 if (reasoning != null && !reasoning.isBlank()) {
-                    content = reasoning;
+                    content1 = reasoning;
                 }
             }
 
             // Strip <think>...</think> tags if present (some models wrap reasoning in these)
-            content = content.replaceAll("(?s)<think>.*?</think>", "").trim();
+            content1 = content1.replaceAll("(?s)<think>.*?</think>", "").trim();
 
             // Strip markdown code fences if present
-            content = content.trim();
-            if (content.startsWith("```json")) {
-                content = content.substring(7);
-            } else if (content.startsWith("```")) {
-                content = content.substring(3);
+            content1 = content1.trim();
+            if (content1.startsWith("```json")) {
+                content1 = content1.substring(7);
+            } else if (content1.startsWith("```")) {
+                content1 = content1.substring(3);
             }
-            if (content.endsWith("```")) {
-                content = content.substring(0, content.length() - 3);
+            if (content1.endsWith("```")) {
+                content1 = content1.substring(0, content1.length() - 3);
             }
-            content = content.trim();
+            content1 = content1.trim();
 
-            JsonNode extracted = objectMapper.readTree(content);
+            JsonNode extracted = objectMapper.readTree(content1);
 
             // 5. Parse statement metadata
             LocalDate periodStart = parseDate(extracted.path("statementPeriod").path("startDate").asText(null));

--- a/backend/src/main/java/com/nemo/bankstatement/StatementImportService.java
+++ b/backend/src/main/java/com/nemo/bankstatement/StatementImportService.java
@@ -7,6 +7,9 @@ import com.nemo.banktransaction.BankTransactionRepository;
 import com.nemo.common.exception.EntityNotFoundException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -42,8 +45,8 @@ public class StatementImportService {
                                    BankTransactionRepository bankTransactionRepository,
                                    ObjectMapper objectMapper,
                                    @Value("${nemo.openai.api-key:}") String apiKey,
-                                   @Value("${nemo.openai.base-url:https://api.deepseek.com}") String baseUrl,
-                                   @Value("${nemo.openai.model:deepseek-v4-flash}") String model) {
+                                   @Value("${nemo.openai.base-url:https://ollama.com/v1}") String baseUrl,
+                                   @Value("${nemo.openai.model:qwen3.5}") String model) {
         this.bankAccountRepository = bankAccountRepository;
         this.bankStatementRepository = bankStatementRepository;
         this.bankTransactionRepository = bankTransactionRepository;
@@ -51,7 +54,12 @@ public class StatementImportService {
         this.apiKey = apiKey;
         this.baseUrl = baseUrl;
         this.model = model;
-        this.restTemplate = new RestTemplate();
+        RestTemplate template = new RestTemplate();
+        template.setRequestFactory(new org.springframework.http.client.SimpleClientHttpRequestFactory() {{
+            setConnectTimeout(java.time.Duration.ofSeconds(10));
+            setReadTimeout(java.time.Duration.ofMinutes(5));
+        }});
+        this.restTemplate = template;
     }
 
     @Transactional
@@ -64,40 +72,41 @@ public class StatementImportService {
         }
 
         try {
-            // 1. Encode PDF to base64
-            String base64Pdf = java.util.Base64.getEncoder().encodeToString(file.getBytes());
+            // 1. Extract text from PDF using PDFBox
+            String pdfText;
+            try (PDDocument document = Loader.loadPDF(file.getBytes())) {
+                PDFTextStripper stripper = new PDFTextStripper();
+                pdfText = stripper.getText(document);
+            }
 
-            // 2. Build OpenAI-compatible request
-            String systemPrompt = "You are a bank statement parser. Extract all transactions from the bank statement. " +
+            if (pdfText == null || pdfText.isBlank()) {
+                throw new RuntimeException("Could not extract any text from the PDF. The file may be a scanned image.");
+            }
+
+            // 2. Build OpenAI-compatible request with extracted text
+            String systemPrompt = "You are a bank statement parser. Extract all transactions from the bank statement text. " +
                     "Return a JSON object with the exact schema specified. " +
                     "Amounts should be positive for credits (money in) and negative for debits (money out). " +
                     "Be thorough — extract every transaction. " +
-                    "The statement period, totals, and balances should match what is shown on the document.";
+                    "The statement period, totals, and balances should match what is shown in the document. " +
+                    "IMPORTANT: Return ONLY valid JSON, no markdown fences, no explanation.";
 
-            String userPrompt = "Extract all transactions from this bank statement. Return JSON with: " +
-                    "statementPeriod (startDate as YYYY-MM-DD, endDate as YYYY-MM-DD), " +
-                    "totalDebits (absolute sum of all negative amounts as positive number), " +
-                    "totalCredits (sum of all positive amounts), " +
-                    "openingBalance, closingBalance, " +
-                    "and operations array (each with date as YYYY-MM-DD, description, amount where positive=credit/negative=debit, reference or null).";
-
-            Map<String, Object> imageUrlContent = Map.of(
-                    "type", "image_url",
-                    "image_url", Map.of("url", "data:application/pdf;base64," + base64Pdf)
-            );
-
-            Map<String, Object> textContent = Map.of(
-                    "type", "text",
-                    "text", userPrompt
-            );
+            String userPrompt = "Extract all transactions from this bank statement text. Return JSON with: " +
+                    "\"statementPeriod\" (\"startDate\" as YYYY-MM-DD, \"endDate\" as YYYY-MM-DD), " +
+                    "\"totalDebits\" (absolute sum of all negative amounts as positive number), " +
+                    "\"totalCredits\" (sum of all positive amounts), " +
+                    "\"openingBalance\", \"closingBalance\", " +
+                    "and \"operations\" array (each with \"date\" as YYYY-MM-DD, \"description\", \"amount\" where positive=credit/negative=debit, \"reference\" or null).\n\n" +
+                    "Bank statement text:\n" + pdfText;
 
             Map<String, Object> request = Map.of(
                     "model", model,
                     "messages", List.of(
                             Map.of("role", "system", "content", systemPrompt),
-                            Map.of("role", "user", "content", List.of(textContent, imageUrlContent))
+                            Map.of("role", "user", "content", userPrompt)
                     ),
-                    "max_tokens", 4096
+                    "max_tokens", 16384,
+                    "response_format", Map.of("type", "json_object")
             );
 
             // 3. Call OpenAI-compatible API
@@ -111,7 +120,19 @@ public class StatementImportService {
 
             // 4. Parse response
             JsonNode responseJson = objectMapper.readTree(response.getBody());
-            String content = responseJson.path("choices").get(0).path("message").path("content").asText();
+            JsonNode messageNode = responseJson.path("choices").get(0).path("message");
+            String content = messageNode.path("content").asText();
+
+            // If content is empty, check for reasoning field (some models like qwen3.5 put the answer there)
+            if (content == null || content.isBlank()) {
+                String reasoning = messageNode.path("reasoning").asText(null);
+                if (reasoning != null && !reasoning.isBlank()) {
+                    content = reasoning;
+                }
+            }
+
+            // Strip <think>...</think> tags if present (some models wrap reasoning in these)
+            content = content.replaceAll("(?s)<think>.*?</think>", "").trim();
 
             // Strip markdown code fences if present
             content = content.trim();

--- a/backend/src/main/java/com/nemo/bankstatement/StatementImportService.java
+++ b/backend/src/main/java/com/nemo/bankstatement/StatementImportService.java
@@ -1,0 +1,247 @@
+package com.nemo.bankstatement;
+
+import com.nemo.bankaccount.BankAccount;
+import com.nemo.bankaccount.BankAccountRepository;
+import com.nemo.banktransaction.BankTransaction;
+import com.nemo.banktransaction.BankTransactionRepository;
+import com.nemo.common.exception.EntityNotFoundException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class StatementImportService {
+
+    private static final Logger log = LoggerFactory.getLogger(StatementImportService.class);
+    private static final BigDecimal MATCH_TOLERANCE = new BigDecimal("0.02");
+    private static final String MODEL = "gpt-4o";
+
+    private final BankAccountRepository bankAccountRepository;
+    private final BankStatementRepository bankStatementRepository;
+    private final BankTransactionRepository bankTransactionRepository;
+    private final ObjectMapper objectMapper;
+    private final String apiKey;
+    private final String baseUrl;
+    private final RestTemplate restTemplate;
+
+    public StatementImportService(BankAccountRepository bankAccountRepository,
+                                   BankStatementRepository bankStatementRepository,
+                                   BankTransactionRepository bankTransactionRepository,
+                                   ObjectMapper objectMapper,
+                                   @Value("${nemo.openai.api-key:}") String apiKey,
+                                   @Value("${nemo.openai.base-url:https://api.openai.com/v1}") String baseUrl) {
+        this.bankAccountRepository = bankAccountRepository;
+        this.bankStatementRepository = bankStatementRepository;
+        this.bankTransactionRepository = bankTransactionRepository;
+        this.objectMapper = objectMapper;
+        this.apiKey = apiKey;
+        this.baseUrl = baseUrl;
+        this.restTemplate = new RestTemplate();
+    }
+
+    @Transactional
+    public BankStatementDto.ImportResult importPdf(Long bankAccountId, MultipartFile file) {
+        BankAccount account = bankAccountRepository.findById(bankAccountId)
+                .orElseThrow(() -> new EntityNotFoundException("BankAccount", bankAccountId));
+
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalStateException("OpenAI API key is not configured. Set nemo.openai.api-key in application.yml or OPENAI_API_KEY environment variable.");
+        }
+
+        try {
+            // 1. Encode PDF to base64
+            String base64Pdf = java.util.Base64.getEncoder().encodeToString(file.getBytes());
+
+            // 2. Build OpenAI-compatible request
+            String systemPrompt = "You are a bank statement parser. Extract all transactions from the bank statement. " +
+                    "Return a JSON object with the exact schema specified. " +
+                    "Amounts should be positive for credits (money in) and negative for debits (money out). " +
+                    "Be thorough — extract every transaction. " +
+                    "The statement period, totals, and balances should match what is shown on the document.";
+
+            String userPrompt = "Extract all transactions from this bank statement. Return JSON with: " +
+                    "statementPeriod (startDate as YYYY-MM-DD, endDate as YYYY-MM-DD), " +
+                    "totalDebits (absolute sum of all negative amounts as positive number), " +
+                    "totalCredits (sum of all positive amounts), " +
+                    "openingBalance, closingBalance, " +
+                    "and operations array (each with date as YYYY-MM-DD, description, amount where positive=credit/negative=debit, reference or null).";
+
+            Map<String, Object> imageUrlContent = Map.of(
+                    "type", "image_url",
+                    "image_url", Map.of("url", "data:application/pdf;base64," + base64Pdf)
+            );
+
+            Map<String, Object> textContent = Map.of(
+                    "type", "text",
+                    "text", userPrompt
+            );
+
+            Map<String, Object> request = Map.of(
+                    "model", MODEL,
+                    "messages", List.of(
+                            Map.of("role", "system", "content", systemPrompt),
+                            Map.of("role", "user", "content", List.of(textContent, imageUrlContent))
+                    ),
+                    "max_tokens", 4096
+            );
+
+            // 3. Call OpenAI-compatible API
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(apiKey);
+
+            HttpEntity<String> entity = new HttpEntity<>(objectMapper.writeValueAsString(request), headers);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    baseUrl + "/chat/completions", HttpMethod.POST, entity, String.class);
+
+            // 4. Parse response
+            JsonNode responseJson = objectMapper.readTree(response.getBody());
+            String content = responseJson.path("choices").get(0).path("message").path("content").asText();
+
+            // Strip markdown code fences if present
+            content = content.trim();
+            if (content.startsWith("```json")) {
+                content = content.substring(7);
+            } else if (content.startsWith("```")) {
+                content = content.substring(3);
+            }
+            if (content.endsWith("```")) {
+                content = content.substring(0, content.length() - 3);
+            }
+            content = content.trim();
+
+            JsonNode extracted = objectMapper.readTree(content);
+
+            // 5. Parse statement metadata
+            LocalDate periodStart = parseDate(extracted.path("statementPeriod").path("startDate").asText(null));
+            LocalDate periodEnd = parseDate(extracted.path("statementPeriod").path("endDate").asText(null));
+            BigDecimal totalDebits = parseBigDecimal(extracted.path("totalDebits"));
+            BigDecimal totalCredits = parseBigDecimal(extracted.path("totalCredits"));
+            BigDecimal openingBalance = parseBigDecimalOrNull(extracted.path("openingBalance"));
+            BigDecimal closingBalance = parseBigDecimalOrNull(extracted.path("closingBalance"));
+
+            // 6. Parse operations and create transactions
+            JsonNode operations = extracted.path("operations");
+            List<BankTransaction> transactions = new ArrayList<>();
+            BigDecimal computedDebits = BigDecimal.ZERO;
+            BigDecimal computedCredits = BigDecimal.ZERO;
+
+            for (JsonNode op : operations) {
+                BigDecimal amount = parseBigDecimal(op.path("amount"));
+                String currency = account.getCurrency();
+                String dateStr = op.path("date").asText(null);
+                String description = op.path("description").asText("");
+                String reference = op.path("reference").asText(null);
+                if ("null".equals(reference)) reference = null;
+
+                BankTransaction tx = new BankTransaction();
+                tx.setBankAccount(account);
+                tx.setDate(dateStr != null ? LocalDate.parse(dateStr) : null);
+                tx.setDescription(description);
+                tx.setAmount(amount != null ? amount : BigDecimal.ZERO);
+                tx.setCurrency(currency);
+                tx.setReference(reference);
+                transactions.add(tx);
+
+                if (amount != null) {
+                    if (amount.compareTo(BigDecimal.ZERO) < 0) {
+                        computedDebits = computedDebits.add(amount.abs());
+                    } else {
+                        computedCredits = computedCredits.add(amount);
+                    }
+                }
+            }
+
+            // 7. Sum check
+            boolean matched = isMatch(computedDebits, totalDebits) && isMatch(computedCredits, totalCredits);
+
+            // 8. Save statement
+            BankStatement statement = new BankStatement();
+            statement.setBankAccount(account);
+            statement.setFileName(file.getOriginalFilename());
+            statement.setPeriodStart(periodStart);
+            statement.setPeriodEnd(periodEnd);
+            statement.setTotalDebits(totalDebits);
+            statement.setTotalCredits(totalCredits);
+            statement.setOpeningBalance(openingBalance);
+            statement.setClosingBalance(closingBalance);
+            statement.setComputedDebits(computedDebits);
+            statement.setComputedCredits(computedCredits);
+            statement.setMatched(matched);
+            bankStatementRepository.save(statement);
+
+            // 9. Save transactions with link to statement
+            for (BankTransaction tx : transactions) {
+                tx.setBankStatement(statement);
+                bankTransactionRepository.save(tx);
+            }
+
+            String warning = null;
+            if (!matched) {
+                warning = String.format("Sum check mismatch: computed debits=%s vs statement=%s, computed credits=%s vs statement=%s",
+                        computedDebits, totalDebits, computedCredits, totalCredits);
+            }
+
+            return new BankStatementDto.ImportResult(
+                    statement.getId(),
+                    transactions.size(),
+                    matched,
+                    warning
+            );
+
+        } catch (EntityNotFoundException e) {
+            throw e;
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Failed to import bank statement PDF", e);
+            throw new RuntimeException("Failed to import bank statement: " + e.getMessage(), e);
+        }
+    }
+
+    private boolean isMatch(BigDecimal computed, BigDecimal stated) {
+        if (computed == null || stated == null) return false;
+        return computed.subtract(stated).abs().compareTo(MATCH_TOLERANCE) <= 0;
+    }
+
+    private LocalDate parseDate(String dateStr) {
+        if (dateStr == null || dateStr.isBlank()) return null;
+        try {
+            return LocalDate.parse(dateStr);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private BigDecimal parseBigDecimal(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) return BigDecimal.ZERO;
+        try {
+            return node.decimalValue();
+        } catch (Exception e) {
+            return BigDecimal.ZERO;
+        }
+    }
+
+    private BigDecimal parseBigDecimalOrNull(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) return null;
+        try {
+            return node.decimalValue();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/com/nemo/bankstatement/StatementImportService.java
+++ b/backend/src/main/java/com/nemo/bankstatement/StatementImportService.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +27,6 @@ public class StatementImportService {
 
     private static final Logger log = LoggerFactory.getLogger(StatementImportService.class);
     private static final BigDecimal MATCH_TOLERANCE = new BigDecimal("0.02");
-    private static final String MODEL = "gpt-4o";
 
     private final BankAccountRepository bankAccountRepository;
     private final BankStatementRepository bankStatementRepository;
@@ -36,6 +34,7 @@ public class StatementImportService {
     private final ObjectMapper objectMapper;
     private final String apiKey;
     private final String baseUrl;
+    private final String model;
     private final RestTemplate restTemplate;
 
     public StatementImportService(BankAccountRepository bankAccountRepository,
@@ -43,13 +42,15 @@ public class StatementImportService {
                                    BankTransactionRepository bankTransactionRepository,
                                    ObjectMapper objectMapper,
                                    @Value("${nemo.openai.api-key:}") String apiKey,
-                                   @Value("${nemo.openai.base-url:https://api.openai.com/v1}") String baseUrl) {
+                                   @Value("${nemo.openai.base-url:https://api.deepseek.com}") String baseUrl,
+                                   @Value("${nemo.openai.model:deepseek-v4-flash}") String model) {
         this.bankAccountRepository = bankAccountRepository;
         this.bankStatementRepository = bankStatementRepository;
         this.bankTransactionRepository = bankTransactionRepository;
         this.objectMapper = objectMapper;
         this.apiKey = apiKey;
         this.baseUrl = baseUrl;
+        this.model = model;
         this.restTemplate = new RestTemplate();
     }
 
@@ -91,7 +92,7 @@ public class StatementImportService {
             );
 
             Map<String, Object> request = Map.of(
-                    "model", MODEL,
+                    "model", model,
                     "messages", List.of(
                             Map.of("role", "system", "content", systemPrompt),
                             Map.of("role", "user", "content", List.of(textContent, imageUrlContent))

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransaction.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransaction.java
@@ -1,0 +1,73 @@
+package com.nemo.banktransaction;
+
+import com.nemo.bankaccount.BankAccount;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "bank_transaction")
+public class BankTransaction {
+
+    public enum Status { NEW, RECONCILED, IGNORED }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bank_account_id", nullable = false)
+    private BankAccount bankAccount;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    private BigDecimal amount;
+
+    @Column(nullable = false, length = 3)
+    private String currency;
+
+    @Column(length = 50)
+    private String reference;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Status status = Status.NEW;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    public BankTransaction() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public BankAccount getBankAccount() { return bankAccount; }
+    public void setBankAccount(BankAccount bankAccount) { this.bankAccount = bankAccount; }
+    public LocalDate getDate() { return date; }
+    public void setDate(LocalDate date) { this.date = date; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public BigDecimal getAmount() { return amount; }
+    public void setAmount(BigDecimal amount) { this.amount = amount; }
+    public String getCurrency() { return currency; }
+    public void setCurrency(String currency) { this.currency = currency; }
+    public String getReference() { return reference; }
+    public void setReference(String reference) { this.reference = reference; }
+    public Status getStatus() { return status; }
+    public void setStatus(Status status) { this.status = status; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getUpdatedAt() { return updatedAt; }
+}

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransaction.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransaction.java
@@ -1,6 +1,7 @@
 package com.nemo.banktransaction;
 
 import com.nemo.bankaccount.BankAccount;
+import com.nemo.bankstatement.BankStatement;
 import jakarta.persistence.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -42,6 +43,10 @@ public class BankTransaction {
     @Column(nullable = false, length = 20)
     private Status status = Status.NEW;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bank_statement_id")
+    private BankStatement bankStatement;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -68,6 +73,8 @@ public class BankTransaction {
     public void setReference(String reference) { this.reference = reference; }
     public Status getStatus() { return status; }
     public void setStatus(Status status) { this.status = status; }
+    public BankStatement getBankStatement() { return bankStatement; }
+    public void setBankStatement(BankStatement bankStatement) { this.bankStatement = bankStatement; }
     public Instant getCreatedAt() { return createdAt; }
     public Instant getUpdatedAt() { return updatedAt; }
 }

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransaction.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransaction.java
@@ -47,6 +47,13 @@ public class BankTransaction {
     @JoinColumn(name = "bank_statement_id")
     private BankStatement bankStatement;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_payment_id")
+    private com.nemo.payment.ProjectPayment projectPayment;
+
+    @Column(name = "external_note", columnDefinition = "TEXT")
+    private String externalNote;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -75,6 +82,10 @@ public class BankTransaction {
     public void setStatus(Status status) { this.status = status; }
     public BankStatement getBankStatement() { return bankStatement; }
     public void setBankStatement(BankStatement bankStatement) { this.bankStatement = bankStatement; }
+    public com.nemo.payment.ProjectPayment getProjectPayment() { return projectPayment; }
+    public void setProjectPayment(com.nemo.payment.ProjectPayment projectPayment) { this.projectPayment = projectPayment; }
+    public String getExternalNote() { return externalNote; }
+    public void setExternalNote(String externalNote) { this.externalNote = externalNote; }
     public Instant getCreatedAt() { return createdAt; }
     public Instant getUpdatedAt() { return updatedAt; }
 }

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransactionController.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransactionController.java
@@ -1,0 +1,87 @@
+package com.nemo.banktransaction;
+
+import com.nemo.bankaccount.BankAccountService;
+import com.nemo.common.dto.ApiResponse;
+import com.nemo.common.dto.PaginatedResponse;
+import com.nemo.common.dto.PaginatedResponse.PaginationInfo;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/bank-accounts/{bankAccountId}/transactions")
+public class BankTransactionController {
+
+    private final BankTransactionService bankTransactionService;
+    private final BankTransactionMapper bankTransactionMapper;
+    private final BankAccountService bankAccountService;
+
+    public BankTransactionController(BankTransactionService bankTransactionService,
+                                      BankTransactionMapper bankTransactionMapper,
+                                      BankAccountService bankAccountService) {
+        this.bankTransactionService = bankTransactionService;
+        this.bankTransactionMapper = bankTransactionMapper;
+        this.bankAccountService = bankAccountService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('FINANCE', 'EXECUTIVE')")
+    public ResponseEntity<PaginatedResponse<BankTransactionDto>> list(
+            @PathVariable Long bankAccountId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "date,desc") String sort) {
+        bankAccountService.getById(bankAccountId); // validate parent exists
+        Page<BankTransaction> result = bankTransactionService.list(bankAccountId, page, size, sort);
+        List<BankTransactionDto> dtos = bankTransactionMapper.toDtoList(result.getContent());
+        return ResponseEntity.ok(PaginatedResponse.of(dtos,
+                new PaginationInfo(page, size, result.getTotalElements(), result.getTotalPages())));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('FINANCE', 'EXECUTIVE')")
+    public ResponseEntity<ApiResponse<BankTransactionDto>> get(
+            @PathVariable Long bankAccountId,
+            @PathVariable Long id) {
+        bankAccountService.getById(bankAccountId); // validate parent exists
+        BankTransaction transaction = bankTransactionService.getById(id);
+        return ResponseEntity.ok(ApiResponse.of(bankTransactionMapper.toDto(transaction)));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<BankTransactionDto>> create(
+            @PathVariable Long bankAccountId,
+            @Valid @RequestBody BankTransactionDto.CreateRequest request) {
+        BankTransaction created = bankTransactionService.create(bankAccountId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(bankTransactionMapper.toDto(created)));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<BankTransactionDto>> update(
+            @PathVariable Long bankAccountId,
+            @PathVariable Long id,
+            @RequestBody BankTransactionDto.UpdateRequest request) {
+        bankAccountService.getById(bankAccountId); // validate parent exists
+        BankTransaction updated = bankTransactionService.update(id, request);
+        return ResponseEntity.ok(ApiResponse.of(bankTransactionMapper.toDto(updated)));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<Void> delete(
+            @PathVariable Long bankAccountId,
+            @PathVariable Long id) {
+        bankAccountService.getById(bankAccountId); // validate parent exists
+        bankTransactionService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransactionDto.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransactionDto.java
@@ -1,0 +1,33 @@
+package com.nemo.banktransaction;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record BankTransactionDto(
+        Long id,
+        Long bankAccountId,
+        String date,
+        String description,
+        BigDecimal amount,
+        String currency,
+        String reference,
+        String status,
+        String createdAt,
+        String updatedAt
+) {
+    public record CreateRequest(
+            @NotBlank String date,
+            @NotBlank String description,
+            @NotNull BigDecimal amount,
+            String currency,
+            String reference
+    ) {}
+
+    public record UpdateRequest(
+            String description,
+            String reference,
+            String status
+    ) {}
+}

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransactionDto.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransactionDto.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 public record BankTransactionDto(
         Long id,
         Long bankAccountId,
+        Long bankStatementId,
         String date,
         String description,
         BigDecimal amount,

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransactionDto.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransactionDto.java
@@ -15,6 +15,9 @@ public record BankTransactionDto(
         String currency,
         String reference,
         String status,
+        Long projectPaymentId,
+        String projectPaymentTitle,
+        String externalNote,
         String createdAt,
         String updatedAt
 ) {

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransactionMapper.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransactionMapper.java
@@ -1,0 +1,24 @@
+package com.nemo.banktransaction;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface BankTransactionMapper {
+
+    @Mapping(target = "bankAccountId", source = "bankAccount.id")
+    @Mapping(target = "date", source = "date", dateFormat = "yyyy-MM-dd")
+    @Mapping(target = "status", source = "status", qualifiedByName = "statusToString")
+    @Mapping(target = "createdAt", source = "createdAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    @Mapping(target = "updatedAt", source = "updatedAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    BankTransactionDto toDto(BankTransaction bankTransaction);
+
+    List<BankTransactionDto> toDtoList(List<BankTransaction> bankTransactions);
+
+    @org.mapstruct.Named("statusToString")
+    default String statusToString(BankTransaction.Status status) {
+        return status != null ? status.name() : null;
+    }
+}

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransactionMapper.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransactionMapper.java
@@ -9,6 +9,7 @@ import java.util.List;
 public interface BankTransactionMapper {
 
     @Mapping(target = "bankAccountId", source = "bankAccount.id")
+    @Mapping(target = "bankStatementId", source = "bankStatement.id")
     @Mapping(target = "date", source = "date", dateFormat = "yyyy-MM-dd")
     @Mapping(target = "status", source = "status", qualifiedByName = "statusToString")
     @Mapping(target = "createdAt", source = "createdAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'")

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransactionMapper.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransactionMapper.java
@@ -10,6 +10,8 @@ public interface BankTransactionMapper {
 
     @Mapping(target = "bankAccountId", source = "bankAccount.id")
     @Mapping(target = "bankStatementId", source = "bankStatement.id")
+    @Mapping(target = "projectPaymentId", source = "projectPayment.id")
+    @Mapping(target = "projectPaymentTitle", source = "projectPayment.title")
     @Mapping(target = "date", source = "date", dateFormat = "yyyy-MM-dd")
     @Mapping(target = "status", source = "status", qualifiedByName = "statusToString")
     @Mapping(target = "createdAt", source = "createdAt", dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'")

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransactionRepository.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransactionRepository.java
@@ -1,0 +1,12 @@
+package com.nemo.banktransaction;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BankTransactionRepository extends JpaRepository<BankTransaction, Long> {
+
+    Page<BankTransaction> findByBankAccountIdOrderByDateDesc(Long bankAccountId, Pageable pageable);
+
+    long countByBankAccountId(Long bankAccountId);
+}

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransactionRepository.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransactionRepository.java
@@ -3,10 +3,23 @@ package com.nemo.banktransaction;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface BankTransactionRepository extends JpaRepository<BankTransaction, Long> {
 
     Page<BankTransaction> findByBankAccountIdOrderByDateDesc(Long bankAccountId, Pageable pageable);
 
     long countByBankAccountId(Long bankAccountId);
+
+    @Query("SELECT COUNT(t) FROM BankTransaction t WHERE t.status = :status " +
+            "AND (:companyId IS NULL OR t.bankAccount.company.id = :companyId)")
+    long countByStatusAndCompany(@Param("status") BankTransaction.Status status, @Param("companyId") Long companyId);
+
+    @Query("SELECT t FROM BankTransaction t LEFT JOIN FETCH t.projectPayment " +
+            "WHERE t.status = :status AND (:companyId IS NULL OR t.bankAccount.company.id = :companyId) " +
+            "ORDER BY t.date DESC")
+    List<BankTransaction> findByStatusAndCompany(@Param("status") BankTransaction.Status status, @Param("companyId") Long companyId);
 }

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransactionService.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransactionService.java
@@ -26,7 +26,7 @@ public class BankTransactionService {
 
     @Transactional(readOnly = true)
     public Page<BankTransaction> list(Long bankAccountId, int page, int size, String sort) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(sort));
+        Pageable pageable = PageRequest.of(page, size);
         return bankTransactionRepository.findByBankAccountIdOrderByDateDesc(bankAccountId, pageable);
     }
 

--- a/backend/src/main/java/com/nemo/banktransaction/BankTransactionService.java
+++ b/backend/src/main/java/com/nemo/banktransaction/BankTransactionService.java
@@ -1,0 +1,68 @@
+package com.nemo.banktransaction;
+
+import com.nemo.bankaccount.BankAccount;
+import com.nemo.bankaccount.BankAccountRepository;
+import com.nemo.common.exception.EntityNotFoundException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+public class BankTransactionService {
+
+    private final BankTransactionRepository bankTransactionRepository;
+    private final BankAccountRepository bankAccountRepository;
+
+    public BankTransactionService(BankTransactionRepository bankTransactionRepository,
+                                   BankAccountRepository bankAccountRepository) {
+        this.bankTransactionRepository = bankTransactionRepository;
+        this.bankAccountRepository = bankAccountRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<BankTransaction> list(Long bankAccountId, int page, int size, String sort) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sort));
+        return bankTransactionRepository.findByBankAccountIdOrderByDateDesc(bankAccountId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public BankTransaction getById(Long id) {
+        return bankTransactionRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("BankTransaction", id));
+    }
+
+    @Transactional
+    public BankTransaction create(Long bankAccountId, BankTransactionDto.CreateRequest request) {
+        BankAccount account = bankAccountRepository.findById(bankAccountId)
+                .orElseThrow(() -> new EntityNotFoundException("BankAccount", bankAccountId));
+        BankTransaction transaction = new BankTransaction();
+        transaction.setBankAccount(account);
+        transaction.setDate(LocalDate.parse(request.date()));
+        transaction.setDescription(request.description());
+        transaction.setAmount(request.amount());
+        transaction.setCurrency(request.currency() != null && !request.currency().isBlank()
+                ? request.currency() : account.getCurrency());
+        transaction.setReference(request.reference());
+        return bankTransactionRepository.save(transaction);
+    }
+
+    @Transactional
+    public BankTransaction update(Long id, BankTransactionDto.UpdateRequest request) {
+        BankTransaction transaction = getById(id);
+        if (request.description() != null) transaction.setDescription(request.description());
+        if (request.reference() != null) transaction.setReference(request.reference());
+        if (request.status() != null) transaction.setStatus(BankTransaction.Status.valueOf(request.status()));
+        return bankTransactionRepository.save(transaction);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        BankTransaction transaction = getById(id);
+        bankTransactionRepository.delete(transaction);
+    }
+}

--- a/backend/src/main/java/com/nemo/company/CompanyController.java
+++ b/backend/src/main/java/com/nemo/company/CompanyController.java
@@ -23,7 +23,7 @@ public class CompanyController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'HR', 'EXECUTIVE', 'MANAGER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'HR', 'EXECUTIVE', 'MANAGER', 'FINANCE')")
     public ResponseEntity<PaginatedResponse<CompanyDto>> list(
             @RequestParam(required = false) String search,
             @RequestParam(defaultValue = "0") int page,

--- a/backend/src/main/java/com/nemo/config/DataSeeder.java
+++ b/backend/src/main/java/com/nemo/config/DataSeeder.java
@@ -12,6 +12,7 @@ import com.nemo.bankaccount.BankAccount;
 import com.nemo.bankaccount.BankAccountRepository;
 import com.nemo.banktransaction.BankTransaction;
 import com.nemo.banktransaction.BankTransactionRepository;
+import com.nemo.bankstatement.BankStatementRepository;
 import com.nemo.documentation.WikiPage;
 import com.nemo.documentation.WikiPageRepository;
 import com.nemo.task.Task;
@@ -124,6 +125,7 @@ public class DataSeeder implements CommandLineRunner {
     private final ProjectPaymentRepository projectPaymentRepository;
     private final BankAccountRepository bankAccountRepository;
     private final BankTransactionRepository bankTransactionRepository;
+    private final BankStatementRepository bankStatementRepository;
 
     public DataSeeder(UserRepository userRepository,
                       PasswordEncoder passwordEncoder,
@@ -156,7 +158,8 @@ public class DataSeeder implements CommandLineRunner {
                       PreSaleRepository preSaleRepository,
                       ProjectPaymentRepository projectPaymentRepository,
                       BankAccountRepository bankAccountRepository,
-                      BankTransactionRepository bankTransactionRepository) {
+                      BankTransactionRepository bankTransactionRepository,
+                      BankStatementRepository bankStatementRepository) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.companyRepository = companyRepository;
@@ -189,6 +192,7 @@ public class DataSeeder implements CommandLineRunner {
         this.projectPaymentRepository = projectPaymentRepository;
         this.bankAccountRepository = bankAccountRepository;
         this.bankTransactionRepository = bankTransactionRepository;
+        this.bankStatementRepository = bankStatementRepository;
     }
 
     // --- Seeding profile records ---

--- a/backend/src/main/java/com/nemo/config/DataSeeder.java
+++ b/backend/src/main/java/com/nemo/config/DataSeeder.java
@@ -10,6 +10,8 @@ import com.nemo.asset.Asset;
 import com.nemo.asset.AssetRepository;
 import com.nemo.bankaccount.BankAccount;
 import com.nemo.bankaccount.BankAccountRepository;
+import com.nemo.banktransaction.BankTransaction;
+import com.nemo.banktransaction.BankTransactionRepository;
 import com.nemo.documentation.WikiPage;
 import com.nemo.documentation.WikiPageRepository;
 import com.nemo.task.Task;
@@ -121,6 +123,7 @@ public class DataSeeder implements CommandLineRunner {
     private final PreSaleRepository preSaleRepository;
     private final ProjectPaymentRepository projectPaymentRepository;
     private final BankAccountRepository bankAccountRepository;
+    private final BankTransactionRepository bankTransactionRepository;
 
     public DataSeeder(UserRepository userRepository,
                       PasswordEncoder passwordEncoder,
@@ -152,7 +155,8 @@ public class DataSeeder implements CommandLineRunner {
                       ProjectExpenseRepository projectExpenseRepository,
                       PreSaleRepository preSaleRepository,
                       ProjectPaymentRepository projectPaymentRepository,
-                      BankAccountRepository bankAccountRepository) {
+                      BankAccountRepository bankAccountRepository,
+                      BankTransactionRepository bankTransactionRepository) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.companyRepository = companyRepository;
@@ -184,6 +188,7 @@ public class DataSeeder implements CommandLineRunner {
         this.preSaleRepository = preSaleRepository;
         this.projectPaymentRepository = projectPaymentRepository;
         this.bankAccountRepository = bankAccountRepository;
+        this.bankTransactionRepository = bankTransactionRepository;
     }
 
     // --- Seeding profile records ---
@@ -1014,12 +1019,31 @@ public class DataSeeder implements CommandLineRunner {
         createExpense(footballTeam, ExpenseCategory.EXPERTISE, new BigDecimal("25000"), "Sports analytics consultancy", today.minusMonths(6), youssef);
 
         // Bank accounts
+        BankAccount mainOperating = null, savingsAcct = null, eurOperating = null, corporateAcct = null, primaryAcct = null;
         if (bankAccountRepository.count() == 0) {
-            bankAccountRepository.save(new BankAccount(company1, "Main Operating Account", "MA12345678901234567890123456", "MAD", new BigDecimal("500000")));
-            bankAccountRepository.save(new BankAccount(company1, "Savings Account", "MA98765432109876543210987654", "MAD", new BigDecimal("2000000")));
-            bankAccountRepository.save(new BankAccount(company2, "EUR Operating Account", "FR1420041010050500013M02606", "EUR", new BigDecimal("150000")));
-            bankAccountRepository.save(new BankAccount(company3, "Corporate Account", "NL91ABNA0417164300", "EUR", new BigDecimal("320000")));
-            bankAccountRepository.save(new BankAccount(company4, "Primary Account", "DE89370400440532013000", "EUR", new BigDecimal("80000")));
+            mainOperating = bankAccountRepository.save(new BankAccount(company1, "Main Operating Account", "MA12345678901234567890123456", "MAD", new BigDecimal("500000")));
+            savingsAcct = bankAccountRepository.save(new BankAccount(company1, "Savings Account", "MA98765432109876543210987654", "MAD", new BigDecimal("2000000")));
+            eurOperating = bankAccountRepository.save(new BankAccount(company2, "EUR Operating Account", "FR1420041010050500013M02606", "EUR", new BigDecimal("150000")));
+            corporateAcct = bankAccountRepository.save(new BankAccount(company3, "Corporate Account", "NL91ABNA0417164300", "EUR", new BigDecimal("320000")));
+            primaryAcct = bankAccountRepository.save(new BankAccount(company4, "Primary Account", "DE89370400440532013000", "EUR", new BigDecimal("80000")));
+        }
+
+        // Bank transactions
+        if (bankTransactionRepository.count() == 0 && mainOperating != null) {
+            createBankTransaction(mainOperating, today.minusMonths(3), "Client payment - FSE Phase 1", new BigDecimal("150000"), "MAD", "TRF-001");
+            createBankTransaction(mainOperating, today.minusMonths(2), "Office rent", new BigDecimal("-25000"), "MAD", "DD-001");
+            createBankTransaction(mainOperating, today.minusMonths(1), "API Gateway subscription", new BigDecimal("-15000"), "MAD", "DD-002");
+            createBankTransaction(mainOperating, today.minusDays(15), "Client payment - Mobile App MVP", new BigDecimal("40000"), "MAD", "TRF-002");
+            createBankTransaction(mainOperating, today.minusDays(5), "Payroll - January", new BigDecimal("-180000"), "MAD", "PAY-001");
+            createBankTransaction(savingsAcct, today.minusMonths(6), "Quarterly interest", new BigDecimal("12500"), "MAD", "INT-001");
+            createBankTransaction(savingsAcct, today.minusMonths(2), "Transfer from operating", new BigDecimal("500000"), "MAD", "TRF-003");
+            createBankTransaction(eurOperating, today.minusMonths(4), "Client payment - Data Warehouse", new BigDecimal("55000"), "EUR", "TRF-EUR-001");
+            createBankTransaction(eurOperating, today.minusMonths(2), "Cloud hosting - AWS", new BigDecimal("-8000"), "EUR", "DD-EUR-001");
+            createBankTransaction(eurOperating, today.minusWeeks(1), "Consulting fees", new BigDecimal("-12000"), "EUR", "DD-EUR-002");
+            createBankTransaction(corporateAcct, today.minusMonths(3), "License revenue", new BigDecimal("85000"), "EUR", "TRF-NL-001");
+            createBankTransaction(corporateAcct, today.minusMonths(1), "Vendor payment - Software", new BigDecimal("-35000"), "EUR", "DD-NL-001");
+            createBankTransaction(primaryAcct, today.minusMonths(2), "Project delivery payment", new BigDecimal("50000"), "EUR", "TRF-DE-001");
+            createBankTransaction(primaryAcct, today.minusWeeks(2), "Office expenses", new BigDecimal("-5000"), "EUR", "DD-DE-001");
         }
 
         // Project payments
@@ -1356,6 +1380,18 @@ public class DataSeeder implements CommandLineRunner {
         expense.setCreatedBy(createdBy);
         expense.setApprovalStatus(ProjectExpense.ApprovalStatus.APPROVED);
         return projectExpenseRepository.save(expense);
+    }
+
+    private BankTransaction createBankTransaction(BankAccount bankAccount, LocalDate date, String description,
+                                                    BigDecimal amount, String currency, String reference) {
+        BankTransaction tx = new BankTransaction();
+        tx.setBankAccount(bankAccount);
+        tx.setDate(date);
+        tx.setDescription(description);
+        tx.setAmount(amount);
+        tx.setCurrency(currency);
+        tx.setReference(reference);
+        return bankTransactionRepository.save(tx);
     }
 
     private ProjectPayment createPayment(Project project, String title, BigDecimal amount,

--- a/backend/src/main/java/com/nemo/payment/ProjectPayment.java
+++ b/backend/src/main/java/com/nemo/payment/ProjectPayment.java
@@ -47,6 +47,9 @@ public class ProjectPayment {
     @Column(columnDefinition = "TEXT")
     private String notes;
 
+    @Column(name = "reconciled", nullable = false)
+    private boolean reconciled = false;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "created_by_id")
     private com.nemo.user.User createdBy;
@@ -79,6 +82,8 @@ public class ProjectPayment {
     public void setNotes(String notes) { this.notes = notes; }
     public com.nemo.user.User getCreatedBy() { return createdBy; }
     public void setCreatedBy(com.nemo.user.User createdBy) { this.createdBy = createdBy; }
+    public boolean isReconciled() { return reconciled; }
+    public void setReconciled(boolean reconciled) { this.reconciled = reconciled; }
     public Instant getCreatedAt() { return createdAt; }
     public Instant getUpdatedAt() { return updatedAt; }
 }

--- a/backend/src/main/java/com/nemo/payment/ProjectPaymentController.java
+++ b/backend/src/main/java/com/nemo/payment/ProjectPaymentController.java
@@ -82,6 +82,7 @@ public class ProjectPaymentController {
                 p.getReceivedDate() != null ? p.getReceivedDate().toString() : null,
                 p.getStatus().name(),
                 p.getInvoiceRef(), p.getNotes(),
+                p.isReconciled(),
                 p.getCreatedBy() != null ? p.getCreatedBy().getId() : null,
                 p.getCreatedBy() != null ? p.getCreatedBy().getFirstName() + " " + p.getCreatedBy().getLastName() : null,
                 p.getCreatedAt() != null ? p.getCreatedAt().toString() : null,

--- a/backend/src/main/java/com/nemo/payment/ProjectPaymentDto.java
+++ b/backend/src/main/java/com/nemo/payment/ProjectPaymentDto.java
@@ -9,6 +9,7 @@ public class ProjectPaymentDto {
             String title, BigDecimal amount, String currency,
             String dueDate, String receivedDate, String status,
             String invoiceRef, String notes,
+            boolean reconciled,
             Long createdById, String createdByName,
             String createdAt, String updatedAt
     ) {}

--- a/backend/src/main/java/com/nemo/payment/ProjectPaymentRepository.java
+++ b/backend/src/main/java/com/nemo/payment/ProjectPaymentRepository.java
@@ -29,4 +29,10 @@ public interface ProjectPaymentRepository extends JpaRepository<ProjectPayment, 
 
     @Query("SELECT p FROM ProjectPayment p JOIN FETCH p.project WHERE p.receivedDate BETWEEN :start AND :end ORDER BY p.receivedDate ASC")
     List<ProjectPayment> findByReceivedDateBetweenOrderByReceivedDateAsc(@Param("start") LocalDate start, @Param("end") LocalDate end);
+
+    @Query("SELECT p FROM ProjectPayment p JOIN FETCH p.project prj " +
+            "WHERE p.reconciled = false AND p.status <> :cancelledStatus " +
+            "AND (:companyId IS NULL OR prj.company.id = :companyId) " +
+            "ORDER BY p.dueDate ASC")
+    List<ProjectPayment> findUnreconciledByCompany(@Param("companyId") Long companyId, @Param("cancelledStatus") ProjectPayment.PaymentStatus cancelledStatus);
 }

--- a/backend/src/main/java/com/nemo/reconciliation/ReconciliationController.java
+++ b/backend/src/main/java/com/nemo/reconciliation/ReconciliationController.java
@@ -1,0 +1,100 @@
+package com.nemo.reconciliation;
+
+import com.nemo.banktransaction.BankTransaction;
+import com.nemo.common.dto.ApiResponse;
+import com.nemo.payment.ProjectPayment;
+import com.nemo.security.AuthHelper;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/reconciliation")
+public class ReconciliationController {
+
+    private final ReconciliationService reconciliationService;
+    private final AuthHelper authHelper;
+
+    public ReconciliationController(ReconciliationService reconciliationService, AuthHelper authHelper) {
+        this.reconciliationService = reconciliationService;
+        this.authHelper = authHelper;
+    }
+
+    @GetMapping("/unreconciled-count")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<ReconciliationDto.UnreconciledCountDto>> getUnreconciledCount(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.getCurrentCompanyId(currentUser);
+        long count = reconciliationService.getUnreconciledCount(companyId);
+        return ResponseEntity.ok(ApiResponse.of(new ReconciliationDto.UnreconciledCountDto(count)));
+    }
+
+    @GetMapping("/view")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<ReconciliationDto.ReconciliationViewDto>> getReconciliationView(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.getCurrentCompanyId(currentUser);
+        List<BankTransaction> transactions = reconciliationService.getUnreconciledTransactions(companyId);
+        List<ProjectPayment> unmatched = reconciliationService.getUnmatchedPayments(companyId);
+        long count = reconciliationService.getUnreconciledCount(companyId);
+
+        ReconciliationDto.ReconciliationViewDto view = new ReconciliationDto.ReconciliationViewDto(
+                transactions.stream().map(reconciliationService::toTransactionDto).toList(),
+                unmatched.stream().map(reconciliationService::toPaymentDto).toList(),
+                count
+        );
+        return ResponseEntity.ok(ApiResponse.of(view));
+    }
+
+    @GetMapping("/suggest/{transactionId}")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<List<ReconciliationDto.UnmatchedPaymentDto>>> suggestMatches(
+            @PathVariable Long transactionId,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.getCurrentCompanyId(currentUser);
+        List<ProjectPayment> matches = reconciliationService.suggestMatches(transactionId, companyId);
+        List<ReconciliationDto.UnmatchedPaymentDto> dtos = matches.stream()
+                .map(reconciliationService::toPaymentDto).toList();
+        return ResponseEntity.ok(ApiResponse.of(dtos));
+    }
+
+    @GetMapping("/reconciled")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<List<ReconciliationDto.UnreconciledTransactionDto>>> getReconciledTransactions(
+            @AuthenticationPrincipal UserDetails currentUser) {
+        Long companyId = authHelper.getCurrentCompanyId(currentUser);
+        List<BankTransaction> transactions = reconciliationService.getReconciledTransactions(companyId);
+        List<ReconciliationDto.UnreconciledTransactionDto> dtos = transactions.stream()
+                .map(reconciliationService::toTransactionDto).toList();
+        return ResponseEntity.ok(ApiResponse.of(dtos));
+    }
+
+    @PostMapping("/bank-transactions/{id}/reconcile")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<ReconciliationDto.UnreconciledTransactionDto>> reconcile(
+            @PathVariable Long id,
+            @Valid @RequestBody ReconciliationDto.ReconcileRequest request) {
+        BankTransaction result;
+        if (request.paymentId() != null) {
+            result = reconciliationService.reconcileWithPayment(id, request.paymentId());
+        } else if (request.externalNote() != null && !request.externalNote().isBlank()) {
+            result = reconciliationService.reconcileAsExternal(id, request.externalNote());
+        } else {
+            throw new IllegalArgumentException("Either paymentId or externalNote must be provided");
+        }
+        return ResponseEntity.ok(ApiResponse.of(reconciliationService.toTransactionDto(result)));
+    }
+
+    @PostMapping("/bank-transactions/{id}/unreconcile")
+    @PreAuthorize("hasRole('FINANCE')")
+    public ResponseEntity<ApiResponse<ReconciliationDto.UnreconciledTransactionDto>> unreconcile(
+            @PathVariable Long id) {
+        BankTransaction result = reconciliationService.unreconcile(id);
+        return ResponseEntity.ok(ApiResponse.of(reconciliationService.toTransactionDto(result)));
+    }
+}

--- a/backend/src/main/java/com/nemo/reconciliation/ReconciliationDto.java
+++ b/backend/src/main/java/com/nemo/reconciliation/ReconciliationDto.java
@@ -1,0 +1,53 @@
+package com.nemo.reconciliation;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class ReconciliationDto {
+
+    public record UnreconciledTransactionDto(
+            Long id,
+            Long bankAccountId,
+            String bankAccountName,
+            String date,
+            String description,
+            BigDecimal amount,
+            String currency,
+            String reference,
+            String status,
+            Long projectPaymentId,
+            String projectPaymentTitle,
+            String externalNote,
+            String createdAt,
+            String updatedAt
+    ) {}
+
+    public record UnmatchedPaymentDto(
+            Long id,
+            Long projectId,
+            String projectName,
+            String title,
+            BigDecimal amount,
+            String currency,
+            String dueDate,
+            String receivedDate,
+            String status,
+            String invoiceRef,
+            boolean reconciled
+    ) {}
+
+    public record ReconcileRequest(
+            Long paymentId,
+            String externalNote
+    ) {}
+
+    public record UnreconciledCountDto(
+            long count
+    ) {}
+
+    public record ReconciliationViewDto(
+            List<UnreconciledTransactionDto> transactions,
+            List<UnmatchedPaymentDto> unmatchedPayments,
+            long unreconciledCount
+    ) {}
+}

--- a/backend/src/main/java/com/nemo/reconciliation/ReconciliationService.java
+++ b/backend/src/main/java/com/nemo/reconciliation/ReconciliationService.java
@@ -1,0 +1,183 @@
+package com.nemo.reconciliation;
+
+import com.nemo.bankaccount.BankAccount;
+import com.nemo.banktransaction.BankTransaction;
+import com.nemo.banktransaction.BankTransactionRepository;
+import com.nemo.common.exception.EntityNotFoundException;
+import com.nemo.payment.ProjectPayment;
+import com.nemo.payment.ProjectPaymentRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+public class ReconciliationService {
+
+    private static final BigDecimal AMOUNT_TOLERANCE = new BigDecimal("0.01");
+    private static final int DATE_WINDOW_DAYS = 3;
+
+    private final BankTransactionRepository transactionRepository;
+    private final ProjectPaymentRepository paymentRepository;
+
+    public ReconciliationService(BankTransactionRepository transactionRepository,
+                                   ProjectPaymentRepository paymentRepository) {
+        this.transactionRepository = transactionRepository;
+        this.paymentRepository = paymentRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<BankTransaction> getUnreconciledTransactions(Long companyId) {
+        return transactionRepository.findByStatusAndCompany(BankTransaction.Status.NEW, companyId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<BankTransaction> getReconciledTransactions(Long companyId) {
+        return transactionRepository.findByStatusAndCompany(BankTransaction.Status.RECONCILED, companyId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectPayment> getUnmatchedPayments(Long companyId) {
+        return paymentRepository.findUnreconciledByCompany(companyId, ProjectPayment.PaymentStatus.CANCELLED);
+    }
+
+    @Transactional(readOnly = true)
+    public long getUnreconciledCount(Long companyId) {
+        return transactionRepository.countByStatusAndCompany(BankTransaction.Status.NEW, companyId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectPayment> suggestMatches(Long transactionId, Long companyId) {
+        BankTransaction tx = transactionRepository.findById(transactionId)
+                .orElseThrow(() -> new EntityNotFoundException("BankTransaction", transactionId));
+
+        List<ProjectPayment> candidates = paymentRepository.findUnreconciledByCompany(
+                companyId, ProjectPayment.PaymentStatus.CANCELLED);
+
+        LocalDate txDate = tx.getDate();
+        BigDecimal absAmount = tx.getAmount().abs();
+
+        return candidates.stream()
+                .filter(p -> p.getCurrency() != null && p.getCurrency().equalsIgnoreCase(tx.getCurrency()))
+                .filter(p -> p.getAmount().subtract(absAmount).abs().compareTo(AMOUNT_TOLERANCE) <= 0)
+                .filter(p -> {
+                    LocalDate compareDate = p.getDueDate() != null ? p.getDueDate() : p.getReceivedDate();
+                    if (compareDate == null) return true;
+                    long daysDiff = Math.abs(ChronoUnit.DAYS.between(txDate, compareDate));
+                    return daysDiff <= DATE_WINDOW_DAYS;
+                })
+                .sorted(Comparator.comparingLong(p -> {
+                    LocalDate compareDate = p.getDueDate() != null ? p.getDueDate() : p.getReceivedDate();
+                    if (compareDate == null) return Long.MAX_VALUE;
+                    return Math.abs(ChronoUnit.DAYS.between(txDate, compareDate));
+                }))
+                .toList();
+    }
+
+    @Transactional
+    public BankTransaction reconcileWithPayment(Long transactionId, Long paymentId) {
+        BankTransaction tx = transactionRepository.findById(transactionId)
+                .orElseThrow(() -> new EntityNotFoundException("BankTransaction", transactionId));
+
+        if (tx.getStatus() != BankTransaction.Status.NEW) {
+            throw new IllegalStateException("Transaction is already reconciled or ignored (status: " + tx.getStatus() + ")");
+        }
+
+        ProjectPayment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new EntityNotFoundException("ProjectPayment", paymentId));
+
+        if (payment.isReconciled()) {
+            throw new IllegalStateException("Payment is already reconciled with another transaction");
+        }
+
+        tx.setProjectPayment(payment);
+        tx.setExternalNote(null);
+        tx.setStatus(BankTransaction.Status.RECONCILED);
+
+        payment.setReconciled(true);
+        if (payment.getStatus() == ProjectPayment.PaymentStatus.PENDING
+                || payment.getStatus() == ProjectPayment.PaymentStatus.OVERDUE) {
+            payment.setStatus(ProjectPayment.PaymentStatus.RECEIVED);
+            payment.setReceivedDate(tx.getDate());
+        }
+
+        paymentRepository.save(payment);
+        return transactionRepository.save(tx);
+    }
+
+    @Transactional
+    public BankTransaction reconcileAsExternal(Long transactionId, String externalNote) {
+        BankTransaction tx = transactionRepository.findById(transactionId)
+                .orElseThrow(() -> new EntityNotFoundException("BankTransaction", transactionId));
+
+        if (tx.getStatus() != BankTransaction.Status.NEW) {
+            throw new IllegalStateException("Transaction is already reconciled or ignored (status: " + tx.getStatus() + ")");
+        }
+
+        tx.setProjectPayment(null);
+        tx.setExternalNote(externalNote);
+        tx.setStatus(BankTransaction.Status.RECONCILED);
+        return transactionRepository.save(tx);
+    }
+
+    @Transactional
+    public BankTransaction unreconcile(Long transactionId) {
+        BankTransaction tx = transactionRepository.findById(transactionId)
+                .orElseThrow(() -> new EntityNotFoundException("BankTransaction", transactionId));
+
+        if (tx.getStatus() != BankTransaction.Status.RECONCILED) {
+            throw new IllegalStateException("Transaction is not reconciled (status: " + tx.getStatus() + ")");
+        }
+
+        if (tx.getProjectPayment() != null) {
+            ProjectPayment payment = tx.getProjectPayment();
+            payment.setReconciled(false);
+            paymentRepository.save(payment);
+        }
+
+        tx.setProjectPayment(null);
+        tx.setExternalNote(null);
+        tx.setStatus(BankTransaction.Status.NEW);
+        return transactionRepository.save(tx);
+    }
+
+    public ReconciliationDto.UnmatchedPaymentDto toPaymentDto(ProjectPayment p) {
+        return new ReconciliationDto.UnmatchedPaymentDto(
+                p.getId(),
+                p.getProject().getId(),
+                p.getProject().getName(),
+                p.getTitle(),
+                p.getAmount(),
+                p.getCurrency(),
+                p.getDueDate() != null ? p.getDueDate().toString() : null,
+                p.getReceivedDate() != null ? p.getReceivedDate().toString() : null,
+                p.getStatus().name(),
+                p.getInvoiceRef(),
+                p.isReconciled()
+        );
+    }
+
+    public ReconciliationDto.UnreconciledTransactionDto toTransactionDto(BankTransaction t) {
+        BankAccount account = t.getBankAccount();
+        return new ReconciliationDto.UnreconciledTransactionDto(
+                t.getId(),
+                account != null ? account.getId() : null,
+                account != null ? account.getName() : null,
+                t.getDate() != null ? t.getDate().toString() : null,
+                t.getDescription(),
+                t.getAmount(),
+                t.getCurrency(),
+                t.getReference(),
+                t.getStatus().name(),
+                t.getProjectPayment() != null ? t.getProjectPayment().getId() : null,
+                t.getProjectPayment() != null ? t.getProjectPayment().getTitle() : null,
+                t.getExternalNote(),
+                t.getCreatedAt() != null ? t.getCreatedAt().toString() : null,
+                t.getUpdatedAt() != null ? t.getUpdatedAt().toString() : null
+        );
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,9 +3,9 @@ nemo:
   version: 0.9.0
   build: ''
   openai:
-    api-key: ${OPENAI_API_KEY:ollama}
-    base-url: ${OPENAI_BASE_URL:http://localhost:11434/v1}
-    model: ${OPENAI_MODEL:qwen3.5:4b}
+    api-key: ${OPENAI_API_KEY:}
+    base-url: ${OPENAI_BASE_URL:https://api.fireworks.ai/inference/v1}
+    model: ${OPENAI_MODEL:accounts/fireworks/models/kimi-k2p6}
 
 spring:
   application:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,9 +3,9 @@ nemo:
   version: 0.9.0
   build: ''
   openai:
-    api-key: ${OPENAI_API_KEY:}
-    base-url: ${OPENAI_BASE_URL:https://api.deepseek.com}
-    model: ${OPENAI_MODEL:deepseek-v4-flash}
+    api-key: ${OPENAI_API_KEY:ollama}
+    base-url: ${OPENAI_BASE_URL:http://localhost:11434/v1}
+    model: ${OPENAI_MODEL:qwen3.5:4b}
 
 spring:
   application:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,8 +4,8 @@ nemo:
   build: ''
   openai:
     api-key: ${OPENAI_API_KEY:}
-    base-url: ${OPENAI_BASE_URL:https://api.fireworks.ai/inference/v1}
-    model: ${OPENAI_MODEL:accounts/fireworks/models/kimi-k2p6}
+    base-url: ${OPENAI_BASE_URL:https://api.together.ai/v1}
+    model: ${OPENAI_MODEL:Qwen/Qwen3.5-9B}
 
 spring:
   application:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,6 +2,9 @@ nemo:
   mode: dev
   version: 0.9.0
   build: ''
+  openai:
+    api-key: ${OPENAI_API_KEY:}
+    base-url: ${OPENAI_BASE_URL:https://api.openai.com/v1}
 
 spring:
   application:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,7 +4,8 @@ nemo:
   build: ''
   openai:
     api-key: ${OPENAI_API_KEY:}
-    base-url: ${OPENAI_BASE_URL:https://api.openai.com/v1}
+    base-url: ${OPENAI_BASE_URL:https://api.deepseek.com}
+    model: ${OPENAI_MODEL:deepseek-v4-flash}
 
 spring:
   application:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,7 +5,7 @@ nemo:
   openai:
     api-key: ${OPENAI_API_KEY:}
     base-url: ${OPENAI_BASE_URL:https://api.together.ai/v1}
-    model: ${OPENAI_MODEL:Qwen/Qwen3.5-9B}
+    model: ${OPENAI_MODEL:google/gemma-4-31B-it}
 
 spring:
   application:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import UserDetailPage from '@/pages/UserDetailPage';
 import FinancePage from '@/pages/FinancePage';
 import BankAccountsPage from '@/pages/BankAccountsPage';
 import BankAccountDetailPage from '@/pages/BankAccountDetailPage';
+import ReconciliationPage from '@/pages/ReconciliationPage';
 
 export default function App() {
   const checkSession = useAuthStore((s) => s.checkSession);
@@ -93,6 +94,7 @@ export default function App() {
           <Route path="/finance" element={<RoleGuard roles={['FINANCE']}><FinancePage /></RoleGuard>} />
           <Route path="/finance/bank-accounts" element={<RoleGuard roles={['FINANCE', 'EXECUTIVE']}><BankAccountsPage /></RoleGuard>} />
           <Route path="/finance/bank-accounts/:id" element={<RoleGuard roles={['FINANCE', 'EXECUTIVE']}><BankAccountDetailPage /></RoleGuard>} />
+          <Route path="/finance/reconciliation" element={<RoleGuard roles={['FINANCE']}><ReconciliationPage /></RoleGuard>} />
           <Route path="/profile" element={<ProfilePage />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ import PreSaleDetailPage from '@/pages/PreSaleDetailPage';
 import UserDetailPage from '@/pages/UserDetailPage';
 import FinancePage from '@/pages/FinancePage';
 import BankAccountsPage from '@/pages/BankAccountsPage';
+import BankAccountDetailPage from '@/pages/BankAccountDetailPage';
 
 export default function App() {
   const checkSession = useAuthStore((s) => s.checkSession);
@@ -91,6 +92,7 @@ export default function App() {
           <Route path="/admin" element={<AdminGuard><AdminPage /></AdminGuard>} />
           <Route path="/finance" element={<RoleGuard roles={['FINANCE']}><FinancePage /></RoleGuard>} />
           <Route path="/finance/bank-accounts" element={<RoleGuard roles={['FINANCE', 'EXECUTIVE']}><BankAccountsPage /></RoleGuard>} />
+          <Route path="/finance/bank-accounts/:id" element={<RoleGuard roles={['FINANCE', 'EXECUTIVE']}><BankAccountDetailPage /></RoleGuard>} />
           <Route path="/profile" element={<ProfilePage />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/api/bankStatements.ts
+++ b/frontend/src/api/bankStatements.ts
@@ -1,0 +1,18 @@
+import { apiGetPaginated } from './client';
+import { client } from './client';
+import type { ApiResponse, PaginatedResponse, BankStatementDto, ImportResult } from '@/types';
+
+export async function importStatement(bankAccountId: number, file: File): Promise<ImportResult> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const res = await client.post<ApiResponse<ImportResult>>(
+    `/bank-accounts/${bankAccountId}/statements/import`,
+    formData,
+    { headers: { 'Content-Type': 'multipart/form-data' } }
+  );
+  return res.data.data;
+}
+
+export async function listStatements(bankAccountId: number, params?: Record<string, string | number>): Promise<PaginatedResponse<BankStatementDto>> {
+  return apiGetPaginated<BankStatementDto>(`/bank-accounts/${bankAccountId}/statements`, params);
+}

--- a/frontend/src/api/bankTransactions.ts
+++ b/frontend/src/api/bankTransactions.ts
@@ -1,0 +1,22 @@
+import { apiGet, apiGetPaginated, apiPost, apiPut, apiDelete } from './client';
+import type { PaginatedResponse, BankTransactionDto, CreateBankTransactionRequest, UpdateBankTransactionRequest } from '@/types';
+
+export async function listTransactions(bankAccountId: number, params?: Record<string, string | number>): Promise<PaginatedResponse<BankTransactionDto>> {
+  return apiGetPaginated<BankTransactionDto>(`/bank-accounts/${bankAccountId}/transactions`, params);
+}
+
+export async function getTransaction(bankAccountId: number, id: number): Promise<BankTransactionDto> {
+  return apiGet<BankTransactionDto>(`/bank-accounts/${bankAccountId}/transactions/${id}`);
+}
+
+export async function createTransaction(bankAccountId: number, request: CreateBankTransactionRequest): Promise<BankTransactionDto> {
+  return apiPost<BankTransactionDto>(`/bank-accounts/${bankAccountId}/transactions`, request);
+}
+
+export async function updateTransaction(bankAccountId: number, id: number, request: UpdateBankTransactionRequest): Promise<BankTransactionDto> {
+  return apiPut<BankTransactionDto>(`/bank-accounts/${bankAccountId}/transactions/${id}`, request);
+}
+
+export async function deleteTransaction(bankAccountId: number, id: number): Promise<void> {
+  await apiDelete(`/bank-accounts/${bankAccountId}/transactions/${id}`);
+}

--- a/frontend/src/api/reconciliation.ts
+++ b/frontend/src/api/reconciliation.ts
@@ -1,0 +1,26 @@
+import { apiGet, apiPost } from './client';
+import type { ReconciliationViewDto, UnmatchedPaymentDto, UnreconciledTransactionDto, UnreconciledCountDto, ReconcileRequest } from '@/types';
+
+export async function getReconciliationView(): Promise<ReconciliationViewDto> {
+  return apiGet<ReconciliationViewDto>('/reconciliation/view');
+}
+
+export async function getUnreconciledCount(): Promise<UnreconciledCountDto> {
+  return apiGet<UnreconciledCountDto>('/reconciliation/unreconciled-count');
+}
+
+export async function suggestMatches(transactionId: number): Promise<UnmatchedPaymentDto[]> {
+  return apiGet<UnmatchedPaymentDto[]>(`/reconciliation/suggest/${transactionId}`);
+}
+
+export async function reconcile(transactionId: number, request: ReconcileRequest): Promise<UnreconciledTransactionDto> {
+  return apiPost<UnreconciledTransactionDto>(`/reconciliation/bank-transactions/${transactionId}/reconcile`, request);
+}
+
+export async function unreconcile(transactionId: number): Promise<UnreconciledTransactionDto> {
+  return apiPost<UnreconciledTransactionDto>(`/reconciliation/bank-transactions/${transactionId}/unreconcile`);
+}
+
+export async function getReconciledTransactions(): Promise<UnreconciledTransactionDto[]> {
+  return apiGet<UnreconciledTransactionDto[]>('/reconciliation/reconciled');
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -2,9 +2,10 @@ import { NavLink, useNavigate, useLocation } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
 import { useUIStore } from '@/stores/uiStore';
 import { getInitials } from '@/utils/format';
-import { useEffect } from 'react';
+import { useEffect, useState, useCallback } from 'react';
+import { getUnreconciledCount } from '@/api/reconciliation';
 
-type NavItem = { to: string; label: string; icon: React.FC<{ className?: string }> };
+type NavItem = { to: string; label: string; icon: React.FC<{ className?: string }>; badge?: number };
 type NavSection = { header?: string; items: NavItem[] };
 
 export default function Sidebar() {
@@ -15,6 +16,20 @@ export default function Sidebar() {
   const closeMobileSidebar = useUIStore((s) => s.closeMobileSidebar);
   const navigate = useNavigate();
   const location = useLocation();
+  const [unreconciledCount, setUnreconciledCount] = useState<number>(0);
+
+  const loadBadge = useCallback(async () => {
+    if (user?.role === 'FINANCE') {
+      try {
+        const data = await getUnreconciledCount();
+        setUnreconciledCount(data.count);
+      } catch { /* ignore */ }
+    }
+  }, [user?.role]);
+
+  useEffect(() => {
+    loadBadge();
+  }, [loadBadge]);
 
   useEffect(() => {
     if (isMobile) closeMobileSidebar();
@@ -86,6 +101,9 @@ export default function Sidebar() {
         ...(role === 'FINANCE' || role === 'EXECUTIVE'
           ? [{ to: '/finance/bank-accounts', label: 'Bank Accounts', icon: BankAccountsIcon }]
           : []),
+        ...(role === 'FINANCE'
+          ? [{ to: '/finance/reconciliation', label: 'Reconciliation', icon: ReconciliationIcon, badge: unreconciledCount }]
+          : []),
       ],
     }] : []),
   ].filter((s) => s.items.length > 0);
@@ -114,7 +132,7 @@ export default function Sidebar() {
               </div>
             )}
             <div className="space-y-0.5">
-              {section.items.map(({ to, label, icon: Icon }) => (
+              {section.items.map(({ to, label, icon: Icon, badge }) => (
                 <NavLink
                   key={to}
                   to={to}
@@ -129,6 +147,16 @@ export default function Sidebar() {
                 >
                   <Icon className="w-5 h-5 shrink-0" />
                   {(!collapsed || isMobile) && <span>{label}</span>}
+                  {badge !== undefined && badge > 0 && (!collapsed || isMobile) && (
+                    <span className="ml-auto inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full text-[10px] font-bold bg-amber-500 text-white">
+                      {badge > 99 ? '99+' : badge}
+                    </span>
+                  )}
+                  {badge !== undefined && badge > 0 && collapsed && !isMobile && (
+                    <span className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-amber-500 text-white text-[9px] font-bold flex items-center justify-center">
+                      {badge > 9 ? '9+' : badge}
+                    </span>
+                  )}
                 </NavLink>
               ))}
             </div>
@@ -295,6 +323,14 @@ function BankAccountsIcon({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M3 6h18M3 6v12a2.25 2.25 0 002.25 2.25h13.5A2.25 2.25 0 0021 18V6M3 6l9-3 9 3M9 12h.01M15 12h.01M9 16h.01M15 16h.01" />
+    </svg>
+  );
+}
+
+function ReconciliationIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
     </svg>
   );
 }

--- a/frontend/src/pages/BankAccountDetailPage.tsx
+++ b/frontend/src/pages/BankAccountDetailPage.tsx
@@ -225,7 +225,25 @@ export default function BankAccountDetailPage() {
                 {transactions.map(tx => (
                   <tr key={tx.id} className="hover:bg-gray-50">
                     <td className="px-4 py-3 text-gray-600">{formatDate(tx.date)}</td>
-                    <td className="px-4 py-3 font-medium text-gray-900">{tx.description}</td>
+                    <td className="px-4 py-3">
+                      <div className="font-medium text-gray-900">{tx.description}</div>
+                      {(tx.projectPaymentTitle || tx.externalNote) && (
+                        <div className="text-xs text-gray-500 mt-0.5">
+                          {tx.projectPaymentTitle && (
+                            <span className="inline-flex items-center gap-1">
+                              <svg className="w-3 h-3 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>
+                              {tx.projectPaymentTitle}
+                            </span>
+                          )}
+                          {tx.externalNote && (
+                            <span className="inline-flex items-center gap-1">
+                              <svg className="w-3 h-3 text-amber-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
+                              External: {tx.externalNote}
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </td>
                     <td className={`px-4 py-3 text-right font-medium ${tx.amount >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                       {tx.amount >= 0 ? '+' : ''}{formatCurrency(tx.amount)}
                     </td>

--- a/frontend/src/pages/BankAccountDetailPage.tsx
+++ b/frontend/src/pages/BankAccountDetailPage.tsx
@@ -1,0 +1,281 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import type { BankAccountDto, BankTransactionDto } from '@/types';
+import { getBankAccount } from '@/api/bankAccounts';
+import { listTransactions, createTransaction, updateTransaction, deleteTransaction } from '@/api/bankTransactions';
+import { useAuth } from '@/hooks/useAuth';
+import { formatCurrency, formatDate } from '@/utils/format';
+import Spinner from '@/components/common/Spinner';
+import Modal from '@/components/common/Modal';
+
+const CURRENCIES = ['MAD', 'EUR', 'USD', 'GBP', 'SAR', 'AED'];
+
+const statusBadge: Record<string, string> = {
+  NEW: 'bg-yellow-100 text-yellow-800',
+  RECONCILED: 'bg-green-100 text-green-800',
+  IGNORED: 'bg-gray-100 text-gray-600',
+};
+
+const statusLabel: Record<string, string> = {
+  NEW: 'New',
+  RECONCILED: 'Reconciled',
+  IGNORED: 'Ignored',
+};
+
+export default function BankAccountDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { user } = useAuth();
+  const canEdit = user?.role === 'FINANCE';
+
+  const [account, setAccount] = useState<BankAccountDto | null>(null);
+  const [transactions, setTransactions] = useState<BankTransactionDto[]>([]);
+  const [loadingAccount, setLoadingAccount] = useState(true);
+  const [loadingTx, setLoadingTx] = useState(false);
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+
+  const [showModal, setShowModal] = useState(false);
+  const [editingTx, setEditingTx] = useState<BankTransactionDto | null>(null);
+  const [txDate, setTxDate] = useState('');
+  const [txDescription, setTxDescription] = useState('');
+  const [txAmount, setTxAmount] = useState('');
+  const [txCurrency, setTxCurrency] = useState('MAD');
+  const [txReference, setTxReference] = useState('');
+  const [txStatus, setTxStatus] = useState('NEW');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const accountId = Number(id);
+
+  useEffect(() => {
+    setLoadingAccount(true);
+    getBankAccount(accountId)
+      .then(setAccount)
+      .catch(() => setAccount(null))
+      .finally(() => setLoadingAccount(false));
+  }, [accountId]);
+
+  const fetchTransactions = async () => {
+    setLoadingTx(true);
+    try {
+      const res = await listTransactions(accountId, { page, size: 20 });
+      setTransactions(res.data);
+      setTotalPages(res.pagination.totalPages);
+    } catch { /* ignore */ }
+    finally { setLoadingTx(false); }
+  };
+
+  useEffect(() => { fetchTransactions(); }, [accountId, page]);
+
+  const openCreate = () => {
+    setEditingTx(null);
+    setTxDate(new Date().toISOString().slice(0, 10));
+    setTxDescription(''); setTxAmount(''); setTxCurrency(account?.currency || 'MAD'); setTxReference('');
+    setShowModal(true);
+  };
+
+  const openEdit = (tx: BankTransactionDto) => {
+    setEditingTx(tx);
+    setTxDescription(tx.description);
+    setTxReference(tx.reference || '');
+    setTxStatus(tx.status);
+    setShowModal(true);
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true); setError(null);
+    try {
+      if (editingTx) {
+        const updated = await updateTransaction(accountId, editingTx.id, {
+          description: txDescription.trim() || undefined,
+          reference: txReference || undefined,
+          status: txStatus || undefined,
+        });
+        setTransactions(prev => prev.map(t => t.id === updated.id ? updated : t));
+      } else {
+        if (!txDate || !txDescription.trim() || !txAmount) return;
+        const created = await createTransaction(accountId, {
+          date: txDate,
+          description: txDescription.trim(),
+          amount: Number(txAmount),
+          currency: txCurrency,
+          reference: txReference || undefined,
+        });
+        setTransactions(prev => [created, ...prev]);
+      }
+      setShowModal(false);
+    } catch { setError('Failed to save transaction.'); }
+    finally { setSaving(false); }
+  };
+
+  const handleDelete = async (tx: BankTransactionDto) => {
+    if (!confirm(`Delete transaction "${tx.description}"?`)) return;
+    await deleteTransaction(accountId, tx.id);
+    setTransactions(prev => prev.filter(t => t.id !== tx.id));
+  };
+
+  if (loadingAccount) {
+    return <div className="flex items-center justify-center h-64"><Spinner className="h-8 w-8 text-primary-600" /></div>;
+  }
+
+  if (!account) {
+    return <div className="p-6 text-center text-gray-500">Bank account not found.</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link to="/finance/bank-accounts" className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700">
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg>
+        Bank Accounts
+      </Link>
+
+      {/* Account header card */}
+      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        <div className="px-6 py-5">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-xl font-bold text-gray-900">{account.name}</h1>
+              <p className="text-sm text-gray-500 font-mono mt-1">{account.iban}</p>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="inline-block px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-700">{account.currency}</span>
+              {account.companyName && (
+                <span className="inline-block px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-700">{account.companyName}</span>
+              )}
+            </div>
+          </div>
+          <div className="mt-4 flex items-baseline gap-2">
+            <span className="text-3xl font-bold text-gray-900">{formatCurrency(account.currentBalance)}</span>
+            <span className="text-sm text-gray-500">{account.currency}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Transactions section */}
+      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900">Transactions</h2>
+          {canEdit && (
+            <button onClick={openCreate} className="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700">Add Transaction</button>
+          )}
+        </div>
+
+        {loadingTx ? (
+          <div className="flex items-center justify-center h-32"><Spinner className="h-6 w-6 text-primary-600" /></div>
+        ) : transactions.length === 0 ? (
+          <div className="p-8 text-center text-gray-500">No transactions yet.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead><tr className="border-b border-gray-200 bg-gray-50">
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Date</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Description</th>
+                <th className="text-right px-4 py-3 font-medium text-gray-500">Amount</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Currency</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Reference</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Status</th>
+                <th className="px-4 py-3"></th>
+              </tr></thead>
+              <tbody className="divide-y divide-gray-100">
+                {transactions.map(tx => (
+                  <tr key={tx.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 text-gray-600">{formatDate(tx.date)}</td>
+                    <td className="px-4 py-3 font-medium text-gray-900">{tx.description}</td>
+                    <td className={`px-4 py-3 text-right font-medium ${tx.amount >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                      {tx.amount >= 0 ? '+' : ''}{formatCurrency(tx.amount)}
+                    </td>
+                    <td className="px-4 py-3"><span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">{tx.currency}</span></td>
+                    <td className="px-4 py-3 text-gray-500 font-mono text-xs">{tx.reference || '—'}</td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${statusBadge[tx.status] || ''}`}>
+                        {statusLabel[tx.status] || tx.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      {canEdit && (
+                        <div className="flex items-center gap-2 justify-end">
+                          <button onClick={() => openEdit(tx)} className="text-primary-600 hover:text-primary-800 text-sm font-medium">Edit</button>
+                          <button onClick={() => handleDelete(tx)} className="text-red-600 hover:text-red-800 text-sm font-medium">Delete</button>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {totalPages > 1 && (
+          <div className="px-4 py-3 border-t border-gray-200 flex items-center justify-center gap-2">
+            <button onClick={() => setPage(p => Math.max(0, p - 1))} disabled={page === 0} className="px-3 py-1 rounded border text-sm disabled:opacity-50">Previous</button>
+            <span className="text-sm text-gray-500">Page {page + 1} of {totalPages}</span>
+            <button onClick={() => setPage(p => p + 1)} disabled={page >= totalPages - 1} className="px-3 py-1 rounded border text-sm disabled:opacity-50">Next</button>
+          </div>
+        )}
+      </div>
+
+      {showModal && (
+        <Modal title={editingTx ? 'Edit Transaction' : 'Add Transaction'} onClose={() => setShowModal(false)}>
+          <form onSubmit={handleSave} className="space-y-4">
+            {error && <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-3 py-2">{error}</div>}
+            {!editingTx && (
+              <>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Date *</label>
+                  <input type="date" value={txDate} onChange={e => setTxDate(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" required />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Description *</label>
+                  <input value={txDescription} onChange={e => setTxDescription(e.target.value)} placeholder="e.g. Client payment, Office rent" className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" required />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Amount * <span className="text-gray-400 font-normal">(negative for debit)</span></label>
+                  <input type="number" step="0.01" value={txAmount} onChange={e => setTxAmount(e.target.value)} placeholder="e.g. 50000 or -15000" className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" required />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Currency</label>
+                  <select value={txCurrency} onChange={e => setTxCurrency(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
+                    {CURRENCIES.map(c => <option key={c} value={c}>{c}</option>)}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Reference</label>
+                  <input value={txReference} onChange={e => setTxReference(e.target.value)} placeholder="e.g. TRF-001" className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 font-mono" />
+                </div>
+              </>
+            )}
+            {editingTx && (
+              <>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+                  <input value={txDescription} onChange={e => setTxDescription(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Reference</label>
+                  <input value={txReference} onChange={e => setTxReference(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 font-mono" />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+                  <select value={txStatus} onChange={e => setTxStatus(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
+                    <option value="NEW">New</option>
+                    <option value="RECONCILED">Reconciled</option>
+                    <option value="IGNORED">Ignored</option>
+                  </select>
+                </div>
+              </>
+            )}
+            <div className="flex justify-end gap-3 pt-2">
+              <button type="button" onClick={() => setShowModal(false)} className="px-4 py-2 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-100">Cancel</button>
+              <button type="submit" disabled={saving} className="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50 flex items-center gap-2">
+                {saving && <Spinner className="h-4 w-4" />}{editingTx ? 'Update' : 'Add'}
+              </button>
+            </div>
+          </form>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/BankAccountDetailPage.tsx
+++ b/frontend/src/pages/BankAccountDetailPage.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import type { BankAccountDto, BankTransactionDto } from '@/types';
 import { getBankAccount } from '@/api/bankAccounts';
 import { listTransactions, createTransaction, updateTransaction, deleteTransaction } from '@/api/bankTransactions';
+import { importStatement } from '@/api/bankStatements';
 import { useAuth } from '@/hooks/useAuth';
 import { formatCurrency, formatDate } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
@@ -44,6 +45,10 @@ export default function BankAccountDetailPage() {
   const [txStatus, setTxStatus] = useState('NEW');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const [importing, setImporting] = useState(false);
+  const [importResult, setImportResult] = useState<{ importedCount: number; matched: boolean; warning: string | null } | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const accountId = Number(id);
 
@@ -115,6 +120,19 @@ export default function BankAccountDetailPage() {
     setTransactions(prev => prev.filter(t => t.id !== tx.id));
   };
 
+  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImporting(true);
+    setImportResult(null);
+    try {
+      const result = await importStatement(accountId, file);
+      setImportResult(result);
+      fetchTransactions();
+    } catch { setError('Failed to import statement. Please check the file and try again.'); }
+    finally { setImporting(false); if (fileInputRef.current) fileInputRef.current.value = ''; }
+  };
+
   if (loadingAccount) {
     return <div className="flex items-center justify-center h-64"><Spinner className="h-8 w-8 text-primary-600" /></div>;
   }
@@ -153,12 +171,37 @@ export default function BankAccountDetailPage() {
         </div>
       </div>
 
+      {/* Import result banner */}
+      {importResult && (
+        <div className={`rounded-xl border p-4 ${importResult.matched ? 'bg-green-50 border-green-200' : 'bg-yellow-50 border-yellow-200'}`}>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className={`font-medium ${importResult.matched ? 'text-green-800' : 'text-yellow-800'}`}>
+                {importResult.importedCount} transaction{importResult.importedCount !== 1 ? 's' : ''} imported successfully
+              </p>
+              {importResult.warning && (
+                <p className="text-sm mt-1 text-yellow-700">{importResult.warning}</p>
+              )}
+            </div>
+            <button onClick={() => setImportResult(null)} className="text-gray-400 hover:text-gray-600">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* Transactions section */}
       <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
         <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
           <h2 className="text-lg font-semibold text-gray-900">Transactions</h2>
           {canEdit && (
-            <button onClick={openCreate} className="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700">Add Transaction</button>
+            <div className="flex items-center gap-2">
+              <input ref={fileInputRef} type="file" accept=".pdf" onChange={handleImport} className="hidden" />
+              <button onClick={() => fileInputRef.current?.click()} disabled={importing} className="bg-white border border-gray-300 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 disabled:opacity-50 flex items-center gap-1.5">
+                {importing ? <><Spinner className="h-4 w-4" />Importing...</> : <><svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" /></svg>Import PDF</>}
+              </button>
+              <button onClick={openCreate} className="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700">Add Transaction</button>
+            </div>
           )}
         </div>
 

--- a/frontend/src/pages/BankAccountsPage.tsx
+++ b/frontend/src/pages/BankAccountsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import type { BankAccountDto } from '@/types';
 import { listBankAccounts, createBankAccount, updateBankAccount, deactivateBankAccount } from '@/api/bankAccounts';
 import { useAuth } from '@/hooks/useAuth';
@@ -118,7 +119,7 @@ export default function BankAccountsPage() {
             <tbody className="divide-y divide-gray-100">
               {accounts.map(a => (
                 <tr key={a.id} className="hover:bg-gray-50">
-                  <td className="px-4 py-3 font-medium text-gray-900">{a.name}</td>
+                  <td className="px-4 py-3 font-medium text-gray-900"><Link to={`/finance/bank-accounts/${a.id}`} className="hover:text-primary-600">{a.name}</Link></td>
                   <td className="px-4 py-3 text-gray-600 font-mono text-xs">{a.iban}</td>
                   <td className="px-4 py-3"><span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">{a.currency}</span></td>
                   <td className="px-4 py-3 text-right font-medium">{formatCurrency(a.currentBalance)}</td>

--- a/frontend/src/pages/BankAccountsPage.tsx
+++ b/frontend/src/pages/BankAccountsPage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import type { BankAccountDto } from '@/types';
+import type { BankAccountDto, CompanyDto } from '@/types';
 import { listBankAccounts, createBankAccount, updateBankAccount, deactivateBankAccount } from '@/api/bankAccounts';
+import { listCompanies } from '@/api/companies';
 import { useAuth } from '@/hooks/useAuth';
 import { formatCurrency, formatDate } from '@/utils/format';
 import Spinner from '@/components/common/Spinner';
@@ -12,8 +13,10 @@ const CURRENCIES = ['MAD', 'EUR', 'USD', 'GBP', 'SAR', 'AED'];
 export default function BankAccountsPage() {
   const { user } = useAuth();
   const canEdit = user?.role === 'FINANCE';
+  const isGlobalUser = !user?.companyId;
 
   const [accounts, setAccounts] = useState<BankAccountDto[]>([]);
+  const [companies, setCompanies] = useState<CompanyDto[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(0);
@@ -21,6 +24,7 @@ export default function BankAccountsPage() {
 
   const [showModal, setShowModal] = useState(false);
   const [editingAccount, setEditingAccount] = useState<BankAccountDto | null>(null);
+  const [companyId, setCompanyId] = useState<string>(user?.companyId ? String(user.companyId) : '');
   const [name, setName] = useState('');
   const [iban, setIban] = useState('');
   const [currency, setCurrency] = useState('MAD');
@@ -39,11 +43,17 @@ export default function BankAccountsPage() {
   };
 
   useEffect(() => { fetchAccounts(); }, [page]);
+  useEffect(() => {
+    if (isGlobalUser) {
+      listCompanies().then(res => setCompanies(res.data.filter(c => c.active))).catch(() => {});
+    }
+  }, [isGlobalUser]);
 
   const handleSearch = () => { setPage(0); fetchAccounts(); };
 
   const openCreate = () => {
     setEditingAccount(null);
+    setCompanyId(user?.companyId ? String(user.companyId) : '');
     setName(''); setIban(''); setCurrency('MAD'); setOpeningBalance('0');
     setShowModal(true);
   };
@@ -68,6 +78,7 @@ export default function BankAccountsPage() {
         setAccounts(prev => prev.map(a => a.id === updated.id ? updated : a));
       } else {
         const created = await createBankAccount({
+          companyId: companyId ? Number(companyId) : null,
           name: name.trim(),
           iban: iban.trim(),
           currency,
@@ -152,6 +163,15 @@ export default function BankAccountsPage() {
         <Modal title={editingAccount ? 'Edit Bank Account' : 'New Bank Account'} onClose={() => setShowModal(false)}>
           <form onSubmit={handleSave} className="space-y-4">
             {error && <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-3 py-2">{error}</div>}
+            {isGlobalUser && !editingAccount && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Company</label>
+                <select value={companyId} onChange={e => setCompanyId(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
+                  <option value="">Global</option>
+                  {companies.map(c => <option key={c.id} value={c.id}>{c.name} ({c.key})</option>)}
+                </select>
+              </div>
+            )}
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Name *</label>
               <input value={name} onChange={e => setName(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" required />

--- a/frontend/src/pages/ReconciliationPage.tsx
+++ b/frontend/src/pages/ReconciliationPage.tsx
@@ -1,0 +1,504 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import type { UnreconciledTransactionDto, UnmatchedPaymentDto } from '@/types';
+import { getReconciliationView, suggestMatches, reconcile, unreconcile, getUnreconciledCount } from '@/api/reconciliation';
+import { formatCurrency, formatDate } from '@/utils/format';
+import Spinner from '@/components/common/Spinner';
+
+const statusBadge: Record<string, string> = {
+  NEW: 'bg-yellow-100 text-yellow-800',
+  RECONCILED: 'bg-green-100 text-green-800',
+  IGNORED: 'bg-gray-100 text-gray-600',
+};
+
+const paymentStatusBadge: Record<string, string> = {
+  PENDING: 'bg-yellow-100 text-yellow-800',
+  RECEIVED: 'bg-green-100 text-green-800',
+  OVERDUE: 'bg-red-100 text-red-800',
+  CANCELLED: 'bg-gray-100 text-gray-600',
+};
+
+export default function ReconciliationPage() {
+  const [activeTab, setActiveTab] = useState<'unreconciled' | 'reconciled'>('unreconciled');
+  const [transactions, setTransactions] = useState<UnreconciledTransactionDto[]>([]);
+  const [reconciledTransactions, setReconciledTransactions] = useState<UnreconciledTransactionDto[]>([]);
+  const [unmatchedPayments, setUnmatchedPayments] = useState<UnmatchedPaymentDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [selectedTx, setSelectedTx] = useState<UnreconciledTransactionDto | null>(null);
+  const [suggestions, setSuggestions] = useState<UnmatchedPaymentDto[]>([]);
+  const [loadingSuggestions, setLoadingSuggestions] = useState(false);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [showExternalModal, setShowExternalModal] = useState(false);
+  const [externalNote, setExternalNote] = useState('');
+  const [unreconciledCount, setUnreconciledCount] = useState<number>(0);
+
+  const loadData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [view, reconciled] = await Promise.all([
+        getReconciliationView(),
+        getReconciledTransactions(),
+      ]);
+      setTransactions(view.transactions);
+      setUnmatchedPayments(view.unmatchedPayments);
+      setUnreconciledCount(view.unreconciledCount);
+      setReconciledTransactions(reconciled);
+    } catch (err) {
+      setError('Failed to load reconciliation data');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleSelectTx = async (tx: UnreconciledTransactionDto) => {
+    setSelectedTx(tx);
+    setSuggestions([]);
+    if (tx.status === 'NEW') {
+      setLoadingSuggestions(true);
+      try {
+        const matches = await suggestMatches(tx.id);
+        setSuggestions(matches);
+      } catch (err) {
+        console.error('Failed to load suggestions', err);
+      } finally {
+        setLoadingSuggestions(false);
+      }
+    }
+  };
+
+  const handleReconcileWithPayment = async (paymentId: number) => {
+    if (!selectedTx) return;
+    try {
+      setActionLoading(true);
+      const updated = await reconcile(selectedTx.id, { paymentId });
+      setTransactions(prev => prev.filter(t => t.id !== updated.id));
+      setUnmatchedPayments(prev => prev.filter(p => p.id !== paymentId));
+      setSelectedTx(null);
+      setSuggestions([]);
+      const countData = await getUnreconciledCount();
+      setUnreconciledCount(countData.count);
+    } catch (err) {
+      console.error('Failed to reconcile', err);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleReconcileAsExternal = async () => {
+    if (!selectedTx || !externalNote.trim()) return;
+    try {
+      setActionLoading(true);
+      const updated = await reconcile(selectedTx.id, { externalNote: externalNote.trim() });
+      setTransactions(prev => prev.filter(t => t.id !== updated.id));
+      setSelectedTx(null);
+      setSuggestions([]);
+      setShowExternalModal(false);
+      setExternalNote('');
+      const countData = await getUnreconciledCount();
+      setUnreconciledCount(countData.count);
+    } catch (err) {
+      console.error('Failed to reconcile as external', err);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleIgnore = async (tx: UnreconciledTransactionDto) => {
+    try {
+      setActionLoading(true);
+      await reconcile(tx.id, { externalNote: 'Ignored' });
+      setTransactions(prev => prev.filter(t => t.id !== tx.id));
+      if (selectedTx?.id === tx.id) {
+        setSelectedTx(null);
+        setSuggestions([]);
+      }
+      const countData = await getUnreconciledCount();
+      setUnreconciledCount(countData.count);
+    } catch (err) {
+      console.error('Failed to ignore transaction', err);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleUnreconcile = async (tx: UnreconciledTransactionDto) => {
+    if (!confirm(`Unreconcile "${tx.description}"? This will mark the payment as unmatched again.`)) return;
+    try {
+      setActionLoading(true);
+      await unreconcile(tx.id);
+      setReconciledTransactions(prev => prev.filter(t => t.id !== tx.id));
+      setSelectedTx(null);
+      const countData = await getUnreconciledCount();
+      setUnreconciledCount(countData.count);
+    } catch (err) {
+      console.error('Failed to unreconcile', err);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div className="p-6 text-center text-red-600">{error}</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <Link to="/finance/bank-accounts" className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700">
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg>
+          Bank Accounts
+        </Link>
+        <div className="flex items-center justify-between mt-2">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Reconciliation</h1>
+            <p className="text-sm text-gray-500 mt-1">
+              Match bank transactions to project payments or mark as external
+            </p>
+          </div>
+          {unreconciledCount > 0 && (
+            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium bg-amber-100 text-amber-800">
+              <span className="w-2 h-2 rounded-full bg-amber-500" />
+              {unreconciledCount} unreconciled
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b border-gray-200">
+        <button
+          onClick={() => { setActiveTab('unreconciled'); setSelectedTx(null); }}
+          className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'unreconciled'
+              ? 'border-primary-600 text-primary-600'
+              : 'border-transparent text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          Unreconciled
+          {unreconciledCount > 0 && (
+            <span className="ml-2 inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full text-[10px] font-bold bg-amber-100 text-amber-800">
+              {unreconciledCount}
+            </span>
+          )}
+        </button>
+        <button
+          onClick={() => { setActiveTab('reconciled'); setSelectedTx(null); }}
+          className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'reconciled'
+              ? 'border-primary-600 text-primary-600'
+              : 'border-transparent text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          Reconciled
+          {reconciledTransactions.length > 0 && (
+            <span className="ml-2 text-xs text-gray-400">({reconciledTransactions.length})</span>
+          )}
+        </button>
+      </div>
+
+      {activeTab === 'unreconciled' ? (
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Transactions list */}
+        <div className="lg:col-span-2 bg-white rounded-xl border border-gray-200 overflow-hidden">
+          <div className="px-4 py-3 border-b border-gray-200">
+            <h2 className="text-lg font-semibold text-gray-900">Unreconciled Transactions</h2>
+            <p className="text-xs text-gray-500 mt-0.5">{transactions.length} transaction{transactions.length !== 1 ? 's' : ''} awaiting reconciliation</p>
+          </div>
+          {transactions.length === 0 ? (
+            <div className="p-8 text-center text-gray-500">No unreconciled transactions. All caught up!</div>
+          ) : (
+            <div className="divide-y divide-gray-100 max-h-[600px] overflow-y-auto">
+              {transactions.map(tx => (
+                <button
+                  key={tx.id}
+                  onClick={() => handleSelectTx(tx)}
+                  className={`w-full text-left px-4 py-3 hover:bg-gray-50 transition-colors ${selectedTx?.id === tx.id ? 'bg-primary-50 border-l-2 border-primary-600' : ''}`}
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-gray-900 truncate">{tx.description}</span>
+                        <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${statusBadge[tx.status] || 'bg-gray-100 text-gray-600'}`}>
+                          {tx.status}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-3 mt-1 text-xs text-gray-500">
+                        <span>{formatDate(tx.date)}</span>
+                        {tx.bankAccountName && <span>{tx.bankAccountName}</span>}
+                        {tx.reference && <span className="font-mono">{tx.reference}</span>}
+                      </div>
+                    </div>
+                    <div className="text-right ml-4 shrink-0">
+                      <div className={`font-semibold ${tx.amount >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                        {tx.amount >= 0 ? '+' : ''}{formatCurrency(tx.amount)}
+                      </div>
+                      <div className="text-xs text-gray-500">{tx.currency}</div>
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Right panel: details + suggestions */}
+        <div className="space-y-4">
+          {selectedTx ? (
+            <>
+              {/* Selected transaction detail */}
+              <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+                <div className="px-4 py-3 border-b border-gray-200 bg-gray-50">
+                  <h3 className="font-semibold text-gray-900">Transaction Detail</h3>
+                </div>
+                <div className="p-4 space-y-3">
+                  <div>
+                    <span className="text-xs text-gray-500">Description</span>
+                    <p className="text-sm font-medium text-gray-900">{selectedTx.description}</p>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <span className="text-xs text-gray-500">Amount</span>
+                      <p className={`text-sm font-semibold ${selectedTx.amount >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                        {selectedTx.amount >= 0 ? '+' : ''}{formatCurrency(selectedTx.amount)} {selectedTx.currency}
+                      </p>
+                    </div>
+                    <div>
+                      <span className="text-xs text-gray-500">Date</span>
+                      <p className="text-sm text-gray-900">{formatDate(selectedTx.date)}</p>
+                    </div>
+                    <div>
+                      <span className="text-xs text-gray-500">Account</span>
+                      <p className="text-sm text-gray-900">{selectedTx.bankAccountName || '—'}</p>
+                    </div>
+                    <div>
+                      <span className="text-xs text-gray-500">Reference</span>
+                      <p className="text-sm text-gray-900 font-mono">{selectedTx.reference || '—'}</p>
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-2 pt-2">
+                    <button
+                      onClick={() => setShowExternalModal(true)}
+                      disabled={actionLoading}
+                      className="w-full bg-gray-100 text-gray-700 px-3 py-2 rounded-lg text-sm font-medium hover:bg-gray-200 disabled:opacity-50"
+                    >
+                      Mark as External
+                    </button>
+                    <button
+                      onClick={() => handleIgnore(selectedTx)}
+                      disabled={actionLoading}
+                      className="w-full bg-red-50 text-red-700 px-3 py-2 rounded-lg text-sm font-medium hover:bg-red-100 disabled:opacity-50"
+                    >
+                      Ignore Transaction
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              {/* Suggested matches */}
+              <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+                <div className="px-4 py-3 border-b border-gray-200 bg-gray-50">
+                  <h3 className="font-semibold text-gray-900">Suggested Matches</h3>
+                </div>
+                {loadingSuggestions ? (
+                  <div className="flex items-center justify-center h-24">
+                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-600" />
+                  </div>
+                ) : suggestions.length === 0 ? (
+                  <div className="p-4 text-sm text-gray-500 text-center">
+                    No matching payments found. Try marking as external.
+                  </div>
+                ) : (
+                  <div className="divide-y divide-gray-100 max-h-[300px] overflow-y-auto">
+                    {suggestions.map(payment => (
+                      <div key={payment.id} className="p-3">
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm font-medium text-gray-900 truncate">{payment.title}</p>
+                            <p className="text-xs text-gray-500">{payment.projectName}</p>
+                            <div className="flex items-center gap-2 mt-1">
+                              <span className="text-xs text-gray-500">{formatDate(payment.dueDate || payment.receivedDate || '')}</span>
+                              <span className={`inline-block px-1.5 py-0.5 rounded text-xs font-medium ${paymentStatusBadge[payment.status] || 'bg-gray-100 text-gray-600'}`}>
+                                {payment.status}
+                              </span>
+                            </div>
+                          </div>
+                          <div className="text-right shrink-0">
+                            <p className="text-sm font-semibold text-gray-900">{formatCurrency(payment.amount)}</p>
+                            <p className="text-xs text-gray-500">{payment.currency}</p>
+                          </div>
+                        </div>
+                        <button
+                          onClick={() => handleReconcileWithPayment(payment.id)}
+                          disabled={actionLoading}
+                          className="mt-2 w-full bg-primary-600 text-white px-3 py-1.5 rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50"
+                        >
+                          Link Payment
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* All unmatched payments (manual selection) */}
+              {unmatchedPayments.length > 0 && (
+                <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+                  <div className="px-4 py-3 border-b border-gray-200 bg-gray-50">
+                    <h3 className="font-semibold text-gray-900">All Unmatched Payments</h3>
+                    <p className="text-xs text-gray-500 mt-0.5">{unmatchedPayments.length} payment{unmatchedPayments.length !== 1 ? 's' : ''} not yet reconciled</p>
+                  </div>
+                  <div className="divide-y divide-gray-100 max-h-[300px] overflow-y-auto">
+                    {unmatchedPayments
+                      .filter(p => !suggestions.some(s => s.id === p.id))
+                      .map(payment => (
+                        <div key={payment.id} className="p-3">
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="flex-1 min-w-0">
+                              <p className="text-sm font-medium text-gray-900 truncate">{payment.title}</p>
+                              <p className="text-xs text-gray-500">{payment.projectName}</p>
+                              <div className="flex items-center gap-2 mt-1">
+                                <span className="text-xs text-gray-500">{formatDate(payment.dueDate || payment.receivedDate || '')}</span>
+                                <span className={`inline-block px-1.5 py-0.5 rounded text-xs font-medium ${paymentStatusBadge[payment.status] || 'bg-gray-100 text-gray-600'}`}>
+                                  {payment.status}
+                                </span>
+                              </div>
+                            </div>
+                            <div className="text-right shrink-0">
+                              <p className="text-sm font-semibold text-gray-900">{formatCurrency(payment.amount)}</p>
+                              <p className="text-xs text-gray-500">{payment.currency}</p>
+                            </div>
+                          </div>
+                          <button
+                            onClick={() => handleReconcileWithPayment(payment.id)}
+                            disabled={actionLoading}
+                            className="mt-2 w-full bg-white border border-gray-300 text-gray-700 px-3 py-1.5 rounded-lg text-sm font-medium hover:bg-gray-50 disabled:opacity-50"
+                          >
+                            Link Payment
+                          </button>
+                        </div>
+                      ))}
+                  </div>
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="bg-white rounded-xl border border-gray-200 p-8 text-center">
+              <svg className="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
+              </svg>
+              <p className="mt-2 text-sm text-gray-500">Select a transaction to see suggested matches and reconciliation options</p>
+            </div>
+          )}
+        </div>
+      </div>
+      ) : (
+      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        <div className="px-4 py-3 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">Reconciled Transactions</h2>
+          <p className="text-xs text-gray-500 mt-0.5">{reconciledTransactions.length} transaction{reconciledTransactions.length !== 1 ? 's' : ''}</p>
+        </div>
+        {reconciledTransactions.length === 0 ? (
+          <div className="p-8 text-center text-gray-500">No reconciled transactions yet.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead><tr className="border-b border-gray-200 bg-gray-50">
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Date</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Description</th>
+                <th className="text-right px-4 py-3 font-medium text-gray-500">Amount</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Matched To</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Account</th>
+                <th className="px-4 py-3"></th>
+              </tr></thead>
+              <tbody className="divide-y divide-gray-100">
+                {reconciledTransactions.map(tx => (
+                  <tr key={tx.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 text-gray-600">{formatDate(tx.date)}</td>
+                    <td className="px-4 py-3 font-medium text-gray-900">{tx.description}</td>
+                    <td className={`px-4 py-3 text-right font-medium ${tx.amount >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                      {tx.amount >= 0 ? '+' : ''}{formatCurrency(tx.amount)}
+                    </td>
+                    <td className="px-4 py-3">
+                      {tx.projectPaymentTitle ? (
+                        <span className="inline-flex items-center gap-1 text-xs font-medium text-green-700 bg-green-50 px-2 py-0.5 rounded-full">
+                          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>
+                          {tx.projectPaymentTitle}
+                        </span>
+                      ) : tx.externalNote ? (
+                        <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 bg-amber-50 px-2 py-0.5 rounded-full">
+                          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
+                          External
+                        </span>
+                      ) : (
+                        <span className="text-xs text-gray-400">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{tx.bankAccountName || '—'}</td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        onClick={() => handleUnreconcile(tx)}
+                        disabled={actionLoading}
+                        className="text-red-600 hover:text-red-800 text-sm font-medium disabled:opacity-50"
+                      >
+                        Unreconcile
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+      )}
+
+      {/* External note modal */}
+      {showExternalModal && selectedTx && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setShowExternalModal(false)}>
+          <div className="bg-white rounded-xl shadow-xl max-w-md w-full mx-4 p-6" onClick={e => e.stopPropagation()}>
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">Mark as External</h3>
+            <p className="text-sm text-gray-500 mb-4">
+              Transaction: <span className="font-medium text-gray-700">{selectedTx.description}</span> — {formatCurrency(selectedTx.amount)} {selectedTx.currency}
+            </p>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Note</label>
+              <textarea
+                value={externalNote}
+                onChange={e => setExternalNote(e.target.value)}
+                placeholder="e.g. Office rent, utility bill, tax payment..."
+                rows={3}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 resize-none"
+              />
+            </div>
+            <div className="flex justify-end gap-3 mt-4">
+              <button onClick={() => setShowExternalModal(false)} className="px-4 py-2 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-100">Cancel</button>
+              <button
+                onClick={handleReconcileAsExternal}
+                disabled={!externalNote.trim() || actionLoading}
+                className="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50"
+              >
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types/bankAccount.ts
+++ b/frontend/src/types/bankAccount.ts
@@ -12,6 +12,7 @@ export interface BankAccountDto {
 }
 
 export interface CreateBankAccountRequest {
+  companyId?: number | null;
   name: string;
   iban: string;
   currency: string;

--- a/frontend/src/types/bankStatement.ts
+++ b/frontend/src/types/bankStatement.ts
@@ -1,0 +1,24 @@
+export interface BankStatementDto {
+  id: number;
+  bankAccountId: number;
+  fileName: string;
+  periodStart: string | null;
+  periodEnd: string | null;
+  totalDebits: number | null;
+  totalCredits: number | null;
+  openingBalance: number | null;
+  closingBalance: number | null;
+  computedDebits: number | null;
+  computedCredits: number | null;
+  matched: boolean;
+  transactionCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ImportResult {
+  statementId: number;
+  importedCount: number;
+  matched: boolean;
+  warning: string | null;
+}

--- a/frontend/src/types/bankTransaction.ts
+++ b/frontend/src/types/bankTransaction.ts
@@ -1,0 +1,26 @@
+export interface BankTransactionDto {
+  id: number;
+  bankAccountId: number;
+  date: string;
+  description: string;
+  amount: number;
+  currency: string;
+  reference: string | null;
+  status: 'NEW' | 'RECONCILED' | 'IGNORED';
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateBankTransactionRequest {
+  date: string;
+  description: string;
+  amount: number;
+  currency?: string;
+  reference?: string;
+}
+
+export interface UpdateBankTransactionRequest {
+  description?: string;
+  reference?: string;
+  status?: string;
+}

--- a/frontend/src/types/bankTransaction.ts
+++ b/frontend/src/types/bankTransaction.ts
@@ -8,6 +8,9 @@ export interface BankTransactionDto {
   currency: string;
   reference: string | null;
   status: 'NEW' | 'RECONCILED' | 'IGNORED';
+  projectPaymentId?: number | null;
+  projectPaymentTitle?: string | null;
+  externalNote?: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/frontend/src/types/bankTransaction.ts
+++ b/frontend/src/types/bankTransaction.ts
@@ -1,6 +1,7 @@
 export interface BankTransactionDto {
   id: number;
   bankAccountId: number;
+  bankStatementId: number | null;
   date: string;
   description: string;
   amount: number;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,3 +18,4 @@ export type { ClientDto, ClientContactDto, CreateClientRequest, UpdateClientRequ
 export type { PreSaleDto, PreSaleStage, CreatePreSaleRequest, UpdatePreSaleRequest, ConvertPreSaleRequest, CostSummaryDto, UserCostEntry } from './presale';
 export type { ProjectExpenseDto, CreateProjectExpenseRequest, UpdateProjectExpenseRequest } from './expense';
 export type { BankAccountDto, CreateBankAccountRequest, UpdateBankAccountRequest } from './bankAccount';
+export type { BankTransactionDto, CreateBankTransactionRequest, UpdateBankTransactionRequest } from './bankTransaction';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -19,3 +19,4 @@ export type { PreSaleDto, PreSaleStage, CreatePreSaleRequest, UpdatePreSaleReque
 export type { ProjectExpenseDto, CreateProjectExpenseRequest, UpdateProjectExpenseRequest } from './expense';
 export type { BankAccountDto, CreateBankAccountRequest, UpdateBankAccountRequest } from './bankAccount';
 export type { BankTransactionDto, CreateBankTransactionRequest, UpdateBankTransactionRequest } from './bankTransaction';
+export type { BankStatementDto, ImportResult } from './bankStatement';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -20,3 +20,4 @@ export type { ProjectExpenseDto, CreateProjectExpenseRequest, UpdateProjectExpen
 export type { BankAccountDto, CreateBankAccountRequest, UpdateBankAccountRequest } from './bankAccount';
 export type { BankTransactionDto, CreateBankTransactionRequest, UpdateBankTransactionRequest } from './bankTransaction';
 export type { BankStatementDto, ImportResult } from './bankStatement';
+export type { UnreconciledTransactionDto, UnmatchedPaymentDto, ReconcileRequest, UnreconciledCountDto, ReconciliationViewDto } from './reconciliation';

--- a/frontend/src/types/reconciliation.ts
+++ b/frontend/src/types/reconciliation.ts
@@ -1,0 +1,45 @@
+export interface UnreconciledTransactionDto {
+  id: number;
+  bankAccountId: number | null;
+  bankAccountName: string | null;
+  date: string;
+  description: string;
+  amount: number;
+  currency: string;
+  reference: string | null;
+  status: string;
+  projectPaymentId: number | null;
+  projectPaymentTitle: string | null;
+  externalNote: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UnmatchedPaymentDto {
+  id: number;
+  projectId: number;
+  projectName: string;
+  title: string;
+  amount: number;
+  currency: string;
+  dueDate: string | null;
+  receivedDate: string | null;
+  status: string;
+  invoiceRef: string | null;
+  reconciled: boolean;
+}
+
+export interface ReconcileRequest {
+  paymentId?: number | null;
+  externalNote?: string | null;
+}
+
+export interface UnreconciledCountDto {
+  count: number;
+}
+
+export interface ReconciliationViewDto {
+  transactions: UnreconciledTransactionDto[];
+  unmatchedPayments: UnmatchedPaymentDto[];
+  unreconciledCount: number;
+}


### PR DESCRIPTION
## Summary

### Issue #223 – Bank Transactions Manual CRUD
- Add BankTransaction entity with manual CRUD (line by line via form)
- Nested REST API: /api/bank-accounts/{id}/transactions (GET paginated, POST, PUT, DELETE)
- Currency defaults from bank account when not provided
- New BankAccountDetailPage with account header + paginated transactions table
- Add/Edit/Delete transaction modals (FINANCE only)
- Amount colored green (credit) / red (debit); status badges
- PDF statement import using VLM vision (PDFBox renders pages as PNG, sent to LLM as base64 image_url)
- Configurable LLM provider via env vars: OPENAI_API_KEY, OPENAI_BASE_URL, OPENAI_MODEL
- Defaults to Together AI with google/gemma-4-31B-it

### Issue #224 – Transaction Reconciliation
- Add projectPayment (ManyToOne) and externalNote fields to BankTransaction
- Add reconciled boolean to ProjectPayment; auto-update payment status to RECEIVED on reconcile
- ReconciliationService: suggest matches (amount ±0.01, date within 3 days, same currency), reconcile (with payment or as external), unreconcile
- ReconciliationController: 6 REST endpoints under /api/reconciliation
- New ReconciliationPage at /finance/reconciliation with unreconciled + reconciled tabs
- Sidebar: Reconciliation nav item with live unreconciled count badge
- BankAccountDetailPage: shows payment title or external note in reconciled transaction rows

Refs #223, #224