### PR TITLE
fix(#235): correct bankStatements.ts named import to default import

### DIFF
--- a/frontend/src/api/bankStatements.ts
+++ b/frontend/src/api/bankStatements.ts
@@ -1,5 +1,5 @@
 import { apiGetPaginated } from './client';
-import { client } from './client';
+import client from './client';
 import type { ApiResponse, PaginatedResponse, BankStatementDto, ImportResult } from '@/types';
 
 export async function importStatement(bankAccountId: number, file: File): Promise<ImportResult> {


### PR DESCRIPTION
## Summary
- Fix named import `{ client }` to default import `client` in `bankStatements.ts`, matching the pattern used in other API files
- Resolves critical frontend crash that prevented the entire app from loading

## Test plan
- [ ] App loads and renders correctly (login page accessible)
- [ ] Bank statements import feature works (requires bank account with statements)
- [ ] No console errors about missing named export from client.ts

Refs #235